### PR TITLE
Cobbler: automatically run ansible after install of new-style profiles

### DIFF
--- a/roles/cobbler/defaults/main.yml
+++ b/roles/cobbler/defaults/main.yml
@@ -12,6 +12,9 @@ snippets:
 scripts:
   - cephlab_preseed_late
 
+triggers:
+  - install/post/cephlab_ansible.sh
+
 ssh_keys: []
 
 ansible_user: ''

--- a/roles/cobbler/defaults/main.yml
+++ b/roles/cobbler/defaults/main.yml
@@ -8,6 +8,7 @@ snippets:
   - cephlab_hostname
   - cephlab_apt-mirror_hack
   - cephlab_packages_rhel
+  - cephlab_rc_local
 
 scripts:
   - cephlab_preseed_late

--- a/roles/cobbler/tasks/upload_templates.yml
+++ b/roles/cobbler/tasks/upload_templates.yml
@@ -31,3 +31,14 @@
   with_items: scripts
   tags:
     - scripts
+
+- name: Upload triggers.
+  template:
+    src: "triggers/{{ item }}"
+    dest: "/var/lib/cobbler/triggers/{{ item }}"
+    owner: root
+    group: root
+    mode: 0744
+  with_items: triggers
+  tags:
+    - triggers

--- a/roles/cobbler/templates/kickstarts/cephlab_rhel.ks
+++ b/roles/cobbler/templates/kickstarts/cephlab_rhel.ks
@@ -77,6 +77,7 @@ $SNIPPET('post_anamon')
 $SNIPPET('cephlab_hostname')
 $SNIPPET('cephlab_user')
 $SNIPPET('cephlab_apt-mirror_hack')
+$SNIPPET('cephlab_rc_local')
 $SNIPPET('kickstart_done')
 # End final steps
 %end

--- a/roles/cobbler/templates/scripts/cephlab_preseed_late
+++ b/roles/cobbler/templates/scripts/cephlab_preseed_late
@@ -9,6 +9,7 @@ $SNIPPET('download_config_files')
 $SNIPPET('cephlab_hostname')
 $SNIPPET('cephlab_user')
 $SNIPPET('cephlab_apt-mirror_hack')
+$SNIPPET('cephlab_rc_local')
 # end custom
 $SNIPPET('kickstart_done')
 # End preseed_late_default

--- a/roles/cobbler/templates/snippets/cephlab_rc_local
+++ b/roles/cobbler/templates/snippets/cephlab_rc_local
@@ -1,0 +1,24 @@
+## {{ ansible_managed }}
+#set lockfile = '/.cephlab_rc_local'
+#set script = '/etc/rc.local'
+
+cat > $script << EOF
+#!/bin/bash
+# First, redirect stderr and stdout to a logfile
+exec 2> /tmp/rc.local.log
+exec 1>&2
+set -ex
+
+# Only run once.
+if [ -e $lockfile ]; then
+    exit 0
+fi
+
+# Wait just a bit for the network to come up
+sleep 15
+# Run the post-install trigger a second time
+wget -O /dev/null "http://$http_server:$http_port/cblr/svc/op/trig/mode/post/system/$system_name"
+touch $lockfile
+EOF
+
+chmod +x $script

--- a/roles/cobbler/templates/triggers/install/post/cephlab_ansible.sh
+++ b/roles/cobbler/templates/triggers/install/post/cephlab_ansible.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+## {{ ansible_managed }}
+set -ex
+name=$2
+export USER=root
+export HOME=/root
+ANSIBLE_CM_PATH=/root/ceph-cm-ansible
+
+# Bail if the ssh port isn't open, as will be the case when this is run 
+# while the installer is still running. When this is triggered by 
+# /etc/rc.local after a reboot, the port will be open and we'll continue
+nc -vz $name 22
+
+mkdir -p /var/log/ansible
+
+# Tell ansible to create users and populate authorized_keys
+pushd $ANSIBLE_CM_PATH
+ANSIBLE_SSH_PIPELINING=1 ansible-playbook testnodes.yml -vv --limit $name* --tags user,pubkeys 2>&1 | tee /var/log/ansible/$name.log
+popd


### PR DESCRIPTION
For now it only uses ``--tags user,pubkeys``, because I'm not sure if running the whole thing is safe. It might be distro dependant and is definitely something we'd want to test carefully. This should be safe though.