### PR TITLE
testnode: add epel_packages for centos 6 and 7

### DIFF
--- a/roles/testnode/vars/centos_6.yml
+++ b/roles/testnode/vars/centos_6.yml
@@ -51,22 +51,15 @@ packages:
   # for running ceph
   - libedit
   - openssl098e
-  - gperftools-devel
   - boost-thread
   - xfsprogs
   - gdisk
   - parted
   - libgcrypt
-  - cryptopp-devel
-  - cryptopp
   - fuse
   - fuse-libs
   ###
-  # for ceph-deploy
-  - python-virtualenv
   ###
-  # for setting BIOS settings
-  - smbios-utils
   ###
   - openssl
   - libuuid
@@ -81,9 +74,6 @@ packages:
   - mpich2
   - mpich2-devel
   - ant
-  - dbench
-  - bonnie++
-  - fuse-sshfs
   - fsstress
   - iozone
   ###
@@ -118,8 +108,6 @@ packages:
   ###
   - libevent-devel
   - python-devel
-  # for json_xs to investigate JSON by hand
-  - perl-JSON
   # for pretty-printing xml
   - perl-XML-Twig
   # for java bindings, hadoop, etc.
@@ -129,3 +117,20 @@ packages:
   - smartmontools
   # for nfs
   - nfs-utils
+
+epel_packages:
+  # for running ceph
+  - gperftools-devel
+  - cryptopp-devel
+  - cryptopp
+  # used by workunits
+  - dbench
+  # used by workunits
+  - fuse-sshfs
+  - bonnie++
+  # for json_xs to investigate JSON by hand
+  - perl-JSON
+  # for ceph-deploy
+  - python-virtualenv
+  # for setting BIOS settings
+  - smbios-utils

--- a/roles/testnode/vars/centos_7.yml
+++ b/roles/testnode/vars/centos_7.yml
@@ -27,14 +27,11 @@ packages:
   # for running ceph
   - libedit
   - openssl098e
-  - gperftools-devel
   - boost-thread
   - xfsprogs
   - gdisk
   - parted
   - libgcrypt
-  - cryptopp-devel
-  - cryptopp
   - fuse
   - fuse-libs
   ###
@@ -50,10 +47,7 @@ packages:
   - python-nose
   - mpich
   - ant
-  - fuse-sshfs
   - iozone
-  - dbench
-  - bonnie++
   ###
   # used by the xfstests tasks
   - libtool
@@ -85,8 +79,6 @@ packages:
   - mod_fastcgi-2.4.7-1.ceph.el7.centos
   ###
   - libevent-devel
-  # for json_xs to investigate JSON by hand
-  - perl-JSON-XS
   # for pretty-printing xml
   - perl-XML-Twig
   # for java bindings, hadoop, etc.
@@ -96,3 +88,16 @@ packages:
   - smartmontools
   # for nfs
   - nfs-utils
+
+epel_packages:
+  # for running ceph
+  - gperftools-devel
+  - cryptopp-devel
+  - cryptopp
+  # used by workunits
+  - dbench
+  # used by workunits
+  - fuse-sshfs
+  - bonnie++
+  # for json_xs to investigate JSON by hand
+  - perl-JSON-XS


### PR DESCRIPTION
This allows the testnode role to provision centos nodes in a lab where epel is disabled.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>