### PR TITLE
downstream-setup: yum_repos will now be removed during cleanup

### DIFF
--- a/roles/downstream-setup/tasks/cleanup.yml
+++ b/roles/downstream-setup/tasks/cleanup.yml
@@ -8,10 +8,13 @@
   tags:
     - yum-repos
 
+- set_fact:
+    repos_to_remove: "{% for repo in yum_repos%}{{ repo.name }}{% if not loop.last %},{% endif %}{% endfor %}"
+
 - include: remove_yum_repos.yml
   when: yum_repos|length > 0
   vars:
-    repos: "{{ yum_repos }}"
+    repos: "{{ repos_to_remove.split(',') }}"
   tags:
     - delete-yum-repos
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/12921

The issue here was that I was passing the hash ``yum_repos`` to ``remove_yum_repos.yml`` in ``cleanup.yml`` when it was expecting a list of repos as strings, causing the task to not find the correct yum repo to remove.