### PR TITLE
Add a teuthology_user group and assign it to the teuthology_user.

### DIFF
--- a/roles/testnode/tasks/user.yml
+++ b/roles/testnode/tasks/user.yml
@@ -4,6 +4,11 @@
     name: sudo
     state: present
 
+- name: Ensure the teuthology_user group exists.
+  group:
+    name: "{{ teuthology_user }}"
+    state: present
+
 - name: Create the teuthology user.
   user:
     name: "{{ teuthology_user }}"
@@ -11,6 +16,7 @@
     # https://github.com/ceph/ceph-qa-chef/commit/5678cc3893fd1cc291254e4d1abe6705e6a9bbb0
     uid: 1000
     group: sudo
+    groups: "{{ teuthology_user }}"
     state: present
 
 - name: Add a user for xfstests to test user quotas.


### PR DESCRIPTION
This fixes a bug when creating a CPAN config directory that belongs to the
group teuthology_user.  If this group wasn't created already that play
fails.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>