### PR TITLE
Use a targets var to optionally define hosts for each playbook

### DIFF
--- a/ansible_managed.yml
+++ b/ansible_managed.yml
@@ -1,7 +1,7 @@
 ---
 # a playbook to create the necessary users, groups and
 # sudoer settings needed for ansible to manage a node.
-- hosts: all
+- hosts: "{{ targets | default('all') }}"
   # assuming the nodes we run this on will most likely
   # have an ubuntu user already created.
   vars:

--- a/cobbler.yml
+++ b/cobbler.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: cobbler 
+- hosts: "{{ targets | default('cobbler') }}"
   roles:
     - common
     - cobbler 

--- a/downstream_setup.yml
+++ b/downstream_setup.yml
@@ -1,6 +1,6 @@
 ---
 # A playbook used to setup a node for downstream
 # RHCeph testing.
-- hosts: testnodes
+- hosts: "{{ targets | default('testnodes') }}"
   roles:
     - downstream-setup

--- a/puddle.yml
+++ b/puddle.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: puddle
+- hosts: "{{ targets | default('puddle') }}"
   roles:
     - common
     - puddle

--- a/testnodes.yml
+++ b/testnodes.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: testnodes
+- hosts: "{{ targets | default('testnodes') }}"
   roles:
     - common
     - testnode

--- a/users.yml
+++ b/users.yml
@@ -1,4 +1,4 @@
 ---
-- hosts: all
+- hosts: "{{ targets | default('all') }}"
   roles:
     - users


### PR DESCRIPTION
This will allow us to pass something like --extra-vars="targets=all"
when running the testnodes playbook to allow it to use any node in the
inventory and not only those in the testnodes group.

I see this as being useful for teuthology so that when the Ansible task
creates an inventory dynamically it doesn't have to worry about trying
to match up the nodes in the inventory with what's defined in the playbook.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>