### PR TITLE
roles used by teuthology should not require a secrets repo

### DIFF
--- a/roles/ansible-managed/meta/main.yml
+++ b/roles/ansible-managed/meta/main.yml
@@ -1,4 +1,3 @@
 ---
 dependencies:
-  - role: secrets
   - role: sudo

--- a/roles/ansible-managed/tasks/main.yml
+++ b/roles/ansible-managed/tasks/main.yml
@@ -51,5 +51,7 @@
     user: "{{ ansible_user }}"
     key: "{{ item }}"
   with_items: ansible_user_ssh_keys
+  when: ansible_user_ssh_keys is defined and
+        ansible_user is defined
   tags:
     - pubkeys

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -8,6 +8,7 @@ rhsm_repos: []
 
 kerberos_realm: EXAMPLE.COM
 
+epel_mirror_baseurl: "http://dl.fedoraproject.org/pub/epel"
 epel_repos:
   epel:
     name: "Extra Packages for Enterprise Linux"

--- a/roles/common/meta/main.yml
+++ b/roles/common/meta/main.yml
@@ -1,4 +1,6 @@
 ---
 dependencies:
+  - role: sudo
   - role: secrets
   - role: users
+  

--- a/roles/sudo/README.rst
+++ b/roles/sudo/README.rst
@@ -1,0 +1,5 @@
+Sudo
+====
+
+This role is mainly used as a dependancy for others. If you add this role as a dependancy
+to another it will ensure that all tasks in that role will use sudo.

--- a/roles/sudo/defaults/main.yml
+++ b/roles/sudo/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# ensures that sudo will be used for all tasks
+ansible_sudo: true

--- a/roles/testnode/defaults/main.yml
+++ b/roles/testnode/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 mirror_host: apt-mirror.front.sepia.ceph.com
+git_mirror_host: git.ceph.com
 pip_mirror_url: "http://{{ mirror_host }}/pypi/simple"
 
 # repos common to a major version

--- a/roles/testnode/defaults/main.yml
+++ b/roles/testnode/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 mirror_host: apt-mirror.front.sepia.ceph.com
 git_mirror_host: git.ceph.com
+gitbuilder_host: gitbuilder.ceph.com
 pip_mirror_url: "http://{{ mirror_host }}/pypi/simple"
 
 # repos common to a major version

--- a/roles/testnode/defaults/main.yml
+++ b/roles/testnode/defaults/main.yml
@@ -34,3 +34,9 @@ modify_fstab: true
 # FIXME: I believe this is only needed because of a quirk in how rhel
 # nodes are imaged in our labs. This might not be needed at all.
 lab_domain: ""
+
+ntp_servers:
+  - 0.us.pool.ntp.org
+  - 1.us.pool.ntp.org
+  - 2.us.pool.ntp.org
+  - 3.us.pool.ntp.org

--- a/roles/testnode/defaults/main.yml
+++ b/roles/testnode/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+mirror_host: apt-mirror.front.sepia.ceph.com
 pip_mirror_url: "http://{{ mirror_host }}/pypi/simple"
 
 # repos common to a major version

--- a/roles/testnode/defaults/main.yml
+++ b/roles/testnode/defaults/main.yml
@@ -27,3 +27,8 @@ start_rpcbind: true
 # mount options, which is useful for long lived bare metal machines,
 # less useful for virtual machines that are re-imaged before each job
 modify_fstab: true
+
+# used to remove lab_domain from the hostname on rhel nodes
+# FIXME: I believe this is only needed because of a quirk in how rhel
+# nodes are imaged in our labs. This might not be needed at all.
+lab_domain: ""

--- a/roles/testnode/tasks/redhat/set_hostname.yml
+++ b/roles/testnode/tasks/redhat/set_hostname.yml
@@ -14,7 +14,7 @@
   set_fact:
     new_hostname: "{{ existing_hostname.stdout.split('.')[0] }}"
   when: existing_hostname is defined and
-        existing_hostname.stdout.find("{{ lab_domain | mandatory }}") != -1
+        existing_hostname.stdout.find("{{ lab_domain }}") != -1
 
 - name: Set hostname.
   hostname:

--- a/roles/testnode/tasks/setup-redhat.yml
+++ b/roles/testnode/tasks/setup-redhat.yml
@@ -1,6 +1,7 @@
 ---
 - name: Set the hostname
   include: redhat/set_hostname.yml
+  when: lab_domain != ""
   tags:
     - hostname
 


### PR DESCRIPTION
I have not tested this yet, but wanted to put it up early for discussion.  I think this should allow the testnodes, ansible-managed and common roles to be used without a secrets repo.  I tried to address all the vars listed in @dachary's blog post here: http://dachary.org/?p=3752

See: http://tracker.ceph.com/issues/12256