### PR TITLE
testnode: put epel packages in their own list for rhel 6 and 7

### DIFF
--- a/roles/testnode/README.rst
+++ b/roles/testnode/README.rst
@@ -103,6 +103,11 @@ A list of packages to install that are common to a distro or distro version. The
 
     common_packages: []
 
+A list of packages that must be installed from epel. These packages are installed with the epel repo explicitly enabled for any
+yum-based distro that provides the list in their var file in ``/vars``::
+
+    epel_packages: []
+
 **NOTE:** A good example of how ``packages`` and ``common_packages`` work together is with Ubuntu. The var file ``roles/testnode/vars/ubuntu.yml`` defines
 a number of packages in ``common_packages`` that need to be installed across all versions of ubuntu, while the version-specific files
 (for example, ``roles/testnode/vars/ubuntu_14.yml``) define packages in ``packages`` that either have varying names across versions or are only needed

--- a/roles/testnode/defaults/main.yml
+++ b/roles/testnode/defaults/main.yml
@@ -20,6 +20,9 @@ apt_repos: []
 # is packages + common_packages
 packages: []
 
+# a list of packages that have to be installed from epel
+epel_packages: []
+
 # packages common to a major version, distro or package type. This means that they
 # have the same name and are intended to be installed for all other versions in that major
 # version, distro or package type

--- a/roles/testnode/tasks/pip.yml
+++ b/roles/testnode/tasks/pip.yml
@@ -3,6 +3,7 @@
   yum:
     name: python-pip
     state: present
+    enablerepo: epel
   when: ansible_pkg_mgr  == "yum"
 
 - name: Install python-pip on apt based systems.

--- a/roles/testnode/tasks/yum/packages.yml
+++ b/roles/testnode/tasks/yum/packages.yml
@@ -39,6 +39,14 @@
   with_items: packages
   when: packages|length > 0
 
+- name: Install epel packages
+  yum:
+    name: "{{ item }}"
+    state: present
+    enablerepo: epel
+  with_items: epel_packages
+  when: epel_packages|length > 0
+
 - name: Remove packages
   yum:
     name: "{{ item }}"

--- a/roles/testnode/vars/redhat_6.yml
+++ b/roles/testnode/vars/redhat_6.yml
@@ -45,22 +45,13 @@ packages:
   # for running ceph
   - libedit
   - openssl098e
-  - gperftools-devel
   - boost-thread
   - xfsprogs
   - gdisk
   - parted
   - libgcrypt
-  - cryptopp-devel
-  - cryptopp
   - fuse
   - fuse-libs
-  ###
-  # for ceph-deploy
-  - python-virtualenv
-  ###
-  # for setting BIOS settings
-  - smbios-utils
   ###
   - openssl
   - libuuid
@@ -71,9 +62,6 @@ packages:
   - python-nose
   - mpich2
   - ant
-  - dbench
-  - bonnie++
-  - fuse-sshfs
   - fsstress
   - iozone
   ###
@@ -107,8 +95,6 @@ packages:
   - mod_fastcgi-2.4.7-1.ceph.el6
   ###
   - libevent-devel
-  # for json_xs to investigate JSON by hand
-  - perl-JSON-XS
   # for pretty-printing xml
   - perl-XML-Twig
   # for java bindings, hadoop, etc.
@@ -118,5 +104,22 @@ packages:
   - smartmontools
   # for nfs
   - nfs-utils
+
+
+epel_packages:
+  # for running ceph
+  - gperftools-devel
+  - cryptopp-devel
+  - cryptopp
+  # used by workunits
+  - dbench
+  - fuse-sshfs
+  - bonnie++
+  # for json_xs to investigate JSON by hand
+  - perl-JSON-XS
+  # for ceph-deploy
+  - python-virtualenv
+  # for setting BIOS settings
+  - smbios-utils
 
 nfs_service: nfs

--- a/roles/testnode/vars/redhat_7.yml
+++ b/roles/testnode/vars/redhat_7.yml
@@ -26,15 +26,12 @@ packages:
   - python-configobj
   - libedit
   - openssl098e
-  - gperftools-devel
   - boost-thread
   - xfsprogs
   - xfsprogs-devel
   - gdisk
   - parted
   - libgcrypt
-  - cryptopp-devel
-  - cryptopp
   - fuse
   - fuse-libs
   - openssl
@@ -45,8 +42,6 @@ packages:
   - python-nose
   - mpich
   - ant
-  - dbench
-  - fuse-sshfs
   - lsof
   - iozone
   - libtool
@@ -70,7 +65,6 @@ packages:
   - mod_ssl
   - mod_fastcgi-2.4.7-1.ceph.el7
   - libevent-devel
-  - perl-JSON-XS
   - perl-XML-Twig
   - java-1.6.0-openjdk-devel
   - junit4
@@ -81,5 +75,13 @@ packages:
   # for s3 tests
   - python-devel
   - python-virtualenv
+
+epel_packages:
+  - gperftools-devel
+  - cryptopp-devel
+  - cryptopp
+  - dbench
+  - fuse-sshfs
+  - perl-JSON-XS
 
 nfs_service: nfs-server


### PR DESCRIPTION
This separates packages we install from epel into their own list for rhel 6 and 7.
We do this so that we can install them with the epel repo explicitly enabled.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>