### PR TITLE
puddle: add ceph-1.3.z config

### DIFF
--- a/roles/puddle/defaults/main.yml
+++ b/roles/puddle/defaults/main.yml
@@ -10,6 +10,7 @@ puddle:
   topurl: ''
   rhel_7_server_repo_url: ''
   rhel_7_common_server_repo_url: ''
+  rhel_7_scl_repo_url: ''
   rhel_7_ceph_calamari_1_2_repo_url: ''
   rhel_7_ceph_installer_1_2_repo_url: ''
   rhel_7_ceph_mon_1_2_repo_url: ''

--- a/roles/puddle/tasks/configure.yml
+++ b/roles/puddle/tasks/configure.yml
@@ -23,6 +23,7 @@
     - rh-common-rhel-7
     - ceph-1.3-rhel-7
     - ceph-1.3-rhel-7-async
+    - ceph-1.3.z-rhel-7
 
 - name: add rcm-kerberos config file
   template:

--- a/roles/puddle/templates/ceph-1.3-rhel-7-async.conf
+++ b/roles/puddle/templates/ceph-1.3-rhel-7-async.conf
@@ -24,6 +24,11 @@ variant = Server-RH7-CEPH-CALAMARI-1.3
 external = {{ puddle.rhel_7_server_repo_url }}
 keys = fd431d51,f21541eb
 
+[Server-RH7-CEPH-INSTALLER-1.3]
+variant = Server-RH7-CEPH-INSTALLER-1.3
+external = {{ puddle.rhel_7_server_repo_url }}
+keys = fd431d51,f21541eb
+
 [Server-RH7-CEPH-MON-1.3]
 variant = Server-RH7-CEPH-MON-1.3
 external = {{ puddle.rhel_7_server_repo_url }}

--- a/roles/puddle/templates/ceph-1.3.z-rhel-7.conf
+++ b/roles/puddle/templates/ceph-1.3.z-rhel-7.conf
@@ -1,0 +1,60 @@
+#
+# {{ ansible_managed }}
+#
+
+[puddle]
+type = errata
+errata_release = CEPH-1.3.0,CEPH-1.3.z,CEPH-ASYNC
+product_name = RHCeph
+version = 1.3-RHEL-7
+rootdir = /var/www/dev-{{ ansible_hostname }}/htdocs/puddles
+emails = {{ puddle.emails }}
+signed = no
+rhndir = no
+mashroot = /tmp/mash/ceph
+brewroot = {{ puddle.brewroot_url }}
+topurl = {{ puddle.topurl }}/puddles
+announcer = {{ puddle.announcer }}
+publish = no
+cdndir = no
+
+
+[Server-RH7-CEPH-CALAMARI-1.3]
+variant = Server-RH7-CEPH-CALAMARI-1.3
+external = {{ puddle.rhel_7_server_repo_url }}
+keys = fd431d51,f21541eb
+
+[Server-RH7-CEPH-INSTALLER-1.3]
+variant = Server-RH7-CEPH-INSTALLER-1.3
+external = {{ puddle.rhel_7_server_repo_url }},{{ puddle.rhel_7_scl_repo_url }}
+keys = fd431d51,f21541eb
+
+[Server-RH7-CEPH-MON-1.3]
+variant = Server-RH7-CEPH-MON-1.3
+external = {{ puddle.rhel_7_server_repo_url }}
+keys = fd431d51,f21541eb
+
+[Server-RH7-CEPH-OSD-1.3]
+variant = Server-RH7-CEPH-OSD-1.3
+external = {{ puddle.rhel_7_server_repo_url }}
+keys = fd431d51,f21541eb
+
+[Server-RH7-CEPH-TOOLS-1.3]
+variant = Server-RH7-CEPH-TOOLS-1.3
+external = {{ puddle.rhel_7_server_repo_url }}
+keys = fd431d51,f21541eb
+
+[Client-RH7-CEPH-TOOLS-1.3]
+variant = Client-RH7-CEPH-TOOLS-1.3
+external = {{ puddle.rhel_7_client_repo_url }}
+keys = fd431d51,f21541eb
+
+[ComputeNode-RH7-CEPH-TOOLS-1.3]
+variant = ComputeNode-RH7-CEPH-TOOLS-1.3
+external = {{ puddle.rhel_7_computenode_repo_url }}
+keys = fd431d51,f21541eb
+
+[Workstation-RH7-CEPH-TOOLS-1.3]
+variant = Workstation-RH7-CEPH-TOOLS-1.3
+external = {{ puddle.rhel_7_workstation_repo_url }}
+keys = fd431d51,f21541eb


### PR DESCRIPTION
Add a new Puddle configuration file for ceph-1.3.z.
    
Output to the "dev-puddle" location for now.
    
In RHCeph 1.3.1, we're introducing Foreman, which has a dependency on the SCL product. Add this to the Puddle configuration for the "Installer" repo.
