### PR TITLE
puddle: add CEPH-TOOLS repo and `ceph-puddle` utility

### DIFF
--- a/roles/puddle/tasks/configure.yml
+++ b/roles/puddle/tasks/configure.yml
@@ -48,3 +48,11 @@
     mode: 0644
   notify:
    - restart faucet
+
+- name: add ceph wrapper script for puddle
+  template:
+    src: 'ceph-puddle'
+    dest: '/usr/local/bin/ceph-puddle'
+    owner: root
+    group: root
+    mode: 0755

--- a/roles/puddle/templates/ceph-1.3-rhel-7.conf
+++ b/roles/puddle/templates/ceph-1.3-rhel-7.conf
@@ -40,3 +40,8 @@ keys = fd431d51,f21541eb
 variant = Server-RH7-CEPH-OSD-1.3
 external = {{ puddle.rhel_7_z_repo_url }}
 keys = fd431d51,f21541eb
+
+[Server-RH7-CEPH-TOOLS-1.3]
+variant = Server-RH7-CEPH-TOOLS-1.3
+external = {{ puddle.rhel_7_z_repo_url }}
+keys = fd431d51,f21541eb

--- a/roles/puddle/templates/ceph-puddle
+++ b/roles/puddle/templates/ceph-puddle
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+#
+# {{ ansible_managed }}
+#
+
+# In order to allow Puddle to communicate with Red Hat's Errata Tool, we need
+# active Kerberos credentials. This script wraps /usr/bin/puddle with the
+# k5start utility.
+
+set -e
+
+exec k5start -U -f {{ puddle.kerberos_keytab }} -- puddle "$@"


### PR DESCRIPTION
The first commit in this PR adds the new CEPH-TOOLS repository to Puddle for the Red Hat Ceph Storage 1.3 product.

The second commit in this PR adds a new `ceph-puddle` wrapper script to make it easier to run Puddle with Kerberos credentials.