### PR TITLE
downstream-setup: add tasks to disable and enable yum repos.

### DIFF
--- a/roles/downstream-setup/defaults/main.yml
+++ b/roles/downstream-setup/defaults/main.yml
@@ -20,3 +20,17 @@ yum_repos: []
 # a list of repo names as strings to delete from /etc/yum.repos.d
 # the name should not include the .repo extension
 remove_yum_repos: []
+
+# a list of repo names as strings to disable in /etc/yum.repos.d
+# the name should not include the .repo extension
+# When using the disable_yum_repos var and if cleanup is true it will
+# delete the repos instead of creating them.
+# NOTE: this does not work on repo files with multiple entries in them,
+# it will only disable the first entry in the repo file.
+disable_yum_repos: []
+
+# a list of repo names as strings to enable in /etc/yum.repos.d
+# the name should not include the .repo extension
+# NOTE: this does not work on repo files with multiple entries in them,
+# it will only enable the first entry in the repo file.
+enable_yum_repos: []

--- a/roles/downstream-setup/tasks/disable_yum_repos.yml
+++ b/roles/downstream-setup/tasks/disable_yum_repos.yml
@@ -1,0 +1,9 @@
+---
+- name: Disable yum repos.
+  lineinfile:
+    dest: "/etc/yum.repos.d/{{ item }}.repo"
+    line: "enabled=0"
+    regexp: "enabled=1"
+    backrefs: yes
+    state: present
+  with_items: disable_yum_repos

--- a/roles/downstream-setup/tasks/enable_yum_repos.yml
+++ b/roles/downstream-setup/tasks/enable_yum_repos.yml
@@ -1,0 +1,9 @@
+---
+- name: Enable yum repos.
+  lineinfile:
+    dest: "/etc/yum.repos.d/{{ item }}.repo"
+    line: "enabled=1"
+    regexp: "enabled=0"
+    backrefs: yes
+    state: present
+  with_items: enable_yum_repos

--- a/roles/downstream-setup/tasks/main.yml
+++ b/roles/downstream-setup/tasks/main.yml
@@ -16,3 +16,21 @@
   when: remove_yum_repos|length > 0
   tags:
     - delete-yum-repos
+
+- include: disable_yum_repos.yml
+  when: disable_yum_repos|length > 0 and
+        not cleanup
+  tags:
+    - disable-yum-repos
+
+- name: Set enable_yum_repos on cleanup
+  set_fact:
+    enable_yum_repos: "{{ disable_yum_repos }}"
+  when: disable_yum_repos|length > 0 and
+        cleanup and
+        enable_yum_repos|length == 0
+
+- include: enable_yum_repos.yml
+  when: enable_yum_repos|length > 0
+  tags:
+    - enable-yum-repos


### PR DESCRIPTION
This works similar to downloading yum_repos. You can specific a repo
file to disable using 'disable_yum_repos' and enable them by using
'enable_yum_repos'. If you use 'disable_yum_repos' with 'cleanup' it
will enable the repos listed in 'disable_yum_repos' - this feature is
used with teuthology and the Ansible task.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>