### PR TITLE
testnodes: Add teuthology_user to 'disk' group

### DIFF
--- a/roles/testnode/tasks/yum_systems.yml
+++ b/roles/testnode/tasks/yum_systems.yml
@@ -22,10 +22,11 @@
     name: kvm
     state: present
 
-- name: Add the teuthology user to group kvm
+- name: Add the teuthology user to groups kvm,disk
   user:
     name: "{{ teuthology_user }}"
-    group: kvm
+    groups: kvm,disk
+    append: yes
 
 - name: Configure /etc/sudoers.
   template:


### PR DESCRIPTION
We were already doing this for apt systems; do it for yum systems as
well

Signed-off-by: Zack Cerza <zack@redhat.com>