### PR TITLE
testnode: fix var file loading order

### DIFF
--- a/roles/testnode/tasks/vars.yml
+++ b/roles/testnode/tasks/vars.yml
@@ -2,16 +2,16 @@
 - name: Include package type specific vars.
   include_vars: "{{ ansible_pkg_mgr }}_systems.yml"
 
-- name: Including major version specific variables.
-  include_vars: "{{ item }}"
-  with_first_found:
-    - "{{ ansible_distribution | lower }}_{{ ansible_distribution_major_version }}.yml"
-    - empty.yml
-
 - name: Including distro specific variables.
   include_vars: "{{ item }}"
   with_first_found:
     - "{{ ansible_distribution | lower }}.yml"
+    - empty.yml
+
+- name: Including major version specific variables.
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_distribution | lower }}_{{ ansible_distribution_major_version }}.yml"
     - empty.yml
 
 - name: Including version specific variables.


### PR DESCRIPTION
We want to load distro specific variables before we load major version
specific variables. Loading of vars should happen in this order: package
manager, distro, major version, version.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>