### PR TITLE
Disable lab-extras repo and iozone installs

### DIFF
--- a/roles/testnode/vars/centos_6.yml
+++ b/roles/testnode/vars/centos_6.yml
@@ -23,7 +23,7 @@ yum_repos:
   lab-extras:
     name: lab-extras
     baseurl: "http://{{ mirror_host }}/lab-extras/centos6/"
-    enabled: 1
+    enabled: 0
     gpgcheck: 0
     priority: 2
 
@@ -64,7 +64,7 @@ packages:
   - mpich2-devel
   - ant
   - fsstress
-  - iozone
+  #- iozone
   ###
   # used by the xfstests tasks
   - libtool

--- a/roles/testnode/vars/centos_7.yml
+++ b/roles/testnode/vars/centos_7.yml
@@ -11,7 +11,7 @@ yum_repos:
   lab-extras:
     name: lab-extras
     baseurl: "http://{{ mirror_host }}/lab-extras/centos7/"
-    enabled: 1
+    enabled: 0
     gpgcheck: 0
     priority: 2
 
@@ -48,7 +48,7 @@ packages:
   - python-nose
   - mpich
   - ant
-  - iozone
+  #- iozone
   ###
   # used by the xfstests tasks
   - libtool

--- a/roles/testnode/vars/redhat_6.yml
+++ b/roles/testnode/vars/redhat_6.yml
@@ -5,7 +5,7 @@ common_yum_repos:
   lab-extras:
     name: "lab-extras"
     baseurl: "http://{{ mirror_host }}/lab-extras/rhel6/"
-    enabled: 1
+    enabled: 0
     gpgcheck: 0
     priority: 2
   centos6-misc-ceph:
@@ -46,7 +46,7 @@ packages:
   - mpich2
   - ant
   - fsstress
-  - iozone
+  #- iozone
   ###
   # used by the xfstests tasks
   - libtool

--- a/roles/testnode/vars/redhat_7.yml
+++ b/roles/testnode/vars/redhat_7.yml
@@ -5,7 +5,7 @@ common_yum_repos:
   lab-extras:
     name: "lab-extras"
     baseurl: "http://{{ mirror_host }}/lab-extras/rhel7/"
-    enabled: 1
+    enabled: 0
     gpgcheck: 0
     priority: 2
 
@@ -38,7 +38,7 @@ packages:
   - mpich
   - ant
   - lsof
-  - iozone
+  #- iozone
   - libtool
   - automake
   - gettext


### PR DESCRIPTION
Tests invoking iozone will still fail. But it's better than nothing, at
least until we get the apt-mirror data we're missing.

Signed-off-by: Zack Cerza <zack@redhat.com>