### PR TITLE
Remove custom qemu packages

### DIFF
--- a/roles/testnode/vars/centos_6.yml
+++ b/roles/testnode/vars/centos_6.yml
@@ -83,10 +83,6 @@ packages:
   # for qemu
   - usbredir
   - genisoimage
-  - qemu-img-0.12.1.2-2.415.el6.3ceph
-  - qemu-kvm-0.12.1.2-2.415.el6.3ceph
-  - qemu-kvm-tools-0.12.1.2-2.415.el6.3ceph
-  - qemu-guest-agent-0.12.1.2-2.415.el6.3ceph
   ###
   # for apache and rgw
   - httpd

--- a/roles/testnode/vars/centos_7.yml
+++ b/roles/testnode/vars/centos_7.yml
@@ -68,9 +68,6 @@ packages:
   # for qemu
   - usbredir
   - genisoimage
-  - qemu-img-rhev-1.5.3-60_ceph.el7.centos.5
-  - qemu-kvm-rhev-1.5.3-60_ceph.el7.centos.5
-  - qemu-kvm-tools-rhev-1.5.3-60_ceph.el7.centos.5
   ###
   # for apache and rgw
   - httpd

--- a/roles/testnode/vars/redhat_6.yml
+++ b/roles/testnode/vars/redhat_6.yml
@@ -71,10 +71,6 @@ packages:
   # for qemu
   - usbredir
   - genisoimage
-  - qemu-img-0.12.1.2-2.415.el6.3ceph
-  - qemu-kvm-0.12.1.2-2.415.el6.3ceph
-  - qemu-kvm-tools-0.12.1.2-2.415.el6.3ceph
-  - qemu-guest-agent-0.12.1.2-2.415.el6.3ceph
   ###
   # for apache and rgw
   - httpd

--- a/roles/testnode/vars/redhat_7.yml
+++ b/roles/testnode/vars/redhat_7.yml
@@ -57,9 +57,6 @@ packages:
   - python-matplotlib
   - usbredir
   - genisoimage
-  - qemu-img-rhev-1.5.3-60_ceph.el7.5
-  - qemu-kvm-rhev-1.5.3-60_ceph.el7.5
-  - qemu-kvm-tools-rhev-1.5.3-60_ceph.el7.5
   - httpd
   - httpd-devel
   - httpd-tools


### PR DESCRIPTION
This commit removes installation requirement of custom Ceph qemu packages that are no longer available for RHEL/CentOS6 and shouldn't be used on RHEL/CentOS7.

Repos containing these packages were removed in https://github.com/ceph/ceph-cm-ansible/commit/0d3dcfe3b3d85901016d6bb767ef17b5c791817e