### PR TITLE
use static versions of release.asc and autobuild.asc

### DIFF
--- a/roles/testnode/tasks/apt/repos.yml
+++ b/roles/testnode/tasks/apt/repos.yml
@@ -22,8 +22,8 @@
     url: "{{ item }}"
     state: present
   with_items:
-    - "http://{{ git_mirror_host }}/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc;hb=HEAD"
-    - "http://{{ git_mirror_host }}/?p=ceph.git;a=blob_plain;f=keys/release.asc"
+    - "http://{{ git_mirror_host }}/autobuild.asc"
+    - "http://{{ git_mirror_host }}/release.asc"
 
 # required for apt_repository
 - name: Install python-apt

--- a/roles/testnode/tasks/yum/gpg_keys.yml
+++ b/roles/testnode/tasks/yum/gpg_keys.yml
@@ -13,6 +13,6 @@
     key: "{{ item }}"
     validate_certs: no
   with_items:
-    - 'https://{{ git_mirror_host }}/?p=ceph.git;a=blob_plain;f=keys/release.asc'
-    - 'https://{{ git_mirror_host }}/?p=ceph.git;a=blob_plain;f=keys/autobuild.asc'
+    - 'https://{{ git_mirror_host }}/release.asc'
+    - 'https://{{ git_mirror_host }}/autobuild.asc'
   register: gpg_keys


### PR DESCRIPTION
Pulling them out of gitweb hits the server too hard.

Signed-off-by: Sage Weil <sage@redhat.com>