### PR TITLE
Disable fastcgi repos and package installs

### DIFF
--- a/roles/testnode/vars/centos_6.yml
+++ b/roles/testnode/vars/centos_6.yml
@@ -5,7 +5,7 @@ yum_repos:
   centos6-fcgi-ceph:
     name: Cent OS 6 Local fastcgi Repo
     baseurl: http://gitbuilder.ceph.com/mod_fastcgi-rpm-centos6-x86_64-basic/ref/master/
-    enabled: 1
+    enabled: 0
     gpgcheck: 0
     priority: 2
   centos6-misc-ceph:
@@ -90,7 +90,7 @@ packages:
   - httpd-devel
   - httpd-tools
   - mod_ssl
-  - mod_fastcgi-2.4.7-1.ceph.el6
+  #- mod_fastcgi-2.4.7-1.ceph.el6
   ###
   - libevent-devel
   - python-devel

--- a/roles/testnode/vars/centos_7.yml
+++ b/roles/testnode/vars/centos_7.yml
@@ -5,7 +5,7 @@ yum_repos:
   centos7-fcgi-ceph:
     name: CentOS 7 Local fastcgi Repo
     baseurl: http://gitbuilder.ceph.com/mod_fastcgi-rpm-centos7-x86_64-basic/ref/master/
-    enabled: 1
+    enabled: 0
     gpgcheck: 0
     priority: 2
   lab-extras:
@@ -75,7 +75,7 @@ packages:
   - httpd-devel
   - httpd-tools
   - mod_ssl
-  - mod_fastcgi-2.4.7-1.ceph.el7.centos
+  #- mod_fastcgi-2.4.7-1.ceph.el7.centos
   ###
   - libevent-devel
   # for pretty-printing xml

--- a/roles/testnode/vars/debian_7.yml
+++ b/roles/testnode/vars/debian_7.yml
@@ -1,7 +1,7 @@
 ---
 apt_repos:
   - "deb http://ceph.com/debian-dumpling/ wheezy main"
-  - "deb http://gitbuilder.ceph.com/libapache-mod-fastcgi-deb-wheezy-x86_64-basic/ref/master/ wheezy main"
+#  - "deb http://gitbuilder.ceph.com/libapache-mod-fastcgi-deb-wheezy-x86_64-basic/ref/master/ wheezy main"
 
 packages:
   - lsb-release
@@ -102,5 +102,5 @@ packages_to_upgrade:
   - apt
   - libcurl3-gnutls
   - apache2
-  - libapache2-mod-fastcgi
+  #- libapache2-mod-fastcgi
   - libfcgi0ldbl

--- a/roles/testnode/vars/debian_8.yml
+++ b/roles/testnode/vars/debian_8.yml
@@ -100,5 +100,5 @@ packages_to_upgrade:
   - apt
   - libcurl3-gnutls
   - apache2
-  - libapache2-mod-fastcgi
+  #- libapache2-mod-fastcgi
   - libfcgi0ldbl

--- a/roles/testnode/vars/fedora_20.yml
+++ b/roles/testnode/vars/fedora_20.yml
@@ -3,7 +3,7 @@ yum_repos:
   fedora-fcgi-ceph:
     name: Fedora Local fastcgi Repo
     baseurl: http://gitbuilder.ceph.com/mod_fastcgi-rpm-fedora20-x86_64-basic/ref/master/
-    enabled: 1
+    enabled: 0
     gpgcheck: 0
     priority: 0
 
@@ -80,7 +80,7 @@ packages:
   - httpd-devel
   - httpd-tools
   - mod_ssl
-  - mod_fastcgi-2.4.7-1.ceph.fc20
+  #- mod_fastcgi-2.4.7-1.ceph.fc20
   ###
   - libevent-devel
   - python-devel

--- a/roles/testnode/vars/ubuntu.yml
+++ b/roles/testnode/vars/ubuntu.yml
@@ -1,7 +1,7 @@
 ---
-common_apt_repos:
+#common_apt_repos:
   # mod_fastcgi for radosgw
-  - "deb http://gitbuilder.ceph.com/libapache-mod-fastcgi-deb-{{ansible_distribution_release}}-x86_64-basic/ref/master/ {{ansible_distribution_release}} main"
+#  - "deb http://gitbuilder.ceph.com/libapache-mod-fastcgi-deb-{{ansible_distribution_release}}-x86_64-basic/ref/master/ {{ansible_distribution_release}} main"
 
 common_packages:
   # for apache
@@ -107,7 +107,7 @@ common_packages:
 packages_to_upgrade:
   - apt
   - apache2
-  - libapache2-mod-fastcgi
+  #- libapache2-mod-fastcgi
 
 packages_to_remove:
    # openmpi-common conflicts with mpitch stuff


### PR DESCRIPTION
This is temporary since we don't have those repos on the new gitbuilder
archive yet. Once we do, we should remove these mentions and replace
them with code in teuthology tasks which need fastcgi.

Signed-off-by: Zack Cerza <zack@redhat.com>