### PR TITLE
Use nginx as a reverse proxy for paddles

### DIFF
--- a/roles/paddles/defaults/main.yml
+++ b/roles/paddles/defaults/main.yml
@@ -3,8 +3,6 @@ paddles_user: paddles
 
 paddles_repo: https://github.com/ceph/paddles.git
 
-# Default is to listen on all interfaces
-listen_ip: "0.0.0.0"
 paddles_port: 8080
 
 log_host: localhost

--- a/roles/paddles/tasks/main.yml
+++ b/roles/paddles/tasks/main.yml
@@ -43,3 +43,6 @@
 
 # Configure the system to run paddles as a daemon
 - include: setup_service.yml
+
+# Configure nginx as a reverse proxy
+- include: nginx.yml

--- a/roles/paddles/tasks/nginx.yml
+++ b/roles/paddles/tasks/nginx.yml
@@ -1,0 +1,29 @@
+---
+- name: Disable default nginx config
+  file:
+    name: /etc/nginx/sites-enabled/default
+    state: absent
+
+- name: Ship nginx config
+  template:
+    src: nginx.conf
+    dest: /etc/nginx/sites-available/paddles
+
+- name: Enable nginx config
+  file:
+    src: /etc/nginx/sites-available/paddles
+    dest: /etc/nginx/sites-enabled/paddles
+    state: link
+
+- name: Disable apache httpd
+  service:
+    name: "{{ apache_service }}"
+    enabled: no
+    state: stopped
+
+- name: Enable nginx
+  service:
+    name: nginx
+    enabled: yes
+    state: reloaded
+  changed_when: false

--- a/roles/paddles/templates/nginx.conf
+++ b/roles/paddles/templates/nginx.conf
@@ -1,0 +1,12 @@
+server {
+        server_name {{ inventory_hostname }};
+        listen {{ ansible_all_ipv4_addresses[0] }}:{{ paddles_port }};
+        proxy_send_timeout 600;
+        proxy_connect_timeout 240;
+        location / {
+           proxy_pass                   http://127.0.0.1:{{ paddles_port }}/;
+           proxy_set_header Host        $host;
+           proxy_set_header X-Real-IP   $remote_addr;
+        }
+
+}

--- a/roles/paddles/templates/prod.py
+++ b/roles/paddles/templates/prod.py
@@ -4,8 +4,8 @@ from paddles import models
 from paddles.hooks.cors import CorsHook
 
 server = {
-    'port': '{{ paddles_port }}',
-    'host': '{{ listen_ip }}'
+    'port': '8080',
+    'host': '127.0.0.1'
 }
 
 address = '{{ paddles_address }}'

--- a/roles/paddles/vars/apt_systems.yml
+++ b/roles/paddles/vars/apt_systems.yml
@@ -11,6 +11,11 @@ paddles_extra_packages:
   - postgresql-contrib
   - postgresql-server-dev-all
   - supervisor
+  # We use nginx to reverse-proxy
+  - nginx
+
+# We need this so we can disable apache2 to get out of the way of nginx
+apache_service: 'apache2'
 
 supervisor_conf_d: /etc/supervisor/conf.d
 supervisor_conf_suffix: conf


### PR DESCRIPTION
This is to avoid timeouts when gunicorn workers are busy.

Signed-off-by: Zack Cerza <zack@redhat.com>