### PR TITLE
cobbler: adds cephlab_ubuntu_network snippet

### DIFF
--- a/roles/cobbler/defaults/main.yml
+++ b/roles/cobbler/defaults/main.yml
@@ -16,6 +16,7 @@ snippets:
   - cephlab_rc_local
   - cephlab_rhel_disks
   - cephlab_post_install_kernel_options
+  - cephlab_ubuntu_network
 
 scripts:
   - cephlab_preseed_late
@@ -27,3 +28,10 @@ ssh_keys: []
 
 ansible_user: ''
 ansible_user_uid_: ''
+
+# A list of lines to add to resolv.conf and resolv.conf.d/base
+# An example:
+#   resolvconf:
+#      - "nameserver x.x.x.x"
+#      - "search an.example.com"
+resolvconf: []

--- a/roles/cobbler/templates/scripts/cephlab_preseed_late
+++ b/roles/cobbler/templates/scripts/cephlab_preseed_late
@@ -1,7 +1,7 @@
 ## {{ ansible_managed }}
 # Start preseed_late_default
 # This script runs in the chroot /target by default
-$SNIPPET('post_install_network_config_deb')
+$SNIPPET('cephlab_ubuntu_network')
 # set kernel options as defined by the system, profile or distro
 # in the Kernel Options (Post Install) field which populates the var kernel_options_post
 $SNIPPET('cephlab_post_install_kernel_options')

--- a/roles/cobbler/templates/snippets/cephlab_ubuntu_network
+++ b/roles/cobbler/templates/snippets/cephlab_ubuntu_network
@@ -1,0 +1,44 @@
+### {{ ansible_managed }}
+#set os_version = $getVar('os_version','')
+#if $os_version == 'vivid'
+# deleting interfaces we don't need for vivid.
+# if these are in place then vivid wants to use eth2 as the
+# primary interface
+sed -i '/eth2/d' /etc/udev/rules.d/70-persistent-net.rules
+sed -i '/eth3/d' /etc/udev/rules.d/70-persistent-net.rules
+#end if
+
+rm -f /etc/network/interfaces
+touch /etc/network/interfaces
+
+cat >> /etc/network/interfaces << EOF
+# This file describes the network interfaces available on your system
+# and how to activate them. For more information, see interfaces(5).
+
+# The loopback network interface
+auto lo
+iface lo inet loopback
+
+# The primary network interface
+auto eth0
+iface eth0 inet dhcp
+# This is an autoconfigured IPv6 interface
+iface eth0 inet6 auto
+EOF
+
+{% if resolvconf|length > 0 %}
+rm -f /etc/resolv.conf
+touch /etc/resolv.conf
+
+cat >> /etc/resolv.conf << EOF
+{% for line in resolvconf %}
+{{ line }}
+{% endfor %}
+EOF
+
+cat >> /etc/resolvconf/resolv.conf.d/base << EOF
+{% for line in resolvconf %}
+{{ line }}
+{% endfor %}
+EOF
+{% endif %}


### PR DESCRIPTION
This is used to set the network connectivity for ubuntu nodes after
imaging using DHCP.

This is also creating a ``resolvconf`` var that I'm using in the snippet to set resolv.conf and resolv.conf.d/base during imaging.  I need to do that so DHCP will work and give us our IP after first boot.  Eventually we should have the testnodes role use this var as well and delete the hardcoded templates it uses.