### PR TITLE
testnode: fixes a bug keeping apt repos from being added

### DIFF
--- a/roles/testnode/tasks/apt_systems.yml
+++ b/roles/testnode/tasks/apt_systems.yml
@@ -3,14 +3,14 @@
 # For anything ubuntu < 15.04 or debian <=7 we still do.
 - name: Setup local repo files.
   include: apt/repos.yml
-  when: ansible_distribution_major_version < 15
+  when: ansible_distribution_major_version|int < 15
   tags:
     - repos
 
 - name: Update apt cache.
   apt:
     update_cache: yes
-  when: ansible_distribution_major_version >= 15 and
+  when: ansible_distribution_major_version|int >= 15 and
         ansible_distribution == "Ubuntu"
   tags:
     - repos


### PR DESCRIPTION
I needed to cast ansible_distribution_major_version to an int for the
comparsion to work.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>