### PR TITLE
testnode: add fcgi to the list of EPEL packages

### DIFF
--- a/roles/testnode/vars/centos_6.yml
+++ b/roles/testnode/vars/centos_6.yml
@@ -118,6 +118,7 @@ epel_packages:
   - gperftools-devel
   - cryptopp-devel
   - cryptopp
+  - fcgi
   # used by workunits
   - dbench
   # used by workunits

--- a/roles/testnode/vars/centos_7.yml
+++ b/roles/testnode/vars/centos_7.yml
@@ -95,6 +95,7 @@ epel_packages:
   - gperftools-devel
   - cryptopp-devel
   - cryptopp
+  - fcgi
   # used by workunits
   - dbench
   # used by workunits

--- a/roles/testnode/vars/redhat_6.yml
+++ b/roles/testnode/vars/redhat_6.yml
@@ -106,6 +106,7 @@ epel_packages:
   - gperftools-devel
   - cryptopp-devel
   - cryptopp
+  - fcgi
   # used by workunits
   - dbench
   - fuse-sshfs

--- a/roles/testnode/vars/redhat_7.yml
+++ b/roles/testnode/vars/redhat_7.yml
@@ -82,6 +82,7 @@ epel_packages:
   - cryptopp-devel
   - cryptopp
   - dbench
+  - fcgi
   - fuse-sshfs
   - perl-JSON-XS
 


### PR DESCRIPTION
For Ceph upstream, we rely on fcgi from EPEL.

http://tracker.ceph.com/issues/13203 Refs: #13203