### PR TITLE
cobbler: set the mode to 0440 on /etc/sudoers.d/cephlab_sudo

### DIFF
--- a/roles/cobbler/templates/snippets/cephlab_user
+++ b/roles/cobbler/templates/snippets/cephlab_user
@@ -13,6 +13,8 @@ Defaults !requiretty
 Defaults visiblepw
 EOF
 
+chmod 0440 /etc/sudoers.d/cephlab_sudo
+
 install -d -m0755 --owner=$user --group=$user /home/$user/.ssh 
 
 cat >> $auth_keys << EOF


### PR DESCRIPTION
Apparently most other distros default anything in /etc/sudoers.d to
0440 except precise. Precise, by default, sets the mode of
/etc/sudoers.d/cephlab_sudo to 0664 which completely breaks sudo usage.
This makes cobbler explicitly set the mode to 0440.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>