### PR TITLE
puddle: add rsyncd

### DIFF
--- a/roles/puddle/handlers/main.yml
+++ b/roles/puddle/handlers/main.yml
@@ -9,3 +9,8 @@
   service:
     name: faucet
     state: restarted
+
+- name: restart rsyncd
+  service:
+    name: rsyncd
+    state: restarted

--- a/roles/puddle/tasks/main.yml
+++ b/roles/puddle/tasks/main.yml
@@ -29,3 +29,8 @@
 - include: distill/configure.yml
   tags:
     - configure-distill
+
+# install and configure rsyncd
+- include: rsync.yml
+  tags:
+    - rsync

--- a/roles/puddle/tasks/rsync.yml
+++ b/roles/puddle/tasks/rsync.yml
@@ -1,0 +1,18 @@
+---
+- name: install rsync
+  yum:
+    name: rsync
+    state: present
+
+- name: configure rsyncd
+  template:
+    src: rsyncd.conf
+    dest: /etc/rsyncd.conf
+  notify:
+   - restart rsyncd
+
+- name: start the rsyncd service
+  service:
+    name: rsyncd
+    state: started
+    enabled: yes

--- a/roles/puddle/templates/rsyncd.conf
+++ b/roles/puddle/templates/rsyncd.conf
@@ -1,0 +1,12 @@
+#
+# {{ ansible_managed }}
+#
+
+        uid = nobody
+        gid = nobody
+        use chroot = yes
+        max connections = 64
+
+[ubuntu]
+        path = /var/www/{{ ansible_hostname }}/htdocs/ubuntu
+        comment = ceph ubuntu packages


### PR DESCRIPTION
Run rsyncd with access to the "ubuntu" directory. This will permit Red Hat's rel-eng to view this repository layout.