### PR TITLE
puddle: ceph-1.3.z adjustments

### DIFF
--- a/roles/puddle/templates/ceph-1.3-rhel-7-async.conf
+++ b/roles/puddle/templates/ceph-1.3-rhel-7-async.conf
@@ -4,9 +4,9 @@
 
 [puddle]
 type = errata
-errata_release = CEPH-1.3.0,CEPH-ASYNC
+errata_release = CEPH-1.3.0,CEPH-1.3.z,CEPH-ASYNC
 product_name = RHCeph
-version = 1.3.0-async-RHEL-7
+version = 1.3-async-RHEL-7
 rootdir = /var/www/{{ ansible_hostname }}/htdocs/puddles
 emails = {{ puddle.emails }}
 signed = no

--- a/roles/puddle/templates/ceph-1.3.z-rhel-7.conf
+++ b/roles/puddle/templates/ceph-1.3.z-rhel-7.conf
@@ -6,7 +6,7 @@
 type = errata
 errata_release = CEPH-1.3.0,CEPH-1.3.z,CEPH-ASYNC
 product_name = RHCeph
-version = 1.3.1-RHEL-7
+version = 1.3.2-RHEL-7
 rootdir = /var/www/{{ ansible_hostname }}/htdocs/puddles
 emails = {{ puddle.emails }}
 signed = no


### PR DESCRIPTION
Now that RHCS 1.3.1 is released,

* Tweak the version numbers in Puddle. These numbers are cosmetic and control the names of the directories where Puddle puts its output. As explained in bfc268d7d11ce4757f44a8729830dff9ecb93df9, the purpose of the separate output directories is to allow the RH QE team to distinguish between "the next micro RHCS release" (in this case, 1.3.2), and any async updates we will ship for RHCS 1.3 in the meantime.

* Add ceph-1.3.z to the list of advisories to query in Red Hat's Errata Tool.