### PR TITLE
testnodes: Set hostnames properly

### DIFF
--- a/roles/testnode/tasks/set_hostname.yml
+++ b/roles/testnode/tasks/set_hostname.yml
@@ -1,23 +1,8 @@
 ---
-- name: Get hostname.
-  command: hostname
-  register: existing_hostname
-  changed_when: false
-
-- name: Correct hostname if it is 'localhost'
+- name: Set hostname var
   set_fact:
-    new_hostname: "{{ inventory_hostname.split('.')[0] }}"
-  when: existing_hostname is defined and
-        existing_hostname.stdout.find("localhost") != -1
+    hostname: "{{ inventory_hostname.split('.')[0] }}"
 
-- name: Remove lab domain from hostname.
-  set_fact:
-    new_hostname: "{{ existing_hostname.stdout.split('.')[0] }}"
-  when: existing_hostname is defined and
-        existing_hostname.stdout.find("{{ lab_domain }}") != -1
-
-- name: Set hostname.
+- name: "Set the system's hostname"
   hostname:
-     name: "{{ new_hostname }}"
-  when: existing_hostname is defined and
-        existing_hostname.stdout != new_hostname
+     name: "{{ hostname }}"


### PR DESCRIPTION
Instead of using convoluted logic to determine whether or not to set the
hostname, just do it. The hostname module is nice and idempotent.

This was inspired by http://tracker.ceph.com/issues/13679

Signed-off-by: Zack Cerza <zack@redhat.com>