### PR TITLE
Enable EPEL when installing packages on testnodes

### DIFF
--- a/roles/testnode/tasks/yum/packages.yml
+++ b/roles/testnode/tasks/yum/packages.yml
@@ -36,6 +36,7 @@
   yum:
     name: "{{ item }}"
     state: present 
+    enablerepo: epel
   with_items: packages
   when: packages|length > 0
 


### PR DESCRIPTION
Signed-off-by: Zack Cerza <zack@redhat.com>