### PR TITLE
rm ceph-extras repository config

### DIFF
--- a/roles/testnode/vars/centos_6.yml
+++ b/roles/testnode/vars/centos_6.yml
@@ -2,12 +2,6 @@
 # vars specific to centos 6.x
 
 yum_repos:
-  centos6-qemu-ceph:
-    name: Cent OS 6 Local Qemu Repo
-    baseurl: http://ceph.com/packages/ceph-extras/rpm/centos6/x86_64/
-    enabled: 1
-    gpgcheck: 0
-    priority: 2
   centos6-fcgi-ceph:
     name: Cent OS 6 Local fastcgi Repo
     baseurl: http://gitbuilder.ceph.com/mod_fastcgi-rpm-centos6-x86_64-basic/ref/master/

--- a/roles/testnode/vars/debian_7.yml
+++ b/roles/testnode/vars/debian_7.yml
@@ -1,6 +1,5 @@
 ---
 apt_repos:
-  - "deb http://ceph.com/packages/ceph-extras/debian/ wheezy main"
   - "deb http://ceph.com/debian-dumpling/ wheezy main"
   - "deb http://gitbuilder.ceph.com/libapache-mod-fastcgi-deb-wheezy-x86_64-basic/ref/master/ wheezy main"
 

--- a/roles/testnode/vars/fedora_20.yml
+++ b/roles/testnode/vars/fedora_20.yml
@@ -6,9 +6,6 @@ yum_repos:
     enabled: 1
     gpgcheck: 0
     priority: 0
-  ceph-extras:
-    name: Fedora ceph extras
-    baseurl: http://ceph.com/packages/ceph-extras/rpm/fedora20/x86_64/
 
 packages_to_upgrade:
   - leveldb

--- a/roles/testnode/vars/redhat_6.yml
+++ b/roles/testnode/vars/redhat_6.yml
@@ -2,12 +2,6 @@
 # vars specific to rhel 6.x
 
 common_yum_repos:
-  centos6-qemu-ceph:
-    name: "Cent OS 6 Local Qemu Repo"
-    baseurl: http://ceph.com/packages/ceph-extras/rpm/rhel6/x86_64/
-    enabled: 1
-    gpgcheck: 0
-    priority: 2
   lab-extras:
     name: "lab-extras"
     baseurl: "http://{{ mirror_host }}/lab-extras/rhel6/"

--- a/roles/testnode/vars/ubuntu_12.04.yml
+++ b/roles/testnode/vars/ubuntu_12.04.yml
@@ -1,8 +1,4 @@
 ---
-apt_repos:
-  # tgt/libleveldb:
-  - "deb http://ceph.com/packages/ceph-extras/debian/ precise main"
-
 packages:
   - libgoogle-perftools0
   - libboost-thread1.46.1


### PR DESCRIPTION
This repository contains packages that we don't have time to continue maintaining. In particular, the CentOS 6 QEMU packages were vulnerable to VENOM (CVE-2015-3456) and no users should rely on them. The other packages in "ceph-extras" will continue to incur security issues over time.

With the recent migration from "ceph.com" -> "download.ceph.com", we've chosen not to copy these "ceph-extras" files over to the new locations.