### PR TITLE
testnode: install QEMU packages on Fedora, RHEL, and CentOS

### DIFF
--- a/roles/testnode/vars/centos_6.yml
+++ b/roles/testnode/vars/centos_6.yml
@@ -81,6 +81,7 @@ packages:
   - python-matplotlib
   ###
   # for qemu
+  - qemu-kvm
   - usbredir
   - genisoimage
   ###

--- a/roles/testnode/vars/centos_7.yml
+++ b/roles/testnode/vars/centos_7.yml
@@ -66,6 +66,7 @@ packages:
   - python-matplotlib
   ###
   # for qemu
+  - qemu-kvm
   - usbredir
   - genisoimage
   ###

--- a/roles/testnode/vars/fedora_20.yml
+++ b/roles/testnode/vars/fedora_20.yml
@@ -72,6 +72,7 @@ packages:
   - python-matplotlib
   ###
   # for qemu
+  - qemu-system-x86
   - genisoimage
   ###
   # for apache and rgw

--- a/roles/testnode/vars/redhat_6.yml
+++ b/roles/testnode/vars/redhat_6.yml
@@ -69,6 +69,7 @@ packages:
   - python-matplotlib
   ###
   # for qemu
+  - qemu-kvm
   - usbredir
   - genisoimage
   ###

--- a/roles/testnode/vars/redhat_7.yml
+++ b/roles/testnode/vars/redhat_7.yml
@@ -55,6 +55,7 @@ packages:
   - blktrace
   - numpy
   - python-matplotlib
+  - qemu-kvm
   - usbredir
   - genisoimage
   - httpd


### PR DESCRIPTION
Several RBD test cases require QEMU to be present to verify integration.
Ubuntu package list already included QEMU packages.

Fixes: #13308
Signed-off-by: Jason Dillaman <dillaman@redhat.com>