### PR TITLE
cobbler: Updating dban profile

### DIFF
--- a/roles/cobbler_profile/defaults/main.yml
+++ b/roles/cobbler_profile/defaults/main.yml
@@ -7,6 +7,7 @@ distros:
       iso: ""
   "dban-2.3.0":
       iso: ""
+      kernel_options: 'nuke=\"dwipe\ --autonuke\ --method\ zero\" silent console=tty0'
   "RHEL-6.6-Server-x86_64":
       iso: ""
   "RHEL-6.7-Server-x86_64":


### PR DESCRIPTION
Since we added dban to the labs to automatically wipe disks before decommissioning a host, I thought it'd be fitting to change the dban cobbler profile accordingly.