### PR TITLE
Retry authorized_keys updates

### DIFF
--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -43,5 +43,10 @@
     user: "{{ item.name }}"
     key: "{{ item.key }}"
   with_items: managed_users|list + managed_admin_users|list
+  # Register and retry to work around transient githubusercontent.com issues
+  register: ssh_key_update
+  until: ssh_key_update.state == 'present'
+  retries: 3
+  delay: 5
   tags:
     - pubkeys


### PR DESCRIPTION
http://tracker.ceph.com/issues/12380
We're seeing transient issues connecting to githubusercontent.com. This
commit will cause ansible to retry three times with a five-second delay
between tries. Hopefully that's good enough.

Signed-off-by: Zack Cerza <zack@redhat.com>