### PR TITLE
users: increase the retry count to 24 for fetching ssh keys from github

### DIFF
--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -46,7 +46,8 @@
   # Register and retry to work around transient githubusercontent.com issues
   register: ssh_key_update
   until: ssh_key_update|success
-  retries: 3
+  # try for 2 minutes to retrieve the key before failing
+  retries: 24
   delay: 5
   tags:
     - pubkeys


### PR DESCRIPTION
We were still getting timeouts when requesting keys from github, so
we're gonna try to just simply increase the number of times it retries
to see if that helps things.

See: http://tracker.ceph.com/issues/12868

Signed-off-by: Andrew Schoen <aschoen@redhat.com>