### PR TITLE
downstream-setup: use 'cleanup' instead of 'teardown'

### DIFF
--- a/roles/downstream-setup/defaults/main.yml
+++ b/roles/downstream-setup/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
-# When teardown is true the tasks being used might
-# perform teardown steps if applicable.
-teardown: false
+# When cleanup is true the tasks being used might
+# perform cleanup steps if applicable.
+cleanup: false
 
 
 # yum_repos is a list of hashes that
@@ -13,7 +13,7 @@ teardown: false
 #     - url: "http://path/to/epel.repo"
 #       name: "epel"
 #
-# When using the yum_repos var and if teardown is true it will
+# When using the yum_repos var and if cleanup is true it will
 # delete the repos instead of creating them.
 yum_repos: []
 

--- a/roles/downstream-setup/tasks/main.yml
+++ b/roles/downstream-setup/tasks/main.yml
@@ -1,15 +1,15 @@
 ---
 - include: yum_repos.yml
   when: yum_repos|length > 0 and
-        not teardown
+        not cleanup
   tags:
     - yum-repos
 
-- name: Set remove_yum_repos on teardown
+- name: Set remove_yum_repos on cleanup
   set_fact:
     remove_yum_repos: "[{% for repo in yum_repos %}'{{ repo.name}}',{% endfor %}]"
   when: yum_repos|length > 0 and
-        teardown and
+        cleanup and
         remove_yum_repos|length == 0
 
 - include: remove_yum_repos.yml


### PR DESCRIPTION
We want this change because using 'teardown' within teuthology was
confusing because we already have a method called 'teardown' on
class-based tasks.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>