### PR TITLE
Fixed bug where entitlement setup would fail with --check.

### DIFF
--- a/roles/common/tasks/rhel-entitlements.yml
+++ b/roles/common/tasks/rhel-entitlements.yml
@@ -19,7 +19,8 @@
            --activationkey={{ subscription_manager_activationkey }}
            --org={{ subscription_manager_org }}
   no_log: true
-  when: subscription.rc != 0
+  when: subscription is defined and
+        subscription.rc != 0
   register: entitled
 
 - name: disable all rhsm repos


### PR DESCRIPTION
The command module is skipped when --check is used which causes the
registered var subscription to not exist the next task fails.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>