### PR TITLE
testnode: do not install fastcgi on RHEL

### DIFF
--- a/roles/testnode/vars/redhat_6.yml
+++ b/roles/testnode/vars/redhat_6.yml
@@ -8,12 +8,6 @@ common_yum_repos:
     enabled: 1
     gpgcheck: 0
     priority: 2
-  centos6-fcgi-ceph:
-    name: "Cent OS 6 Local fastcgi Repo"
-    baseurl: http://gitbuilder.ceph.com/mod_fastcgi-rpm-rhel6-x86_64-basic/ref/master/
-    enabled: 1
-    gpgcheck: 0
-    priority: 2
   centos6-misc-ceph:
     name: "Cent OS 6 Local misc Repo"
     baseurl: "http://{{ mirror_host }}/misc-rpms/"
@@ -78,7 +72,6 @@ packages:
   - httpd-devel
   - httpd-tools
   - mod_ssl
-  - mod_fastcgi-2.4.7-1.ceph.el6
   ###
   - libevent-devel
   # for pretty-printing xml

--- a/roles/testnode/vars/redhat_7.yml
+++ b/roles/testnode/vars/redhat_7.yml
@@ -2,12 +2,6 @@
 # vars specific to any rhel 7.x version
 
 common_yum_repos:
-  rhel-7-fcgi-ceph:
-    name: "RHEL 7 Local fastcgi Repo"
-    baseurl: http://gitbuilder.ceph.com/mod_fastcgi-rpm-rhel7-x86_64-basic/ref/master/
-    enabled: 1
-    gpgcheck: 0
-    priority: 2
   lab-extras:
     name: "lab-extras"
     baseurl: "http://{{ mirror_host }}/lab-extras/rhel7/"
@@ -62,7 +56,6 @@ packages:
   - httpd-devel
   - httpd-tools
   - mod_ssl
-  - mod_fastcgi-2.4.7-1.ceph.el7
   - libevent-devel
   - perl-XML-Twig
   - java-1.6.0-openjdk-devel


### PR DESCRIPTION
Red Hat QE occasionally tests full in-place OS upgrades from RHEL 6 to
RHEL 7. When mod_fastcgi is pre-installed on a RHEL 6 node, and the node
is upgraded to RHEL 7, then Apache will refuse to start unless the QE
team member also upgrades the mod_fastcgi package explicitly. (see
https://bugzilla.redhat.com/1230679 for an example)

Since RGW's Civetweb is becoming mainstream, we don't really need to
focus on mod_fastcgi for Ceph any more, and having it pre-installed on
our RHEL nodes is more of a hindrance than a help.

I'm leaving the CentOS configs alone, for now, so we don't interfere
with any upstream testing with mod_fastcgi.