### PR TITLE
Enable SELinux on yum systems

### DIFF
--- a/roles/testnode/tasks/yum_systems.yml
+++ b/roles/testnode/tasks/yum_systems.yml
@@ -55,3 +55,8 @@
   include: yum/packages.yml
   tags:
     - packages
+
+- name: Enable SELinux
+  selinux: state=permissive policy=targeted
+  tags:
+    - selinux


### PR DESCRIPTION
This doesn't reboot them to initiate autorelabel, but we can do that in the future if we need to.

Signed-off-by: Zack Cerza <zack@redhat.com>