### PR TITLE
puddle: fixes for ceph-1.3-async and distill

### DIFF
--- a/roles/puddle/templates/ceph-1.3-rhel-7-async.conf
+++ b/roles/puddle/templates/ceph-1.3-rhel-7-async.conf
@@ -26,7 +26,7 @@ keys = fd431d51,f21541eb
 
 [Server-RH7-CEPH-INSTALLER-1.3]
 variant = Server-RH7-CEPH-INSTALLER-1.3
-external = {{ puddle.rhel_7_server_repo_url }}
+external = {{ puddle.rhel_7_server_repo_url }},{{ puddle.rhel_7_scl_repo_url }}
 keys = fd431d51,f21541eb
 
 [Server-RH7-CEPH-MON-1.3]

--- a/roles/puddle/templates/distill/ceph-distill
+++ b/roles/puddle/templates/distill/ceph-distill
@@ -25,7 +25,6 @@ compose_config=1.3-compose-trees
 # and loop over more compose_configs here.
 
 target=/var/www/{{ ansible_hostname }}/htdocs/distill/$compose_config
-compose_id=$(cat $target/latest-Ceph-1-RHEL-7/COMPOSE_ID)
 
 # Cleanup temporary files that we don't need and take up space
 pushd $target/latest-Ceph-1-RHEL-7


### PR DESCRIPTION
The first commit adds the SCL repository to the ceph-1.3-async configuration.
In RHCeph 1.3.1, we introduced Foreman, which has a dependency on the SCL
product. All async updates after this must use the SCL repo for repoclosure.

The second commit fixes an issue where our Distill wrapper script would fail
when Distill's "latest" symlink was not present.