### PR TITLE
users: fixes bug related to ssh key update retries

### DIFF
--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -45,7 +45,7 @@
   with_items: managed_users|list + managed_admin_users|list
   # Register and retry to work around transient githubusercontent.com issues
   register: ssh_key_update
-  until: ssh_key_update.state == 'present'
+  until: ssh_key_update|success
   retries: 3
   delay: 5
   tags:


### PR DESCRIPTION
When updating ssh keys for users we implemented a do until loop that
will account for transient issues when downloading the key from github.
The problem was that if the url fails then the var we were registering
was never created and the 'until' block errors out trying to check it.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>