### PR TITLE
downstream-setup: ignore errors when disabling or enabling repos

### DIFF
--- a/roles/downstream-setup/tasks/disable_yum_repos.yml
+++ b/roles/downstream-setup/tasks/disable_yum_repos.yml
@@ -7,3 +7,4 @@
     backrefs: yes
     state: present
   with_items: disable_yum_repos
+  ignore_errors: true

--- a/roles/downstream-setup/tasks/enable_yum_repos.yml
+++ b/roles/downstream-setup/tasks/enable_yum_repos.yml
@@ -7,3 +7,4 @@
     backrefs: yes
     state: present
   with_items: enable_yum_repos
+  ignore_errors: true


### PR DESCRIPTION
The lineinfile module fails if dest doesn't exist. We want this to fail
silently instead. The ansible output still does a good job of letting
you know a task failed without failing the entire playbook.

Sample output:

```
TASK: [downstream-setup | Disable yum repos.] *********************************
failed: [XXX.com] => (item=notthere) => {"failed": true, "item": "notthere", "rc": 257}
msg: Destination /etc/yum.repos.d/notthere.repo does not exist !
...ignoring
ok: [XXX.com] => (item=epel) => {"backup": "", "changed": false, "item": "epel", "msg": ""}
```