### PR TITLE
Add an entry for apt-mirror.front.sepia.ceph.com to /etc/hosts.

### DIFF
--- a/roles/ansible-managed/defaults/main.yml
+++ b/roles/ansible-managed/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+apt_mirror_front_access: false

--- a/roles/ansible-managed/tasks/main.yml
+++ b/roles/ansible-managed/tasks/main.yml
@@ -40,3 +40,12 @@
     user: "{{ ansible_user }}"
     key: "{{ item }}"
   with_items: ssh_keys
+
+- name: Add apt-mirror.front.sepia.ceph.com to /etc/hosts
+  lineinfile:
+    dest: /etc/hosts
+    line: "64.90.32.37 apt-mirror.front.sepia.ceph.com"
+    state: present
+  when: apt_mirror_front_access
+  tags:
+    - apt-mirror


### PR DESCRIPTION
This is only a transitional thing so that one lab can talk to
apt-mirror.front.  Eventually that lab will not need apt-mirror.front as
this is only fixing a problem introduced by ceph-qa-chef.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>