### PR TITLE
Enable mirrorlist for epel repo

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -9,16 +9,21 @@ rhsm_repos: []
 kerberos_realm: EXAMPLE.COM
 
 epel_mirror_baseurl: "http://dl.fedoraproject.org/pub/epel"
+epel_mirrorlist: "http://mirrors.fedoraproject.org"
 epel_repos:
   epel:
     name: "Extra Packages for Enterprise Linux"
     baseurl: "{{ epel_mirror_baseurl }}/{{ ansible_distribution_major_version }}/$basearch"
+    mirrorlist: "{{ epel_mirrorlist }}/metalink?repo=epel-{{ ansible_distribution_major_version }}&arch=$basearch"
+    failovermethod: priority
     # ternary requires ansible >= 1.9
     enabled: "{{ enable_epel | ternary(1, 0) }}"
     gpgcheck: 0
   epel-testing:
     name: "Extra Packages for Enterprise Linux - Testing"
     baseurl: "{{ epel_mirror_baseurl }}/testing/{{ ansible_distribution_major_version }}/$basearch"
+    mirrorlist: "{{ epel_mirrorlist }}/metalink?repo=testing-epel{{ ansible_distribution_major_version }}&arch=$basearch"
+    failovermethod: priority
     enabled: 0
     gpgcheck: 0
 

--- a/roles/testnode/vars/centos_6.yml
+++ b/roles/testnode/vars/centos_6.yml
@@ -43,6 +43,7 @@ packages:
   - '@core'
   - '@base'
   - yum-plugin-priorities
+  - yum-plugin-fastestmirror
   - redhat-lsb
   - sysstat
   - gdb

--- a/roles/testnode/vars/centos_7.yml
+++ b/roles/testnode/vars/centos_7.yml
@@ -19,6 +19,7 @@ packages:
   - '@core'
   - '@base'
   - yum-plugin-priorities
+  - yum-plugin-fastestmirror
   - redhat-lsb
   - sysstat
   - gdb

--- a/roles/testnode/vars/redhat_6.yml
+++ b/roles/testnode/vars/redhat_6.yml
@@ -37,6 +37,7 @@ packages:
   - '@core'
   - '@base'
   - yum-plugin-priorities
+  - yum-plugin-fastestmirror
   - redhat-lsb
   - sysstat
   - gdb

--- a/roles/testnode/vars/redhat_7.yml
+++ b/roles/testnode/vars/redhat_7.yml
@@ -19,6 +19,7 @@ packages:
   - '@core'
   - '@base'
   - yum-plugin-priorities
+  - yum-plugin-fastestmirror
   - redhat-lsb
   - sysstat
   - gdb


### PR DESCRIPTION
This enables mirrorlist functionality with the epel repo.

This should prevent package installation from breaking when yum runs into a connection timeout with the baseurl.