### PR TITLE
Temporarily disable blkin repo (part 2)

### DIFF
--- a/roles/testnode/vars/ubuntu_14.yml
+++ b/roles/testnode/vars/ubuntu_14.yml
@@ -10,5 +10,5 @@ packages:
   - libboost-thread1.54.0
   - mpich
   - qemu-system-x86
-  - blkin
+#  - blkin
   - lttng-tools


### PR DESCRIPTION
Tests that need blkin are welcome to install it in a way that makes sense.

http://tracker.ceph.com/issues/13572

Signed-off-by: Loic Dachary <ldachary@redhat.com>