### PR TITLE
Adds a new downstream_setup.yml playbook.

### DIFF
--- a/downstream_setup.yml
+++ b/downstream_setup.yml
@@ -1,0 +1,6 @@
+---
+# A playbook used to setup a node for downstream
+# RHCeph testing.
+- hosts: testnodes
+  roles:
+    - downstream-setup

--- a/roles/downstream-setup/defaults/main.yml
+++ b/roles/downstream-setup/defaults/main.yml
@@ -9,3 +9,7 @@
 #       name: "epel"
 #
 yum_repos: []
+
+# a list of repo names as strings to delete from /etc/yum.repos.d
+# the name should not include the .repo extension
+remove_yum_repos: []

--- a/roles/downstream-setup/defaults/main.yml
+++ b/roles/downstream-setup/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+# yum_repos is a list of hashes that
+# define the url to download the yum repo
+# from and the name to save it as in etc/yum.repos.d
+#
+# For example:
+#   yum_repos:
+#     - url: "http://path/to/epel.repo"
+#       name: "epel"
+#
+yum_repos: []

--- a/roles/downstream-setup/tasks/main.yml
+++ b/roles/downstream-setup/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- include: yum_repos.yml
+  tags:
+    - yum-repos

--- a/roles/downstream-setup/tasks/main.yml
+++ b/roles/downstream-setup/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
 - include: yum_repos.yml
+  when: yum_repos|length > 0
   tags:
     - yum-repos
+
+- include: remove_yum_repos.yml
+  when: remove_yum_repos|length > 0
+  tags:
+    - delete-yum-repos

--- a/roles/downstream-setup/tasks/remove_yum_repos.yml
+++ b/roles/downstream-setup/tasks/remove_yum_repos.yml
@@ -1,0 +1,6 @@
+---
+- name: Delete yum repos from /etc/yum.repos.d
+  file:
+    path: "/etc/yum.repos.d/{{ item }}.repo"
+    state: absent
+  with_items: remove_yum_repos

--- a/roles/downstream-setup/tasks/yum_repos.yml
+++ b/roles/downstream-setup/tasks/yum_repos.yml
@@ -1,0 +1,7 @@
+---
+- name: Download yum repos to /etc/yum.repos.d
+  get_url:
+    url: "{{ item.url }}"
+    dest: "/etc/yum.repos.d/{{ item.name }}.repo"
+    force: yes
+  with_items: yum_repos


### PR DESCRIPTION
This playbook will be used to setup testnodes for downstream
testing by downloading arbitrary yum repos. The repos to install should
be passed in with the --extra-vars option to ansible-playbook.

The yum_repos var must be a list of hashes defining the url to download
the repo from and the name to save it as in /etc/yum.repos.d

For example:

      --extra-vars '{"yum_repos":[{"url": "<url>", "name": "name"}]}'

Or, removing repos from /etc/yum.repos.d::

      -- extra-vars "remove_yum_repos=['name']"
