### PR TITLE
Add support for debian 8

### DIFF
--- a/roles/common/tasks/kerberos.yml
+++ b/roles/common/tasks/kerberos.yml
@@ -7,6 +7,17 @@
     state: present
   when: ansible_distribution == 'RedHat'
 
+- name: Update apt cache.
+  apt:
+    update_cache: yes
+  # Register and retry to work around transient http issues
+  register: apt_cache_update
+  until: apt_cache_update|success
+  # try for 2 minutes before failing
+  retries: 24
+  delay: 5
+  when: ansible_distribution == 'Debian'
+
 - name: Install Kerberos Packages (Debian)
   apt:
     name: krb5-user

--- a/roles/testnode/tasks/apt/repos.yml
+++ b/roles/testnode/tasks/apt/repos.yml
@@ -52,16 +52,3 @@
     mode: 0644
   with_items: apt_repos|list + common_apt_repos|list
   register: local_apt_repos
-
-- name: Update apt cache.
-  apt:
-    update_cache: yes
-  when: sources|changed or
-        local_apt_repos|changed or
-        apt_prefs|changed
-  # Register and retry to work around transient http issues
-  register: apt_cache_update
-  until: apt_cache_update|success
-  # try for 2 minutes before failing
-  retries: 24
-  delay: 5

--- a/roles/testnode/tasks/apt/repos.yml
+++ b/roles/testnode/tasks/apt/repos.yml
@@ -37,6 +37,9 @@
   with_items:
     - "http://{{ git_mirror_host }}/autobuild.asc"
     - "http://{{ git_mirror_host }}/release.asc"
+  # try for 2 minutes before failing
+  retries: 24
+  delay: 5
 
 # required for apt_repository
 - name: Install python-apt

--- a/roles/testnode/tasks/apt_systems.yml
+++ b/roles/testnode/tasks/apt_systems.yml
@@ -10,10 +10,12 @@
 - name: Update apt cache.
   apt:
     update_cache: yes
-  when: ansible_distribution_major_version|int >= 15 and
-        ansible_distribution == "Ubuntu"
+  # try for 2 minutes before failing
+  retries: 24
+  delay: 5
   tags:
     - repos
+    - packages
 
 - name: Perform package related tasks.
   include: apt/packages.yml

--- a/roles/testnode/tasks/apt_systems.yml
+++ b/roles/testnode/tasks/apt_systems.yml
@@ -42,6 +42,11 @@
   when: add_user_xattr is defined and
         add_user_xattr|changed
 
+- name: Ensure fuse group exists.
+  group:
+    name: fuse
+    state: present
+
 - name: Upload /etc/fuse.conf.
   template:
     src: fuse.conf

--- a/roles/testnode/templates/apt/sources.list.jessie
+++ b/roles/testnode/templates/apt/sources.list.jessie
@@ -1,0 +1,4 @@
+# {{ ansible_managed }}
+deb http://http.debian.net/debian jessie main contrib non-free
+deb http://security.debian.org/ jessie/updates main contrib non-free
+deb http://http.debian.net/debian jessie-updates main contrib non-free

