### PR TITLE
testnode: do not modify resolv.conf on ubuntu

### DIFF
--- a/roles/testnode/handlers/main.yml
+++ b/roles/testnode/handlers/main.yml
@@ -40,8 +40,3 @@
   service:
     name: nagios-nrpe-server
     state: restarted
-
-- name: restart resolvdns
-  service:
-    name: resolvconf
-    state: restarted

--- a/roles/testnode/tasks/setup-ubuntu.yml
+++ b/roles/testnode/tasks/setup-ubuntu.yml
@@ -88,19 +88,6 @@
   script: scripts/static-ip.sh creates=/static-ip-setup
   when: "'vps' not in group_names"
 
-- name: Upload a lab specific base resolv.conf.
-  template:
-    src: "{{ item }}"
-    dest: /etc/resolvconf/resolv.conf.d/base
-    owner: root
-    group: root
-    mode: 0755
-  with_first_found:
-    - "resolvconf/base_{{ lab_name }}"
-    - resolvconf/base
-  notify:
-    - restart resolvdns
-
 - name: Edit lvm.conf to support LVM on RBD.
   lineinfile:
     dest: /etc/lvm/lvm.conf

--- a/roles/testnode/templates/resolvconf/base
+++ b/roles/testnode/templates/resolvconf/base
@@ -1,4 +1,0 @@
-# {{ ansible_managed }}
-nameserver 10.214.128.4
-nameserver 10.214.128.5
-search front.sepia.ceph.com sepia.ceph.com

--- a/roles/testnode/templates/resolvconf/base_octo
+++ b/roles/testnode/templates/resolvconf/base_octo
@@ -1,3 +1,0 @@
-# {{ ansible_managed }}
-nameserver 10.10.160.1
-search ceph.redhat.com sepia.ceph.com

--- a/roles/testnode/templates/resolvconf/base_typica
+++ b/roles/testnode/templates/resolvconf/base_typica
@@ -1,4 +1,0 @@
-# {{ ansible_managed }}
-nameserver 172.20.132.1
-nameserver 172.20.132.2
-search front.sepia.ceph.com sepia.ceph.com


### PR DESCRIPTION
There is no need to modify resolv.conf for ubuntu anymore.  When using
cobbler this is set by using the resolvconf var in the cobbler role. For
vms, like ones created by openstack, this allows ubuntu nodes to use the
resolv.conf already provided.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>