### PR TITLE
Install the Core and Base groups on rpm systems

### DIFF
--- a/roles/cobbler/templates/kickstarts/cephlab_rhel.ks
+++ b/roles/cobbler/templates/kickstarts/cephlab_rhel.ks
@@ -45,6 +45,8 @@ $SNIPPET('pre_anamon')
 %end
 
 %packages
+@core
+@base
 $SNIPPET('cephlab_packages_rhel')
 $SNIPPET('func_install_if_enabled')
 %end

--- a/roles/testnode/vars/centos_6.yml
+++ b/roles/testnode/vars/centos_6.yml
@@ -40,6 +40,8 @@ yum_repos:
     priority: 2
 
 packages:
+  - '@core'
+  - '@base'
   - yum-plugin-priorities
   - redhat-lsb
   - sysstat

--- a/roles/testnode/vars/centos_7.yml
+++ b/roles/testnode/vars/centos_7.yml
@@ -16,6 +16,8 @@ yum_repos:
     priority: 2
 
 packages:
+  - '@core'
+  - '@base'
   - yum-plugin-priorities
   - redhat-lsb
   - sysstat

--- a/roles/testnode/vars/fedora_20.yml
+++ b/roles/testnode/vars/fedora_20.yml
@@ -17,6 +17,8 @@ packages_to_remove:
   - ceph-libs
 
 packages:
+  - '@core'
+  - '@base'
   - yum-plugin-priorities
   - redhat-lsb
   - sysstat

--- a/roles/testnode/vars/redhat_6.yml
+++ b/roles/testnode/vars/redhat_6.yml
@@ -34,6 +34,8 @@ common_yum_repos:
     priority: 2
 
 packages:
+  - '@core'
+  - '@base'
   - yum-plugin-priorities
   - redhat-lsb
   - sysstat

--- a/roles/testnode/vars/redhat_7.yml
+++ b/roles/testnode/vars/redhat_7.yml
@@ -16,6 +16,8 @@ common_yum_repos:
     priority: 2
 
 packages:
+  - '@core'
+  - '@base'
   - yum-plugin-priorities
   - redhat-lsb
   - sysstat


### PR DESCRIPTION
We need to make sure basic things like bzip2 are installed.

Signed-off-by: Zack Cerza <zack@redhat.com>