### PR TITLE
downstream-setup: separate cleanup and setup tasks into their own files

### DIFF
--- a/roles/downstream-setup/tasks/cleanup.yml
+++ b/roles/downstream-setup/tasks/cleanup.yml
@@ -1,0 +1,30 @@
+---
+- debug: msg="Performing cleanup related tasks..."
+
+- include: yum_repos.yml
+  when: remove_yum_repos|length > 0
+  vars:
+    repos: "{{ remove_yum_repos }}"
+  tags:
+    - yum-repos
+
+- include: remove_yum_repos.yml
+  when: yum_repos|length > 0
+  vars:
+    repos: "{{ yum_repos }}"
+  tags:
+    - delete-yum-repos
+
+- include: disable_yum_repos.yml
+  when: enable_yum_repos|length > 0
+  vars:
+    repos: "{{ enable_yum_repos }}"
+  tags:
+    - disable-yum-repos
+
+- include: enable_yum_repos.yml
+  when: disable_yum_repos|length > 0
+  vars:
+    repos: "{{ disable_yum_repos }}"
+  tags:
+    - enable-yum-repos

--- a/roles/downstream-setup/tasks/disable_yum_repos.yml
+++ b/roles/downstream-setup/tasks/disable_yum_repos.yml
@@ -6,5 +6,5 @@
     regexp: "enabled=1"
     backrefs: yes
     state: present
-  with_items: disable_yum_repos
+  with_items: repos
   ignore_errors: true

--- a/roles/downstream-setup/tasks/enable_yum_repos.yml
+++ b/roles/downstream-setup/tasks/enable_yum_repos.yml
@@ -6,5 +6,5 @@
     regexp: "enabled=0"
     backrefs: yes
     state: present
-  with_items: enable_yum_repos
+  with_items: repos
   ignore_errors: true

--- a/roles/downstream-setup/tasks/main.yml
+++ b/roles/downstream-setup/tasks/main.yml
@@ -1,36 +1,14 @@
 ---
-- include: yum_repos.yml
-  when: yum_repos|length > 0 and
-        not cleanup
-  tags:
-    - yum-repos
+# These are tasks which perform actions corresponding to the names of
+# the variables they use.  For example, `disable_yum_repos` would actually
+# disable all repos defined in that list.
+- include: setup.yml
+  when: not cleanup
 
-- name: Set remove_yum_repos on cleanup
-  set_fact:
-    remove_yum_repos: "[{% for repo in yum_repos %}'{{ repo.name}}',{% endfor %}]"
-  when: yum_repos|length > 0 and
-        cleanup and
-        remove_yum_repos|length == 0
-
-- include: remove_yum_repos.yml
-  when: remove_yum_repos|length > 0
-  tags:
-    - delete-yum-repos
-
-- include: disable_yum_repos.yml
-  when: disable_yum_repos|length > 0 and
-        not cleanup
-  tags:
-    - disable-yum-repos
-
-- name: Set enable_yum_repos on cleanup
-  set_fact:
-    enable_yum_repos: "{{ disable_yum_repos }}"
-  when: disable_yum_repos|length > 0 and
-        cleanup and
-        enable_yum_repos|length == 0
-
-- include: enable_yum_repos.yml
-  when: enable_yum_repos|length > 0
-  tags:
-    - enable-yum-repos
+# These are tasks which reverse the actions corresponding to the names of
+# the variables they use. For example, `disable_yum_repos` would actually
+# enable all repos defined in that list. The primary use for this is through
+# teuthology, so that you can tell a teuthology run to disable a set of repos
+# for the test run but then re-enable them during the teuthology cleanup process.
+- include: cleanup.yml
+  when: cleanup

--- a/roles/downstream-setup/tasks/remove_yum_repos.yml
+++ b/roles/downstream-setup/tasks/remove_yum_repos.yml
@@ -3,4 +3,4 @@
   file:
     path: "/etc/yum.repos.d/{{ item }}.repo"
     state: absent
-  with_items: remove_yum_repos
+  with_items: repos

--- a/roles/downstream-setup/tasks/setup.yml
+++ b/roles/downstream-setup/tasks/setup.yml
@@ -1,0 +1,28 @@
+---
+- include: yum_repos.yml
+  when: yum_repos|length > 0
+  vars:
+    repos: "{{ yum_repos }}"
+  tags:
+    - yum-repos
+
+- include: remove_yum_repos.yml
+  when: remove_yum_repos|length > 0
+  vars:
+    repos: "{{ remove_yum_repos }}"
+  tags:
+    - delete-yum-repos
+
+- include: disable_yum_repos.yml
+  when: disable_yum_repos|length > 0
+  vars:
+    repos: "{{ disable_yum_repos }}"
+  tags:
+    - disable-yum-repos
+
+- include: enable_yum_repos.yml
+  when: enable_yum_repos|length > 0
+  vars:
+    repos: "{{ enable_yum_repos }}"
+  tags:
+    - enable-yum-repos

--- a/roles/downstream-setup/tasks/yum_repos.yml
+++ b/roles/downstream-setup/tasks/yum_repos.yml
@@ -4,4 +4,4 @@
     url: "{{ item.url }}"
     dest: "/etc/yum.repos.d/{{ item.name }}.repo"
     force: yes
-  with_items: yum_repos
+  with_items: repos


### PR DESCRIPTION
This is a refactor that makes this role a bit easier to understand and
use. I've simplified main.yml to only include setup.yml and cleanup.yml.
This separation of cleanup and setup related tasks make it a bit easier
to understand.

Also fixes this bug: http://tracker.ceph.com/issues/12693

Signed-off-by: Andrew Schoen <aschoen@redhat.com>