### PR TITLE
Remove apt-mirror.front from octo resolv.conf base config.

### DIFF
--- a/roles/testnode/templates/resolvconf/base_octo
+++ b/roles/testnode/templates/resolvconf/base_octo
@@ -1,3 +1,3 @@
 # {{ ansible_managed }}
 nameserver 10.10.160.1
-search ceph.redhat.com front.sepia.ceph.com sepia.ceph.com
+search ceph.redhat.com sepia.ceph.com


### PR DESCRIPTION
Signed-off-by: Andrew Schoen <aschoen@redhat.com>