### PR TITLE
Puddle updates

### DIFF
--- a/roles/puddle/tasks/distill/configure.yml
+++ b/roles/puddle/tasks/distill/configure.yml
@@ -31,8 +31,7 @@
     mode: 0755
     state: directory
   with_items:
-    - 1.3-candidate
-    # 1.3-pending
+    - 1.3-compose
 
 - name: add ceph wrapper script for run-distill
   template:

--- a/roles/puddle/templates/ceph-1.2-rhel-6-async.conf
+++ b/roles/puddle/templates/ceph-1.2-rhel-6-async.conf
@@ -4,7 +4,7 @@
 
 [puddle]
 type = errata
-errata_release = CEPH-ASYNC
+errata_release = CEPH-1.2,CEPH-ASYNC
 errata_whitelist = no
 product_name = RHCeph
 version = 1.2-RHEL-6
@@ -22,16 +22,16 @@ cdndir = no
 
 [RH6-CEPH-CALAMARI-1.2]
 variant = RH6-CEPH-CALAMARI-1.2
-external = {{ puddle.rhel_6_server_repo_url }},{{ puddle.rhel_6_ceph_calamari_1_2_repo_url }}
+external = {{ puddle.rhel_6_server_repo_url }}
 
 [RH6-CEPH-INSTALLER-1.2]
 variant = RH6-CEPH-INSTALLER-1.2
-external = {{ puddle.rhel_6_server_repo_url }},{{ puddle.rhel_6_ceph_installer_1_2_repo_url }}
+external = {{ puddle.rhel_6_server_repo_url }}
 
 [RH6-CEPH-MON-1.2]
 variant = RH6-CEPH-MON-1.2
-external = {{ puddle.rhel_6_server_repo_url }},{{ puddle.rhel_6_ceph_mon_1_2_repo_url }}
+external = {{ puddle.rhel_6_server_repo_url }}
 
 [RH6-CEPH-OSD-1.2]
 variant = RH6-CEPH-OSD-1.2
-external = {{ puddle.rhel_6_server_repo_url }},{{ puddle.rhel_6_ceph_osd_1_2_repo_url }}
+external = {{ puddle.rhel_6_server_repo_url }}

--- a/roles/puddle/templates/ceph-1.2-rhel-7-async.conf
+++ b/roles/puddle/templates/ceph-1.2-rhel-7-async.conf
@@ -4,8 +4,7 @@
 
 [puddle]
 type = errata
-errata_release = CEPH-ASYNC
-errata_whitelist = no
+errata_release = CEPH-1.2,CEPH-ASYNC
 product_name = RHCeph
 version = 1.2-RHEL-7
 rootdir = /var/www/{{ ansible_hostname }}/htdocs/puddles
@@ -22,16 +21,20 @@ cdndir = no
 
 [Server-RH7-CEPH-CALAMARI-1.2]
 variant = Server-RH7-CEPH-CALAMARI-1.2
-external = {{ puddle.rhel_7_server_repo_url }},{{ puddle.rhel_7_ceph_calamari_1_2_repo_url }}
+external = {{ puddle.rhel_7_server_repo_url }}
+keys = fd431d51,f21541eb
 
 [Server-RH7-CEPH-INSTALLER-1.2]
 variant = Server-RH7-CEPH-INSTALLER-1.2
-external = {{ puddle.rhel_7_server_repo_url }},{{ puddle.rhel_7_ceph_installer_1_2_repo_url }}
+external = {{ puddle.rhel_7_server_repo_url }}
+keys = fd431d51,f21541eb
 
 [Server-RH7-CEPH-MON-1.2]
 variant = Server-RH7-CEPH-MON-1.2
-external = {{ puddle.rhel_7_server_repo_url }},{{ puddle.rhel_7_ceph_mon_1_2_repo_url }}
+external = {{ puddle.rhel_7_server_repo_url }}
+keys = fd431d51,f21541eb
 
 [Server-RH7-CEPH-OSD-1.2]
 variant = Server-RH7-CEPH-OSD-1.2
