### PR TITLE
move default rhsm vars to "common" role

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -1,4 +1,8 @@
 ---
+# Red Hat Subscription Manager credentials
+subscription_manager_activationkey: ""
+subscription_manager_org: ""
+
 # Repos to enable in Red Hat Subscription Manager
 rhsm_repos: []
 

--- a/roles/testnode/defaults/main.yml
+++ b/roles/testnode/defaults/main.yml
@@ -1,9 +1,6 @@
 ---
 pip_mirror_url: "http://{{ mirror_host }}/pypi/simple"
 
-subscription_manager_activationkey: ""
-subscription_manager_org: ""
-
 # repos common to a major version
 common_yum_repos: {}
 


### PR DESCRIPTION
Commit 3d1ecaac01f9ed7a589741700fdb7fc22056218c moved the Red Hat subscription bits into the "common" role, but I neglected to move the default variables to "common" as well. Move them here.