### PR TITLE
downstream-setup: make yum_repos clean up after itself on teardown

### DIFF
--- a/roles/downstream-setup/defaults/main.yml
+++ b/roles/downstream-setup/defaults/main.yml
@@ -1,4 +1,9 @@
 ---
+# When teardown is true the tasks being used might
+# perform teardown steps if applicable.
+teardown: false
+
+
 # yum_repos is a list of hashes that
 # define the url to download the yum repo
 # from and the name to save it as in etc/yum.repos.d
@@ -8,6 +13,8 @@
 #     - url: "http://path/to/epel.repo"
 #       name: "epel"
 #
+# When using the yum_repos var and if teardown is true it will
+# delete the repos instead of creating them.
 yum_repos: []
 
 # a list of repo names as strings to delete from /etc/yum.repos.d

--- a/roles/downstream-setup/tasks/main.yml
+++ b/roles/downstream-setup/tasks/main.yml
@@ -1,8 +1,16 @@
 ---
 - include: yum_repos.yml
-  when: yum_repos|length > 0
+  when: yum_repos|length > 0 and
+        not teardown
   tags:
     - yum-repos
+
+- name: Set remove_yum_repos on teardown
+  set_fact:
+    remove_yum_repos: "[{% for repo in yum_repos %}'{{ repo.name}}',{% endfor %}]"
+  when: yum_repos|length > 0 and
+        teardown and
+        remove_yum_repos|length == 0
 
 - include: remove_yum_repos.yml
   when: remove_yum_repos|length > 0


### PR DESCRIPTION
This lets us pass a teardown==True var to downstream-setup with the
yum_repos var defined and it will instead remove the repos defined in
yum_repos instead of downloading them.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>