### PR TITLE
puddle: multiple updates

### DIFF
--- a/roles/puddle/templates/ceph-1.3-rhel-7-async.conf
+++ b/roles/puddle/templates/ceph-1.3-rhel-7-async.conf
@@ -6,7 +6,7 @@
 type = errata
 errata_release = CEPH-1.3.0,CEPH-ASYNC
 product_name = RHCeph
-version = 1.3-RHEL-7
+version = 1.3.0-async-RHEL-7
 rootdir = /var/www/{{ ansible_hostname }}/htdocs/puddles
 emails = {{ puddle.emails }}
 signed = no

--- a/roles/puddle/templates/ceph-1.3.z-rhel-7.conf
+++ b/roles/puddle/templates/ceph-1.3.z-rhel-7.conf
@@ -6,7 +6,7 @@
 type = errata
 errata_release = CEPH-1.3.0,CEPH-1.3.z,CEPH-ASYNC
 product_name = RHCeph
-version = 1.3-RHEL-7
+version = 1.3.1-RHEL-7
 rootdir = /var/www/{{ ansible_hostname }}/htdocs/puddles
 emails = {{ puddle.emails }}
 signed = no

--- a/roles/puddle/templates/rh-common-rhel-6.conf
+++ b/roles/puddle/templates/rh-common-rhel-6.conf
@@ -6,7 +6,7 @@
 type = errata
 #errata_release = RH-Common-ASYNC
 errata_release = no
-errata_whitelist = 20902,21479
+errata_whitelist = 20902,21479,21623
 product_name = RHEL-6-Server-RH-Common
 version = 6.5
 rootdir = /var/www/{{ ansible_hostname }}/htdocs/puddles

--- a/roles/puddle/templates/rh-common-rhel-7.conf
+++ b/roles/puddle/templates/rh-common-rhel-7.conf
@@ -6,7 +6,7 @@
 type = errata
 #errata_release = RH-Common-ASYNC
 errata_release = no
-errata_whitelist = 20902
+errata_whitelist = 20902,21623
 product_name = RHEL-7-RH-Common
 version = 7.1
 rootdir = /var/www/{{ ansible_hostname }}/htdocs/puddles


### PR DESCRIPTION
**output RHCEPH 1.3 to separate locations**
I periodically generate Puddles for both RHCS 1.3.0-async and 1.3.1. It's confusing when these Puddles exist in the same parent directory. Split them up into two directories so it is easier to understand what
each Puddle is.

**new RH-COMMON advisory undergoing testing**
Adjust the RHEL 6 and 7 RH-COMMON Puddle configs for a new async update that will be undergoing testing.
