### PR TITLE
python-rados does not exist in firefly

### DIFF
--- a/roles/testnode/vars/apt_systems.yml
+++ b/roles/testnode/vars/apt_systems.yml
@@ -9,6 +9,7 @@ ceph_packages:
   - libcephfs1
   - radosgw
   - python-ceph
+  - python-rados
   - librbd1
   - librados2
 

--- a/roles/testnode/vars/yum_systems.yml
+++ b/roles/testnode/vars/yum_systems.yml
@@ -11,5 +11,6 @@ ceph_packages:
   - libcephfs1
   - ceph-radosgw
   - python-ceph
+  - python-rados
   - librbd1
   - librados2


### PR DESCRIPTION
It must be removed if present otherwise a firefly installation will
fail with:

Package python-ceph is obsoleted by python-rados,
  but obsoleting package does not provide for requirements

or similar errors.

Signed-off-by: Loic Dachary <loic@dachary.org>