### PR TITLE
testnodes: fixing nrpe service configuration setup order

### DIFF
--- a/roles/testnode/tasks/nagios.yml
+++ b/roles/testnode/tasks/nagios.yml
@@ -8,18 +8,18 @@
     mode: 0440
     validate: visudo -cf %s
 
-- name: Upload nagios nrpe config.
-  template:
-    src: nagios/nrpe.cfg 
-    dest: /etc/nagios/nrpe.cfg
-    owner: root
-    group: root
-    mode: 0644
-
 - name: Configure nagios nrpe settings.
   template:
     src: nagios/nagios-nrpe-server
     dest: "/etc/default/{{ nrpe_service_name }}"
+    owner: root
+    group: root
+    mode: 0644
+
+- name: Upload nagios nrpe config.
+  template:
+    src: nagios/nrpe.cfg 
+    dest: /etc/nagios/nrpe.cfg
     owner: root
     group: root
     mode: 0644


### PR DESCRIPTION
- Undo commit 2f28215cf79e596142986c8835040e5b1676849b
  - Service should be restarted after nrpe.cfg is modified; not after the /etc/default/{{ nrpe_service_name }} file is modified
  - /etc/default/{{ nrpe_service_name }} gets read anytime service is restarted

Signed-off-by: David Galloway <dgallowa@redhat.com>