### PR TITLE
Add 'nokeymap' to inktank-rescue cobbler profile's kernel options

### DIFF
--- a/roles/cobbler_profile/defaults/main.yml
+++ b/roles/cobbler_profile/defaults/main.yml
@@ -5,6 +5,7 @@ distros:
   # set in the secrets repo.
   "inktank-rescue":
       iso: ""
+      kernel_options: "nokeymap"
   "dban-2.3.0-autonuke":
       iso: ""
   "RHEL-6.6-Server-x86_64":


### PR DESCRIPTION
This stops it prompting for a keymap on boot.

Signed-off-by: Dan Mick <dan.mick@redhat.com>