### PR TITLE
testnode: rm cuttlefish repository

### DIFF
--- a/roles/testnode/vars/centos_6.yml
+++ b/roles/testnode/vars/centos_6.yml
@@ -14,12 +14,6 @@ yum_repos:
     enabled: 1
     gpgcheck: 0
     priority: 2
-  centos6-ceph:
-    name: Cent OS 6 Local ceph Repo
-    baseurl: http://ceph.com/rpm-cuttlefish/el6/x86_64/
-    enabled: 1
-    gpgcheck: 0
-    priority: 2
   rpmforge:
     name: Red Hat Enterprise $releasever - RPMforge.net - dag
     baseurl: "http://{{ mirror_host }}/rpmforge/"

--- a/roles/testnode/vars/redhat_6.yml
+++ b/roles/testnode/vars/redhat_6.yml
@@ -20,12 +20,6 @@ common_yum_repos:
     enabled: 1
     gpgcheck: 0
     priority: 2
-  centos6-ceph:
-    name: "Cent OS 6 Local ceph Repo"
-    baseurl: http://ceph.com/rpm-cuttlefish/rhel6/x86_64/
-    enabled: 1
-    gpgcheck: 0
-    priority: 2
 
 packages:
   - '@core'


### PR DESCRIPTION
Prior to this commit, every RHEL 6 and CentOS 6 node would automatically have the cuttlefish repository enabled.

This hardcoding seems wrong. Now that we've moved the RPMs off of ceph.com to download.ceph.com, it actually breaks nodes. So let's stop hard-coding this one altogether.

Reported-by: @wusui