### PR TITLE
common: |mandatory is not needed for secrets_path, it is always defined.

### DIFF
--- a/roles/common/tasks/rhel-entitlements.yml
+++ b/roles/common/tasks/rhel-entitlements.yml
@@ -3,7 +3,7 @@
 
 - name: Set entitlements_path
   set_fact:
-    entitlements_path: "{{ secrets_path | mandatory }}/entitlements.yml"
+    entitlements_path: "{{ secrets_path }}/entitlements.yml"
 
 - name: Include Red Hat encrypted variables.
   include_vars: "{{ item }}"


### PR DESCRIPTION
secrets_path comes from the secrets role and it is always defined.  It
will default to /etc/ansible/secrets if the env var ANSIBLE_SECRETS_PATH
is not defined. You can also define secrets_path by passing a variable
to the playbook being used.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>