### PR TITLE
users: add a 'users' var to act as a filter

### DIFF
--- a/roles/users/README.rst
+++ b/roles/users/README.rst
@@ -35,6 +35,10 @@ sure to define either ``managed_users`` or ``managed_admin_users`` in your inven
 
     $ ansible-playbook users.yml --limit="$NODE"
 
+You can also filter the list of users being managed by passing the 'users' variable::
+
+    $ ansible-playbook users.yml --limit="$NODE" --extra-vars='{"users"=["user1"]}'
+
 Variables
 +++++++++
 
@@ -64,6 +68,10 @@ For example, in inventory/group_vars/webservers.yml you might have a list of use
     managed_admin_users:
       - name: admin
         key: <ssh_key_string>
+
+A list of usernames to filter ``managed_users`` and ``managed_admin_users`` by::
+
+    users: []
 
 Tags
 ++++

--- a/roles/users/defaults/main.yml
+++ b/roles/users/defaults/main.yml
@@ -12,3 +12,9 @@
 managed_users: []
 # are given sudo access
 managed_admin_users: []
+
+# A list of usernames to filter managed_users and
+# managed_admin_users by.  For example, if given ['user1']
+# both managed_users and managed_admin_users would be filtered
+# to only contain the information for 'user1'.
+users: []

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -1,4 +1,24 @@
 ---
+- name: Filter the managed_users list
+  set_fact:
+    managed_users:
+        "[{% for user in managed_users %}
+            {% if user.name in users %}{{ user }},{%endif%}
+        {%endfor%}]"
+  when: users|length > 0
+  tags:
+    - always
+
+- name: Filter the managed_admin_users list
+  set_fact:
+    managed_admin_users:
+        "[{% for user in managed_admin_users %}
+            {% if user.name in users %}{{ user }},{%endif%}
+        {%endfor%}]"
+  when: users|length > 0
+  tags:
+    - always
+
 - name: Create all admin users with sudo access.
   user:
     name: "{{ item.name }}"


### PR DESCRIPTION
If 'users' is provided it will filter 'managed_users'
and 'managed_admin_users' by the usernames provided in 'users'.

'users' must be a list of usernames as strings.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>