### PR TITLE
puddle: move nginx params on to multiple lines

### DIFF
--- a/roles/puddle/tasks/nginx.yml
+++ b/roles/puddle/tasks/nginx.yml
@@ -1,6 +1,8 @@
 ---
 - name: install nginx web server
-  yum: name=nginx state=present
+  yum:
+    name: nginx
+    state: present
 
 - name: create nginx docroot
   file:
@@ -17,4 +19,7 @@
    - restart nginx
 
 - name: start the nginx service
-  service: name=nginx state=started enabled=yes
+  service:
+    name: nginx
+    state: started
+    enabled: yes


### PR DESCRIPTION
Follow the convention of putting each parameter on multiple lines, instead of cramming everything into one line.

This is a style change only; no functional change.