### PR TITLE
Set iso_name and iso_path when not downloading

### DIFF
--- a/roles/cobbler_profile/tasks/download_iso.yml
+++ b/roles/cobbler_profile/tasks/download_iso.yml
@@ -1,12 +1,4 @@
 ---
-- name: Set ISO name
-  set_fact:
-      iso_name: "{{ distro.iso.split('/')[-1] }}"
-
-- name: Set ISO path
-  set_fact:
-      iso_path: "{{ iso_dir }}/{{ iso_name }}"
-
 - name: Check to see if the ISO exists
   stat: path={{ iso_path }} get_checksum=no get_md5=no
   register: iso_stat

--- a/roles/cobbler_profile/tasks/import_distro.yml
+++ b/roles/cobbler_profile/tasks/import_distro.yml
@@ -28,6 +28,14 @@
   ignore_errors: true
   changed_when: false
 
+- name: Set ISO name
+  set_fact:
+      iso_name: "{{ distro.iso.split('/')[-1] }}"
+
+- name: Set ISO path
+  set_fact:
+      iso_path: "{{ iso_dir }}/{{ iso_name }}"
+
 - include: download_iso.yml
   when: distro.iso != ''
 


### PR DESCRIPTION
Otherwise we bail when trying to clear the mount point

Signed-off-by: Zack Cerza <zack@redhat.com>