### PR TITLE
Revert "testnode: install QEMU packages on Fedora, RHEL, and CentOS"

### DIFF
--- a/roles/testnode/vars/centos_6.yml
+++ b/roles/testnode/vars/centos_6.yml
@@ -81,7 +81,6 @@ packages:
   - python-matplotlib
   ###
   # for qemu
-  - qemu-kvm
   - usbredir
   - genisoimage
   ###

--- a/roles/testnode/vars/centos_7.yml
+++ b/roles/testnode/vars/centos_7.yml
@@ -66,7 +66,6 @@ packages:
   - python-matplotlib
   ###
   # for qemu
-  - qemu-kvm
   - usbredir
   - genisoimage
   ###

--- a/roles/testnode/vars/fedora_20.yml
+++ b/roles/testnode/vars/fedora_20.yml
@@ -72,7 +72,6 @@ packages:
   - python-matplotlib
   ###
   # for qemu
-  - qemu-system-x86
   - genisoimage
   ###
   # for apache and rgw

--- a/roles/testnode/vars/redhat_6.yml
+++ b/roles/testnode/vars/redhat_6.yml
@@ -69,7 +69,6 @@ packages:
   - python-matplotlib
   ###
   # for qemu
-  - qemu-kvm
   - usbredir
   - genisoimage
   ###

--- a/roles/testnode/vars/redhat_7.yml
+++ b/roles/testnode/vars/redhat_7.yml
@@ -55,7 +55,6 @@ packages:
   - blktrace
   - numpy
   - python-matplotlib
-  - qemu-kvm
   - usbredir
   - genisoimage
   - httpd


### PR DESCRIPTION
@dillaman @andrewschoen 

This has dependency on librados2 and librbd1 and endsup installing older version either on rhel or on fedora, Since @Ceph provides the right version of librados and rbd, it should be the main source.  I think it might be better to handle this at the later stage.

Check here for logs:  http://fpaste.org/291685/18351144/

Reverts ceph/ceph-cm-ansible#153
