### PR TITLE
puddle: add 1.2 configs for ceph-async

### DIFF
--- a/roles/puddle/tasks/configure.yml
+++ b/roles/puddle/tasks/configure.yml
@@ -16,7 +16,9 @@
     mode: 0644
   with_items:
     - ceph-1.2-rhel-6
+    - ceph-1.2-rhel-6-async
     - ceph-1.2-rhel-7
+    - ceph-1.2-rhel-7-async
     - rh-common-rhel-6
     - rh-common-rhel-7
     - ceph-1.3-rhel-7

--- a/roles/puddle/templates/ceph-1.2-rhel-6-async.conf
+++ b/roles/puddle/templates/ceph-1.2-rhel-6-async.conf
@@ -1,0 +1,37 @@
+#
+# {{ ansible_managed }}
+#
+
+[puddle]
+type = errata
+errata_release = CEPH-ASYNC
+errata_whitelist = no
+product_name = RHCeph
+version = 1.2-RHEL-6
+rootdir = /var/www/{{ ansible_hostname }}/htdocs/puddles
+emails = {{ puddle.emails }}
+signed = no
+rhndir = no
+mashroot = /tmp/mash/ceph
+brewroot = {{ puddle.brewroot_url }}
+topurl = {{ puddle.topurl }}/puddles
+announcer = {{ puddle.announcer }}
+publish = no
+cdndir = no
+
+
+[RH6-CEPH-CALAMARI-1.2]
+variant = RH6-CEPH-CALAMARI-1.2
+external = {{ puddle.rhel_6_z_repo_url }},{{ puddle.rhel_6_ceph_calamari_1_2_repo_url }}
+
+[RH6-CEPH-INSTALLER-1.2]
+variant = RH6-CEPH-INSTALLER-1.2
+external = {{ puddle.rhel_6_z_repo_url }},{{ puddle.rhel_6_ceph_installer_1_2_repo_url }}
+
+[RH6-CEPH-MON-1.2]
+variant = RH6-CEPH-MON-1.2
+external = {{ puddle.rhel_6_z_repo_url }},{{ puddle.rhel_6_ceph_mon_1_2_repo_url }}
+
+[RH6-CEPH-OSD-1.2]
+variant = RH6-CEPH-OSD-1.2
+external = {{ puddle.rhel_6_z_repo_url }},{{ puddle.rhel_6_ceph_osd_1_2_repo_url }}

--- a/roles/puddle/templates/ceph-1.2-rhel-7-async.conf
+++ b/roles/puddle/templates/ceph-1.2-rhel-7-async.conf
@@ -1,0 +1,37 @@
+#
+# {{ ansible_managed }}
+#
+
+[puddle]
+type = errata
+errata_release = CEPH-ASYNC
+errata_whitelist = no
+product_name = RHCeph
+version = 1.2-RHEL-7
+rootdir = /var/www/{{ ansible_hostname }}/htdocs/puddles
+emails = {{ puddle.emails }}
+signed = no
+rhndir = no
+mashroot = /tmp/mash/ceph
+brewroot = {{ puddle.brewroot_url }}
+topurl = {{ puddle.topurl }}/puddles
+announcer = {{ puddle.announcer }}
+publish = no
+cdndir = no
+
+
+[Server-RH7-CEPH-CALAMARI-1.2]
+variant = Server-RH7-CEPH-CALAMARI-1.2
+external = {{ puddle.rhel_7_z_repo_url }},{{ puddle.rhel_7_ceph_calamari_1_2_repo_url }}
+
+[Server-RH7-CEPH-INSTALLER-1.2]
+variant = Server-RH7-CEPH-INSTALLER-1.2
+external = {{ puddle.rhel_7_z_repo_url }},{{ puddle.rhel_7_ceph_installer_1_2_repo_url }}
+
+[Server-RH7-CEPH-MON-1.2]
+variant = Server-RH7-CEPH-MON-1.2
+external = {{ puddle.rhel_7_z_repo_url }},{{ puddle.rhel_7_ceph_mon_1_2_repo_url }}
+
+[Server-RH7-CEPH-OSD-1.2]
+variant = Server-RH7-CEPH-OSD-1.2
+external = {{ puddle.rhel_7_z_repo_url }},{{ puddle.rhel_7_ceph_osd_1_2_repo_url }}


### PR DESCRIPTION
CEPH-ASYNC advisories have a slightly different config than the config we used for the 1.2.3 release. Here are the changes I made from the 1.2.3 configs:

  1. "errata_release" is "CEPH-ASYNC"
  2. Packages are not always signed (remove the keys settings)
  3. We need to add more repos for repoclosure to succeed (namely, the
     production read-only pulp repos)