### PR TITLE
Manage the firewall on RHEL/CentOS 6/7

### DIFF
--- a/roles/cobbler/tasks/redhat/rhel_6.yml
+++ b/roles/cobbler/tasks/redhat/rhel_6.yml
@@ -1,0 +1,5 @@
+---
+- name: Stop iptables
+  service:
+    name: iptables
+    state: stopped

--- a/roles/cobbler/tasks/redhat/rhel_7.yml
+++ b/roles/cobbler/tasks/redhat/rhel_7.yml
@@ -1,0 +1,11 @@
+---
+- name: Enable http and https using firewalld
+  firewalld:
+    service: "{{ item }}"
+    state: enabled
+    permanent: yes
+  with_items:
+    - http
+    - https
+  tags:
+    - firewall

--- a/roles/cobbler/tasks/setup-redhat.yml
+++ b/roles/cobbler/tasks/setup-redhat.yml
@@ -1,0 +1,8 @@
+---
+- name: Include rhel 7.x specific tasks.
+  include: redhat/rhel_7.yml
+  when: ansible_distribution_major_version == "7"
+
+- name: Include rhel 6.x specific tasks.
+  include: redhat/rhel_6.yml
+  when: ansible_distribution_major_version == "6"

--- a/roles/cobbler/tasks/yum_systems.yml
+++ b/roles/cobbler/tasks/yum_systems.yml
@@ -11,3 +11,7 @@
     state: latest
   with_items: cobbler_extra_packages
   when: cobbler_extra_packages|length > 0
+
+# configure red hat specific things
+- include: setup-redhat.yml
+  when: ansible_distribution in ('RedHat', 'CentOS')


### PR DESCRIPTION
On EL7, poke holes for http and https. On EL6, just stop iptables.

Signed-off-by: Zack Cerza <zack@redhat.com>