### PR TITLE
Revert "testnode: do not install fastcgi on RHEL"

### DIFF
--- a/roles/testnode/vars/redhat_6.yml
+++ b/roles/testnode/vars/redhat_6.yml
@@ -10,7 +10,7 @@ common_yum_repos:
     priority: 2
   centos6-fcgi-ceph:
     name: "Cent OS 6 Local fastcgi Repo"
-    baseurl: http://gitbuilder.ceph.com/mod_fastcgi-rpm-rhel6-x86_64-basic/ref/master/
+    baseurl: "http://{{ gitbuilder_host }}/mod_fastcgi-rpm-rhel6-x86_64-basic/ref/master/"
     enabled: 1
     gpgcheck: 0
     priority: 2

--- a/roles/testnode/vars/redhat_6.yml
+++ b/roles/testnode/vars/redhat_6.yml
@@ -8,6 +8,12 @@ common_yum_repos:
     enabled: 1
     gpgcheck: 0
     priority: 2
+  centos6-fcgi-ceph:
+    name: "Cent OS 6 Local fastcgi Repo"
+    baseurl: http://gitbuilder.ceph.com/mod_fastcgi-rpm-rhel6-x86_64-basic/ref/master/
+    enabled: 1
+    gpgcheck: 0
+    priority: 2
   centos6-misc-ceph:
     name: "Cent OS 6 Local misc Repo"
     baseurl: "http://{{ mirror_host }}/misc-rpms/"
@@ -72,6 +78,7 @@ packages:
   - httpd-devel
   - httpd-tools
   - mod_ssl
+  - mod_fastcgi-2.4.7-1.ceph.el6
   ###
   - libevent-devel
   # for pretty-printing xml

--- a/roles/testnode/vars/redhat_7.yml
+++ b/roles/testnode/vars/redhat_7.yml
@@ -2,6 +2,12 @@
 # vars specific to any rhel 7.x version
 
 common_yum_repos:
+  rhel-7-fcgi-ceph:
+    name: "RHEL 7 Local fastcgi Repo"
+    baseurl: http://gitbuilder.ceph.com/mod_fastcgi-rpm-rhel7-x86_64-basic/ref/master/
+    enabled: 1
+    gpgcheck: 0
+    priority: 2
   lab-extras:
     name: "lab-extras"
     baseurl: "http://{{ mirror_host }}/lab-extras/rhel7/"
@@ -56,6 +62,7 @@ packages:
   - httpd-devel
   - httpd-tools
   - mod_ssl
+  - mod_fastcgi-2.4.7-1.ceph.el7
   - libevent-devel
   - perl-XML-Twig
   - java-1.6.0-openjdk-devel

--- a/roles/testnode/vars/redhat_7.yml
+++ b/roles/testnode/vars/redhat_7.yml
@@ -4,7 +4,7 @@
 common_yum_repos:
   rhel-7-fcgi-ceph:
     name: "RHEL 7 Local fastcgi Repo"
-    baseurl: http://gitbuilder.ceph.com/mod_fastcgi-rpm-rhel7-x86_64-basic/ref/master/
+    baseurl: "http://{{ gitbuilder_host }}/mod_fastcgi-rpm-rhel7-x86_64-basic/ref/master/"
     enabled: 1
     gpgcheck: 0
     priority: 2


### PR DESCRIPTION
Sorry didn't realize without this rgw swift tests will fail on rhel, we will need this on rhel but should document for qe folks to uninstall it during upgrade tests.

Reverts ceph/ceph-cm-ansible#166