### PR TITLE
testnode: do not start rpcbind on precise

### DIFF
--- a/roles/testnode/defaults/main.yml
+++ b/roles/testnode/defaults/main.yml
@@ -18,3 +18,7 @@ packages_to_upgrade: []
 # the user teuthology will use
 teuthology_user: "ubuntu"
 xfstests_user: "fsgqa"
+
+# some distros need to start rpcbind before
+# trying to use nfs while others don't.
+start_rpcbind: true

--- a/roles/testnode/handlers/main.yml
+++ b/roles/testnode/handlers/main.yml
@@ -14,6 +14,7 @@
     name: rpcbind
     state: started
     enabled: yes
+  when: start_rpcbind
 
 - name: restart nfs-server
   service:

--- a/roles/testnode/vars/ubuntu_12.04.yml
+++ b/roles/testnode/vars/ubuntu_12.04.yml
@@ -9,3 +9,7 @@ packages:
   - ltp-kernel-test
   - libmpich2-3
   - kvm
+
+# on precise rpcbind does not provide a way to
+# be managed with upstart
+start_rpcbind: false


### PR DESCRIPTION
rpcbind does not provide a way to be managed with upstart on precise.
This creates a var we can use to toggle this task on and off per distro
as the other distros we support are ok with starting and enabling rpcbind.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>