### PR TITLE
Don't modify the teuthology_user if it is in use

### DIFF
--- a/roles/testnode/tasks/user.yml
+++ b/roles/testnode/tasks/user.yml
@@ -19,6 +19,9 @@
     groups: "{{ teuthology_user }}"
     shell: /bin/bash
     state: present
+  # If we're currently running as teuthology_user, we won't be able to modify
+  # the account
+  when: "{{ teuthology_user != ansible_ssh_user }}"
 
 - name: Add a user for xfstests to test user quotas.
   user:


### PR DESCRIPTION
This is to work around cases where the user exists, with a different
uid, and we are currently logged in as that user:

msg: usermod: user ubuntu is currently logged in

Signed-off-by: Zack Cerza <zack@redhat.com>