### PR TITLE
testnode: remove scsci-target-utils and iscsi-initiator-utils

### DIFF
--- a/roles/testnode/vars/centos_6.yml
+++ b/roles/testnode/vars/centos_6.yml
@@ -125,13 +125,6 @@ packages:
   # for java bindings, hadoop, etc.
   - java-1.7.0-openjdk-devel
   - junit4
-  ###
-  # tgt & open-iscsi
-  # installing these 2 packages makes this playbook
-  # not idempotent on rhel 6.x and centos 6.x
-  # see: http://tracker.ceph.com/issues/11216
-  - scsi-target-utils
-  - iscsi-initiator-utils
   # for disk/etc monitoring
   - smartmontools
   # for nfs

--- a/roles/testnode/vars/centos_7.yml
+++ b/roles/testnode/vars/centos_7.yml
@@ -89,13 +89,6 @@ packages:
   # for java bindings, hadoop, etc.
   - java-1.6.0-openjdk-devel
   - junit4
-  ###
-  # tgt & open-iscsi
-  # installing these 2 packages makes this playbook
-  # not idempotent on rhel 6.x
-  # see: http://tracker.ceph.com/issues/11216
-  - scsi-target-utils
-  - iscsi-initiator-utils
   # for disk/etc monitoring
   - smartmontools
   # for nfs

--- a/roles/testnode/vars/fedora_20.yml
+++ b/roles/testnode/vars/fedora_20.yml
@@ -93,13 +93,6 @@ packages:
   # for java bindings, hadoop, etc.
   - java-1.7.0-openjdk-devel
   - junit4
-  ###
-  # tgt & open-iscsi
-  # installing these 2 packages makes this playbook
-  # not idempotent on rhel 6.x and centos 6.x
-  # see: http://tracker.ceph.com/issues/11216
-  - scsi-target-utils
-  - iscsi-initiator-utils
   # for disk/etc monitoring
   - smartmontools
   # for nfs

--- a/roles/testnode/vars/redhat_6.yml
+++ b/roles/testnode/vars/redhat_6.yml
@@ -114,13 +114,6 @@ packages:
   # for java bindings, hadoop, etc.
   - java-1.6.0-openjdk-devel
   - junit4
-  ###
-  # tgt & open-iscsi
-  # installing these 2 packages makes this playbook
-  # not idempotent on rhel 6.x and centos 6.x
-  # see: http://tracker.ceph.com/issues/11216
-  - scsi-target-utils
-  - iscsi-initiator-utils
   # for disk/etc monitoring
   - smartmontools
   # for nfs

--- a/roles/testnode/vars/redhat_7.yml
+++ b/roles/testnode/vars/redhat_7.yml
@@ -74,8 +74,6 @@ packages:
   - perl-XML-Twig
   - java-1.6.0-openjdk-devel
   - junit4
-  - scsi-target-utils
-  - iscsi-initiator-utils
   - smartmontools
   - nfs-utils
   # for xfstests


### PR DESCRIPTION
We don't want to install these anymore as they're causing issues with
the teuthology install task because of their dependency on librados.

See: http://tracker.ceph.com/issues/12371

Signed-off-by: Andrew Schoen <aschoen@redhat.com>