### PR TITLE
testnode/tasks/ntp: make sure ntpd is started

### DIFF
--- a/roles/testnode/tasks/ntp.yml
+++ b/roles/testnode/tasks/ntp.yml
@@ -24,3 +24,9 @@
     mode: 0644
   notify:
     - restart ntp
+
+- name: Make sure ntpd is running.
+  service:
+    name: "{{ntp_service_name}}"
+    enabled: yes
+    state: started


### PR DESCRIPTION
Tested with:

$ ansible-playbook -i ../ceph-octo-secrets/ansible/inventory/octo
--limit 'magna064*' --tag ntp-client testnodes.yml

Fixes: #12603
Signed-off-by: Dan Mick <dan.mick@redhat.com>