--- a/roles/testnode/templates/ssh/sshd_config_debian_8
+++ b/roles/testnode/templates/ssh/sshd_config_debian_8
@@ -1,0 +1,91 @@
+# {{ ansible_managed }}
+# Package generated configuration file
+# See the sshd_config(5) manpage for details
+
+# What ports, IPs and protocols we listen for
+Port 22
+# Use these options to restrict which interfaces/protocols sshd will bind to
+#ListenAddress ::
+#ListenAddress 0.0.0.0
+Protocol 2
+# HostKeys for protocol version 2
+HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_dsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
+HostKey /etc/ssh/ssh_host_ed25519_key
+#Privilege Separation is turned on for security
+UsePrivilegeSeparation yes
+
+# Lifetime and size of ephemeral version 1 server key
+KeyRegenerationInterval 3600
+ServerKeyBits 1024
+
+# Logging
+SyslogFacility AUTH
+LogLevel INFO
+
+# Authentication:
+LoginGraceTime 120
+PermitRootLogin yes
+StrictModes yes
+
+RSAAuthentication yes
+PubkeyAuthentication yes
+#AuthorizedKeysFile	%h/.ssh/authorized_keys
+
+# Don't read the user's ~/.rhosts and ~/.shosts files
+IgnoreRhosts yes
+# For this to work you will also need host keys in /etc/ssh_known_hosts
+RhostsRSAAuthentication no
+# similar for protocol version 2
+HostbasedAuthentication no
+# Uncomment if you don't trust ~/.ssh/known_hosts for RhostsRSAAuthentication
+#IgnoreUserKnownHosts yes
+
+# To enable empty passwords, change to yes (NOT RECOMMENDED)
+PermitEmptyPasswords no
+
+# Change to yes to enable challenge-response passwords (beware issues with
+# some PAM modules and threads)
+ChallengeResponseAuthentication no
+
+# Change to no to disable tunnelled clear text passwords
+#PasswordAuthentication yes
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosGetAFSToken no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+
+X11Forwarding yes
+X11DisplayOffset 10
+PrintMotd no
+PrintLastLog yes
+TCPKeepAlive yes
+#UseLogin no
+
+#MaxStartups 10:30:60
+#Banner /etc/issue.net
+
+# Allow client to pass locale environment variables
+AcceptEnv LANG LC_*
+
+Subsystem sftp /usr/lib/openssh/sftp-server
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+UsePAM yes
+
+MaxSessions 1000

--- a/roles/testnode/vars/debian_8.yml
+++ b/roles/testnode/vars/debian_8.yml
@@ -1,0 +1,104 @@
+---
+packages:
+  - lsb-release
+  - build-essential
+  - sysstat
+  - gdb
+  - python-configobj
+  - python-gevent
+  - python-dev
+  - python-virtualenv
+  - libevent-dev
+  - fuse
+  - libssl1.0.0
+  - libgoogle-perftools4
+  - cryptsetup-bin
+  - libcrypto++9
+  - iozone3
+  - collectl
+  - nfs-kernel-server
+  # for running ceph
+  - libedit2
+  - xfsprogs
+  - gdisk
+  - parted
+  ###
+  # for setting BIOS settings 
+  - libsmbios-bin
+  ###
+  - libuuid1
+  - libfcgi
+  - btrfs-tools
+  # for compiling helpers and such
+  - libatomic-ops-dev
+  ###
+  # used by workunits
+  - git-core
+  - attr
+  - dbench
+  - bonnie++
+  - valgrind
+  - python-nose
+  - mpich2
+  - libmpich2-dev
+  - ant
+  ###
+  # used by the xfstests tasks
+  - libtool
+  - automake
+  - gettext
+  - uuid-dev
+  - libacl1-dev
+  - bc
+  - xfsdump
+  - dmapi
+  - xfslibs-dev
+  ###
+  # For Mark Nelson
+  - sysprof
+  - pdsh
+  ###
+  # for blktrace and seekwatcher
+  - blktrace
+  - python-numpy
+  - python-matplotlib
+  ###
+  # for qemu
+  - kvm
+  - genisoimage
+  ###
+  # for json_xs to investigate JSON by hand
+  - libjson-xs-perl
+  ###
+  # for pretty-printing xml
+  - xml-twig-tools
+  ###
+  # for java bindings, hadoop, etc.
+  - default-jdk
+  - junit4
+  ###
+  # for disk/etc monitoring
+  - smartmontools
+  - nagios-nrpe-server
+  ###
+  # for samba testing
+  - cifs-utils
+  ###
+  # DistCC for arm
+  - distcc
+  ###
+  # tgt
+  - tgt
+  - open-iscsi
+
+#NOTE: these packages were not found for debian 8, but are present for debian 7
+#- mencoder
+#- libmpich2-3
+#- libboost-thread1.49.0
+  
+packages_to_upgrade:
+  - apt
+  - libcurl3-gnutls
+  - apache2
+  - libapache2-mod-fastcgi
+  - libfcgi0ldbl


### PR DESCRIPTION
This adds support for debian 8. There were a few packages present in the packages list for debian 7 that are not present in debian 8.  I've just removed those for now and added a comment about them. I'm unsure how to determine if they're actually needed or not.

See: http://tracker.ceph.com/issues/12957