### PR TITLE
cobbler: renaming cobbler distro/profile to indicate autonuke/non-interactive

### DIFF
--- a/cobbler.yml
+++ b/cobbler.yml
@@ -4,7 +4,7 @@
     - common
     - cobbler 
     - { role: cobbler_profile, distro_name: inktank-rescue, tags: ['inktank-rescue'] }
-    - { role: cobbler_profile, distro_name: dban-2.3.0, tags: ['dban-2.3.0'] }
+    - { role: cobbler_profile, distro_name: dban-2.3.0-autonuke, tags: ['dban-autonuke'] }
     - { role: cobbler_profile, distro_name: RHEL-6.6-Server-x86_64, tags: ['rhel6.6'] }
     - { role: cobbler_profile, distro_name: RHEL-6.7-Server-x86_64, tags: ['rhel6.7'] }
     - { role: cobbler_profile, distro_name: RHEL-7.0-Server-x86_64, tags: ['rhel7.0'] }

--- a/roles/cobbler_profile/defaults/main.yml
+++ b/roles/cobbler_profile/defaults/main.yml
@@ -5,7 +5,7 @@ distros:
   # set in the secrets repo.
   "inktank-rescue":
       iso: ""
-  "dban-2.3.0":
+  "dban-2.3.0-autonuke":
       iso: ""
   "RHEL-6.6-Server-x86_64":
       iso: ""


### PR DESCRIPTION
Changing `kernel_options:` in secrets repos