### PR TITLE
Wip rhel entitlements

### DIFF
--- a/roles/common/tasks/rhel-entitlements.yml
+++ b/roles/common/tasks/rhel-entitlements.yml
@@ -52,7 +52,7 @@
     repo_list: "{{ repo_list_cmd.stdout.split('\n') }}"
   when: repo_list_cmd is defined and not repo_list_cmd|skipped
 
-- name: Set replace_repos if rhsm_repos changed
+- name: Set replace_repos if rhsm_repos differs from repo_list
   set_fact:
     replace_repos: "{{ repo_list|sort != rhsm_repos|sort }}"
   when: repo_list is defined
@@ -62,21 +62,16 @@
     replace_repos: True
   when: entitled|changed and entitled.rc == 0
 
-- name: Set replace_repos if entitlement is skipped
-  set_fact:
-    replace_repos: False
-  when: entitled|skipped
-
 - name: Disable all rhsm repos
   command: subscription-manager repos --disable '*'
-  when: replace_repos == True
+  when: replace_repos
   # This produces an absurd amount of useless output
   no_log: True
 
 - name: Enable necessary rhsm repos
   command: subscription-manager repos --enable {{ item }}
   with_items: rhsm_repos
-  when: replace_repos == True and rhsm_repos|length > 0
+  when: replace_repos
 
 - name: Remove old apt-mirror repository definition.
   file:


### PR DESCRIPTION
Bug was found by re-imaging RHEL7.1 system while customer portal was down, and thus, subscription-manager failed.
Ran testnodes playbook again after outage resolved and rhsm_repos were not disabled.
This resulted in yum-plugin-priorities installation failure due to missing item=rhel-7-server-optional-rpms repo
Remander of playbook failed at that point