### PR TITLE
puddle: accept hostkey when cloning distill's rcm-metadata.git

### DIFF
--- a/roles/puddle/tasks/distill/configure.yml
+++ b/roles/puddle/tasks/distill/configure.yml
@@ -14,6 +14,7 @@
     repo: "{{ distill.rcm_metadata_repo }}"
     update: no
     version: ceph
+    accept_hostkey: yes
 
 # distill requires this symlink in order to run.
 - name: symlink /mnt/brew


### PR DESCRIPTION
I recently switched rcm-metadata.git to use the git:// protocol instead of http://. When operating on a repository that uses a protocol other than HTTP, Ansible's git module unconditionally requires accept_hostkey to be set.

(See https://github.com/ansible/ansible-modules-core/issues/1931 for the upstream report.)