### PR TITLE
Install python-devel and python-virtualenv on rhel 7.x

### DIFF
--- a/roles/testnode/vars/redhat_7.yml
+++ b/roles/testnode/vars/redhat_7.yml
@@ -78,5 +78,8 @@ packages:
   - nfs-utils
   # for xfstests
   - ncurses-devel
+  # for s3 tests
+  - python-devel
+  - python-virtualenv
 
 nfs_service: nfs-server


### PR DESCRIPTION
python-virtualenv was actually missed in the port, oops.  python-devel was new though.  At some point we should talk again about how we push this kind of stuff out to the task that needs it.  For now, I don't want to hold things up as we figure out the best way to do that.

re: http://tracker.ceph.com/issues/11637
