### PR TITLE
Support for ubuntu vivid

### DIFF
--- a/roles/cobbler/templates/scripts/cephlab_preseed_late
+++ b/roles/cobbler/templates/scripts/cephlab_preseed_late
@@ -5,7 +5,6 @@ $SNIPPET('cephlab_ubuntu_network')
 # set kernel options as defined by the system, profile or distro
 # in the Kernel Options (Post Install) field which populates the var kernel_options_post
 $SNIPPET('cephlab_post_install_kernel_options')
-$SNIPPET('late_apt_repo_config')
 $SNIPPET('post_run_deb')
 $SNIPPET('download_config_files')
 # custom

--- a/roles/testnode/handlers/main.yml
+++ b/roles/testnode/handlers/main.yml
@@ -15,11 +15,10 @@
     state: started
     enabled: yes
 
-- name: start nfs-server
+- name: restart nfs-server
   service:
     name: "{{ nfs_service }}"
-    state: started 
-    enabled: yes
+    state: restarted
 
 - name: restart cron
   service:

--- a/roles/testnode/tasks/apt_systems.yml
+++ b/roles/testnode/tasks/apt_systems.yml
@@ -1,6 +1,17 @@
 ---
+# Starting with ubuntu 15.04 we no longer maintain our own package mirrors.
+# For anything ubuntu < 15.04 or debian <=7 we still do.
 - name: Setup local repo files.
   include: apt/repos.yml
+  when: ansible_distribution_major_version < 15
+  tags:
+    - repos
+
+- name: Update apt cache.
+  apt:
+    update_cache: yes
+  when: ansible_distribution_major_version >= 15 and
+        ansible_distribution == "Ubuntu"
   tags:
     - repos
 

--- a/roles/testnode/tasks/nfs.yml
+++ b/roles/testnode/tasks/nfs.yml
@@ -8,4 +8,4 @@
     mode: 0644
   notify:
     - start rpcbind
-    - start nfs-server
+    - restart nfs-server

--- a/roles/testnode/tasks/nfs.yml
+++ b/roles/testnode/tasks/nfs.yml
@@ -9,3 +9,10 @@
   notify:
     - start rpcbind
     - restart nfs-server
+
+- name: Enable nfs-server on rhel 7.x.
+  service:
+    name: "{{ nfs_service }}"
+    enabled: true
+  when: ansible_distribution == "RedHat" and
+        ansible_distribution_major_version == "7"

--- a/roles/testnode/templates/ssh/sshd_config_ubuntu_15
+++ b/roles/testnode/templates/ssh/sshd_config_ubuntu_15
@@ -1,0 +1,91 @@
+# {{ ansible_managed }}
+# Package generated configuration file
+# See the sshd_config(5) manpage for details
+
+# What ports, IPs and protocols we listen for
+Port 22
+# Use these options to restrict which interfaces/protocols sshd will bind to
+#ListenAddress ::
+#ListenAddress 0.0.0.0
+Protocol 2
+# HostKeys for protocol version 2
+HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_dsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
+HostKey /etc/ssh/ssh_host_ed25519_key
+#Privilege Separation is turned on for security
+UsePrivilegeSeparation yes
+
+# Lifetime and size of ephemeral version 1 server key
+KeyRegenerationInterval 3600
+ServerKeyBits 1024
+
+# Logging
+SyslogFacility AUTH
+LogLevel INFO
+
+# Authentication:
+LoginGraceTime 120
+PermitRootLogin without-password
+StrictModes yes
+
+RSAAuthentication yes
+PubkeyAuthentication yes
+#AuthorizedKeysFile	%h/.ssh/authorized_keys
+
+# Don't read the user's ~/.rhosts and ~/.shosts files
+IgnoreRhosts yes
+# For this to work you will also need host keys in /etc/ssh_known_hosts
+RhostsRSAAuthentication no
+# similar for protocol version 2
+HostbasedAuthentication no
+# Uncomment if you don't trust ~/.ssh/known_hosts for RhostsRSAAuthentication
+#IgnoreUserKnownHosts yes
+
+# To enable empty passwords, change to yes (NOT RECOMMENDED)
+PermitEmptyPasswords no
+
+# Change to yes to enable challenge-response passwords (beware issues with
+# some PAM modules and threads)
+ChallengeResponseAuthentication no
+
+# Change to no to disable tunnelled clear text passwords
+#PasswordAuthentication yes
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosGetAFSToken no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+
+X11Forwarding yes
+X11DisplayOffset 10
+PrintMotd no
+PrintLastLog yes
+TCPKeepAlive yes
+#UseLogin no
+
+#MaxStartups 10:30:60
+#Banner /etc/issue.net
+
+# Allow client to pass locale environment variables
+AcceptEnv LANG LC_*
+
+Subsystem sftp /usr/lib/openssh/sftp-server
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+UsePAM yes
+
+MaxSessions 1000

--- a/roles/testnode/vars/ubuntu.yml
+++ b/roles/testnode/vars/ubuntu.yml
@@ -76,7 +76,6 @@ common_packages:
   - blktrace
   - python-numpy
   - python-matplotlib
-  - mencoder
   ###
   # qemu
   - genisoimage

--- a/roles/testnode/vars/ubuntu_15.yml
+++ b/roles/testnode/vars/ubuntu_15.yml
@@ -1,0 +1,12 @@
+---
+apt_repos: []
+
+packages:
+  - libgoogle-perftools4
+# FIXME: not available on vivid, figure out what's available and use it
+# - libboost-thread1.54.0
+  - mpich
+  - qemu-system-x86
+# FIXME: not available on vivid, figure out what's available and use it
+#  - blkin
+  - lttng-tools


### PR DESCRIPTION
There are a few things here I feel need discussion before merge. 

1) We're not going to be maintain a package mirror for vivid and instead will use the distro provided mirror. This was discussed in irc, but more people can weigh in here if they care.

2) There are some packages that we install on other version of ubuntu that aren't available in vivid.  We're already removed mencoder, do we need to find alternate versions for the others commented out in vars/ubuntu_15.yml?

3) Vivid fails to 'enable' nfs-server, but can start it fine.  My first pass at debugging that didn't come up with anything as to why ansible can't 'enable' nfs-server. I'm unsure if this will be an issue or not.

I also have not tested this change against trusty to make sure I didn't break anything so I want to do that before merge as well.  I don't imagine I have though.