### PR TITLE
common: set timeout in /etc/yum.conf

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -28,3 +28,4 @@ epel_repos:
     gpgcheck: 0
 
 enable_epel: true
+yum_timeout: 300

--- a/roles/common/tasks/epel.yml
+++ b/roles/common/tasks/epel.yml
@@ -1,4 +1,11 @@
 ---
+- name: Increase the yum timeout.
+  lineinfile:
+    dest: /etc/yum.conf
+    line: "timeout={{ yum_timeout }}"
+    regexp: "^timeout="
+    state: present
+
 - name: Configure epel repos in /etc/yum.repos.d/
   template:
     src: yum_repo.j2


### PR DESCRIPTION
We were getting timeouts when using epel mirrors and the default timeout value
is only 30 seconds which is not long enough for heavily used mirrors to
respond.

See: http://tracker.ceph.com/issues/12778

Signed-off-by: Andrew Schoen <aschoen@redhat.com>