### PR TITLE
Set all created users' shells to /bin/bash

### DIFF
--- a/roles/ansible-managed/tasks/main.yml
+++ b/roles/ansible-managed/tasks/main.yml
@@ -10,6 +10,7 @@
   user:
     name: "{{ ansible_user }}"
     group: sudo
+    shell: /bin/bash
     uid: "{{ ansible_user_uid_ }}"
     update_password: on_create
   register: user_created

--- a/roles/testnode/tasks/user.yml
+++ b/roles/testnode/tasks/user.yml
@@ -17,6 +17,7 @@
     uid: 1000
     group: sudo
     groups: "{{ teuthology_user }}"
+    shell: /bin/bash
     state: present
 
 - name: Add a user for xfstests to test user quotas.

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -3,6 +3,7 @@
   user:
     name: "{{ item.name }}"
     group: sudo
+    shell: /bin/bash
     state: present
   with_items: managed_admin_users
   tags:
@@ -11,6 +12,7 @@
 - name: Create all users without sudo access.
   user:
     name: "{{ item.name }}"
+    shell: /bin/bash
     state: present
   with_items: managed_users
   tags:


### PR DESCRIPTION
They were ending up with sh, which is horrible

Signed-off-by: Zack Cerza <zack@redhat.com>