### PR TITLE
paddles: Always include secrets

### DIFF
--- a/roles/paddles/tasks/main.yml
+++ b/roles/paddles/tasks/main.yml
@@ -1,7 +1,9 @@
 ---
-- name: Include cobbler keys.
+- name: Include secrets
   include_vars: "{{ secrets_path | mandatory }}/paddles.yml"
   no_log: true
+  tags:
+    - always
 
 - name: Set repo location
   set_fact:


### PR DESCRIPTION
Currently this only stores the db_pass var. Also fix the name of the
play.

Signed-off-by: Zack Cerza <zack@redhat.com>