### PR TITLE
puddle: add "dev-puddle" virtualhost

### DIFF
--- a/roles/puddle/tasks/nginx.yml
+++ b/roles/puddle/tasks/nginx.yml
@@ -4,12 +4,15 @@
     name: nginx
     state: present
 
-- name: create nginx docroot
+- name: create nginx docroots
   file:
-    path: "/var/www/{{ ansible_hostname }}/htdocs"
+    path: "/var/www/{{ item }}/htdocs"
     owner: "{{ puddle_user }}"
     mode: 0755
     state: directory
+  with_items:
+    - "dev-{{ ansible_hostname }}"
+    - "{{ ansible_hostname }}"
 
 - name: configure nginx
   template:

--- a/roles/puddle/templates/nginx.conf
+++ b/roles/puddle/templates/nginx.conf
@@ -70,8 +70,5 @@ http {
             # More from distill:
             text/plain manifest MD5SUM SHA1SUM SHA256SUM;
         }
-
-        #access_log  /var/log/nginx/host.access.log  main;
-
     }
 }

--- a/roles/puddle/templates/nginx.conf
+++ b/roles/puddle/templates/nginx.conf
@@ -71,4 +71,28 @@ http {
             text/plain manifest MD5SUM SHA1SUM SHA256SUM;
         }
     }
+
+    server {
+        listen       80;
+        listen       [::]:80;
+        server_name  dev-{{ ansible_fqdn }};
+        root         /var/www/dev-{{ ansible_hostname }}/htdocs;
+
+        location / {
+            autoindex on;
+            autoindex_exact_size off;
+        }
+
+        # Some of distill's files have no suffix and are simply plaintext.
+        location ~ (COMPOSE_ID|STATUS)$ {
+            default_type text/plain;
+        }
+
+        types {
+            # Plaintext files from puddle and distill:
+            text/plain conf log repo txt;
+            # More from distill:
+            text/plain manifest MD5SUM SHA1SUM SHA256SUM;
+        }
+    }
 }


### PR DESCRIPTION
In Red Hat's (internal) DNS, dev-puddle is a CNAME to puddle. This PR sets up Nginx's configuration file to handle this new name and route the requests to a dedicated "dev-puddle" htdocs directory.

Update the nginx task to create multiple docroots, and add "dev-puddle" to be the second one.