-external = {{ puddle.rhel_7_server_repo_url }},{{ puddle.rhel_7_ceph_osd_1_2_repo_url }}
+external = {{ puddle.rhel_7_server_repo_url }}
+keys = fd431d51,f21541eb

--- a/roles/puddle/templates/ceph-1.3-rhel-7-async.conf
+++ b/roles/puddle/templates/ceph-1.3-rhel-7-async.conf
@@ -4,9 +4,7 @@
 
 [puddle]
 type = errata
-errata_release = no
-errata_whitelist = 20942,21015
-errata_blacklist = no
+errata_release = CEPH-1.3.0,CEPH-ASYNC
 product_name = RHCeph
 version = 1.3-RHEL-7
 rootdir = /var/www/{{ ansible_hostname }}/htdocs/puddles
@@ -23,35 +21,35 @@ cdndir = no
 
 [Server-RH7-CEPH-CALAMARI-1.3]
 variant = Server-RH7-CEPH-CALAMARI-1.3
-external = {{ puddle.rhel_7_server_repo_url }},{{ puddle.rhel_7_ceph_calamari_1_3_repo_url }}
+external = {{ puddle.rhel_7_server_repo_url }}
 keys = fd431d51,f21541eb
 
 [Server-RH7-CEPH-MON-1.3]
 variant = Server-RH7-CEPH-MON-1.3
-external = {{ puddle.rhel_7_server_repo_url }},{{ puddle.rhel_7_ceph_mon_1_3_repo_url }}
+external = {{ puddle.rhel_7_server_repo_url }}
 keys = fd431d51,f21541eb
 
 [Server-RH7-CEPH-OSD-1.3]
 variant = Server-RH7-CEPH-OSD-1.3
-external = {{ puddle.rhel_7_server_repo_url }},{{ puddle.rhel_7_ceph_osd_1_3_repo_url }}
+external = {{ puddle.rhel_7_server_repo_url }}
 keys = fd431d51,f21541eb
 
 [Server-RH7-CEPH-TOOLS-1.3]
 variant = Server-RH7-CEPH-TOOLS-1.3
-external = {{ puddle.rhel_7_server_repo_url }},{{ puddle.rhel_7_ceph_tools_1_3_server_repo_url }}
+external = {{ puddle.rhel_7_server_repo_url }}
 keys = fd431d51,f21541eb
 
 [Client-RH7-CEPH-TOOLS-1.3]
 variant = Client-RH7-CEPH-TOOLS-1.3
-external = {{ puddle.rhel_7_client_repo_url }},{{ puddle.rhel_7_ceph_tools_1_3_client_repo_url }}
+external = {{ puddle.rhel_7_client_repo_url }}
 keys = fd431d51,f21541eb
 
 [ComputeNode-RH7-CEPH-TOOLS-1.3]
 variant = ComputeNode-RH7-CEPH-TOOLS-1.3
-external = {{ puddle.rhel_7_computenode_repo_url }},{{ puddle.rhel_7_ceph_tools_1_3_computenode_repo_url }}
+external = {{ puddle.rhel_7_computenode_repo_url }}
 keys = fd431d51,f21541eb
 
 [Workstation-RH7-CEPH-TOOLS-1.3]
 variant = Workstation-RH7-CEPH-TOOLS-1.3
-external = {{ puddle.rhel_7_workstation_repo_url }},{{ puddle.rhel_7_ceph_tools_1_3_workstation_repo_url }}
+external = {{ puddle.rhel_7_workstation_repo_url }}
 keys = fd431d51,f21541eb


### PR DESCRIPTION
The first commit fixes our ceph-1.2-async configs to be more complete/user-friendly for QE, and the second commit cleans up the distill directory name that we finally ended up using.