### PR TITLE
Fix warning in 'when' clause in 'Create the teuthology user.'

### DIFF
--- a/roles/testnode/tasks/user.yml
+++ b/roles/testnode/tasks/user.yml
@@ -21,7 +21,7 @@
     state: present
   # If we're currently running as teuthology_user, we won't be able to modify
   # the account
-  when: "{{ teuthology_user != ansible_ssh_user }}"
+  when: teuthology_user != ansible_ssh_user
 
 - name: Add a user for xfstests to test user quotas.
   user:


### PR DESCRIPTION
Warnings appeared each run:

[WARNING]: It is unnecessary to use '{{' in conditionals, leave variables in
loop expressions bare

Apparently 'when' clauses are already Jinja2 expressions, and so don't
need the normal variable quoting.

Signed-off-by: Dan Mick <dan.mick@redhat.com>