### PR TITLE
Create users with same-named primary group

### DIFF
--- a/roles/ansible-managed/tasks/main.yml
+++ b/roles/ansible-managed/tasks/main.yml
@@ -9,7 +9,8 @@
 - name: Create the ansible user.
   user:
     name: "{{ ansible_user }}"
-    group: sudo
+    group: "{{ ansible_user }}"
+    groups: sudo
     shell: /bin/bash
     uid: "{{ ansible_user_uid_ }}"
     update_password: on_create

--- a/roles/testnode/tasks/user.yml
+++ b/roles/testnode/tasks/user.yml
@@ -15,8 +15,8 @@
     # apparently some ceph tests fail without this uid
     # https://github.com/ceph/ceph-qa-chef/commit/5678cc3893fd1cc291254e4d1abe6705e6a9bbb0
     uid: 1000
-    group: sudo
-    groups: "{{ teuthology_user }}"
+    group: "{{ teuthology_user }}"
+    groups: sudo
     shell: /bin/bash
     state: present
   # If we're currently running as teuthology_user, we won't be able to modify

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -22,7 +22,8 @@
 - name: Create all admin users with sudo access.
   user:
     name: "{{ item.name }}"
-    group: sudo
+    group: "{{ item.name }}"
+    groups: sudo
     shell: /bin/bash
     state: present
   with_items: managed_admin_users


### PR DESCRIPTION
If adding sudo, add as secondary group ('groups:').  This is more
standard, and allows for quick enumeration of "who's in sudo" by
examining /etc/group

Signed-off-by: Dan Mick <dan.mick@redhat.com>