### PR TITLE
puddle: nginx configs for HTTPS

### DIFF
--- a/roles/puddle/tasks/nginx.yml
+++ b/roles/puddle/tasks/nginx.yml
@@ -21,6 +21,16 @@
   notify:
    - restart nginx
 
+# Note: this file must be installed on the host independent of ansible.
+- name: set permissions on htaccess
+  file:
+    path: '/etc/nginx/htpasswd'
+    owner: root
+    group: nginx
+    mode: 0640
+  notify:
+   - restart nginx
+
 - name: start the nginx service
   service:
     name: nginx

--- a/roles/puddle/templates/nginx.conf
+++ b/roles/puddle/templates/nginx.conf
@@ -83,6 +83,8 @@ http {
             if ($scheme != "https") {
                 rewrite ^ https://$host$uri permanent;
             }
+            auth_basic "Restricted";
+            auth_basic_user_file /etc/nginx/htpasswd;
         }
     }
 

--- a/roles/puddle/templates/nginx.conf
+++ b/roles/puddle/templates/nginx.conf
@@ -51,8 +51,13 @@ http {
     server {
         listen       80 default_server;
         listen       [::]:80 default_server;
+        listen       443 default_server ssl;
         server_name  localhost;
         root         /var/www/{{ ansible_hostname }}/htdocs;
+
+        ssl_certificate     /etc/pki/tls/certs/{{ ansible_fqdn }}-bundled.crt;
+        ssl_certificate_key /etc/pki/tls/private/{{ ansible_fqdn }}.key;
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
 
         location / {
             autoindex on;
@@ -69,6 +74,15 @@ http {
             text/plain conf log repo txt;
             # More from distill:
             text/plain manifest MD5SUM SHA1SUM SHA256SUM;
+        }
+
+        # Online Ubuntu repos
+        location /ubuntu/ {
+            autoindex on;
+            autoindex_exact_size off;
+            if ($scheme != "https") {
+                rewrite ^ https://$host$uri permanent;
+            }
         }
     }
 


### PR DESCRIPTION
I'm adding HTTPS to our Puddle web server in order to support test Apt repos over HTTPS.

The packages will be hosted under http://puddle.fqdn/ubuntu/

The key and certificate files are managed outside of Ansible.