### PR TITLE
Adds cgroups packages and net_cls kernel module to ubuntu systems

### DIFF
--- a/roles/testnode/templates/modules
+++ b/roles/testnode/templates/modules
@@ -8,3 +8,4 @@ loop
 lp
 rtc
 scsi_transport_iscsi
+cls_cgroup

--- a/roles/testnode/vars/ubuntu.yml
+++ b/roles/testnode/vars/ubuntu.yml
@@ -103,6 +103,9 @@ common_packages:
   # nfs
   - nfs-common
   - nfs-kernel-server
+  # cgroups
+  - cgroup-lite
+  - cgroup-bin
 
 packages_to_upgrade:
   - apt


### PR DESCRIPTION
This is part of the work for http://tracker.ceph.com/issues/12424 which enables the ceph task in ceph/ceph-qa-suite to create and place osd/mon/mds in control groups.

For ubuntu, kernels for precise and up have `CONFIG_CGROUP_*` enabled, so the only thing that it's required is to install `cgroup-lite` which is a service that mounts the cgroups virtual FS. The `cgroup-bin` package will also be used from the ceph task to manipulate (create/modify/delete) control groups.

The `net_cls` subsystem is included as a module (named `cls_cgroup`) and is not enabled loaded by `cgroup-lite`, i.e. it has to be done explicitly. So we add it to `/etc/modules`