### PR TITLE
Add vmhost role, supporting tasks, to provision VPS hosts

### DIFF
--- a/roles/vmhost/README.rst
+++ b/roles/vmhost/README.rst
@@ -1,0 +1,56 @@
+vmhost
+======
+
+This role does a lot of the setup for a mira node running Ubuntu
+(probably sticking with an LTS of trusty or later is a good idea;
+trusty is where it's got the most testing) to turn it into a
+'standard' VPS host.  Our standard is: 8 qemu-kvm virtual machines,
+provisioned by libvirt through downburst, as noted in the lock
+database on paddles for the sepia lab.  The first of those uses
+data storage sharing the root drive, and the last seven use
+the seven free mira drives as their storage pool.
+
+This role does not set up the storage pool directories/mount
+points, and does not add any mapping of which vpm VMs belong
+on any particular node (from the vps_hosts group).  It assumes
+that you have already:
+
+- created /srv/libvirtpool on the vmhost
+
+- made subdirs there named after the vpms
+
+On mira, we then use disks b..h as separate filesystems to
+mount on vpmNNN+1..vpmNNN+7, so for miras, we will have:
+
+- made filesystems (xfs is the usual choice)
+
+- mounted those filesystems on /srv/libvirtpool/<vpm#2--N>
+
+- added UUID= lines to /etc/fstab so the mounts happen at reboot
+
+Note that the role does not assume any particular structure
+of what provides /srv/libvirtpool/vpmNNN, but simply uses that
+to drive creating libvirt pools.
+
+It is certainly possible to do the above with ansible as well,
+and a later version may.
+
+
+Variables
++++++++++
+
+Only one variable is defined, ``vmhost_apt_packages``.  The default
+is empty, but the current definition in vars/ is not expected to change
+soon.
+
+Tags
+++++
+
+packages
+    Just install packages
+
+networking
+    Set up the bridge for qemu to use as the 'front' network
+
+libvirt
+    All the libvirt-related setup (pools, networks, etc.)

--- a/roles/vmhost/files/interfaces
+++ b/roles/vmhost/files/interfaces
@@ -1,0 +1,12 @@
+auto lo
+iface lo inet loopback
+
+iface eth0 inet manual
+
+auto br-front
+iface br-front inet dhcp
+  bridge_ports eth0
+  bridge_fd 9
+  bridge_hello 2
+  bridge_maxage 12
+  bridge_stp off

--- a/roles/vmhost/files/libvirt-net-front.xml
+++ b/roles/vmhost/files/libvirt-net-front.xml
@@ -1,0 +1,5 @@
+<network>
+  <name>front</name>
+  <bridge name='br-front'/>
+  <forward mode='bridge'/>
+</network>

--- a/roles/vmhost/tasks/libvirt.yml
+++ b/roles/vmhost/tasks/libvirt.yml
@@ -1,0 +1,131 @@
+---
+# default pool
+- name: Query libvirt pool 'default'
+  command: virsh pool-uuid default
+  register: pool_uuid
+  failed_when: false
+
+- name: Define libvirt pool 'default'
+  command: virsh pool-define-as --name default dir --target /var/lib/libvirt/images
+  when: pool_uuid is defined and pool_uuid | failed
+
+- name: Query 'default' pool state
+  command: virsh -q pool-info default
+  ignore_errors: yes
+  register: default_pool_info
+
+- name: Start pool 'default'
+  command: virsh pool-start default
+  when: 'default_pool_info is defined and default_pool_info.stdout|search("State:  *inactive")'
+
+- name: Autostart pool 'default'
+  command: virsh pool-autostart default
+  when: 'default_pool_info is defined and default_pool_info.stdout | search("Autostart:  *no")'
+
+# Per-vpm storage pools
+
+- name: Test for /srv/libvirtpool
+  stat:
+    path: /srv/libvirtpool
+  register: srv_libvirtpool
+  failed_when: srv_libvirtpool.stat.exists is False
+
+- name: Ensure proper ownership in /srv/libvirtpool
+  file: 
+    path: /srv/libvirtpool
+    state: directory
+    owner: libvirt-qemu
+    group: kvm
+    recurse: yes
+  when: srv_libvirtpool.stat.exists
+
+# the dance here is to figure out which pools are already defined,
+# and avoid trying to defining them again.
+
+- name: Find defined vpm names
+  command: ls /srv/libvirtpool
+  register: ls_libvirtpool
+  when: srv_libvirtpool.stat.exists
+
+- name: See which pools are defined and which are not
+  shell: virsh pool-info {{ item }}
+  with_items: ls_libvirtpool.stdout_lines
+  register: pool_info
+  when: srv_libvirtpool.stat.exists
+  # don't bother reporting anything about this command; it's not useful
+  failed_when: false
+
+# pool_info.results is a now list of dicts, one per item, with 'rc',
+# 'changed', 'stdout', 'stderr' etc.  Make a new list for
+# all of the above that failed (i.e. rc == 1), as those
+# are the pools that still need definition.  "" stop
+# jinja templating from being confused with yaml, as usual;
+# {%- and -%} suppress blank lines so that the only thing
+# that expands is the list declaration.
+
+- name: Form list of undefined pools
+  set_fact:
+    pools_to_define:
+      "{%- set l = [] %}
+      {%- for result in pool_info.results %}
+        {%- if result.rc == 1 %}
+          {%- set dummy = l.append(result.item) %}
+        {%- endif %}
+      {%- endfor -%}
+      {{ l | list }}"
+
+- name: Define pools which are left to be defined
+  shell: |
+    virsh pool-define-as --name {{ item | quote }} --type dir --target /srv/libvirtpool/{{ item }};
+    virsh pool-autostart {{ item | quote }};
+    virsh pool-build {{ item | quote }};
+    virsh pool-start {{ item | quote }}
+  with_items: pools_to_define
+  when: pools_to_define|length > 0
+
+# Front network
+
+- name: Query for front network definition
+  command: virsh net-info front
+  failed_when: false
+  register: front_net
+
+- name: Send front network definition file
+  copy:
+    src: ../files/libvirt-net-front.xml
+    dest: /tmp/libvirt-net-front.xml
+  when: front_net is defined and front_net | failed
+
+- name: Create front network
+  command: virsh net-define /tmp/libvirt-net-front.xml
+  when: front_net is defined and front_net | failed
+
+- name: Remove tmp network definition file
+  file:
+    dest: /tmp/libvirt-net-front.xml
+    state: absent
+  when: front_net is defined and front_net | failed
+
+- name: Re-query for front network definition
+  command: virsh net-info front
+  ignore_errors: yes
+  register: front_net
+
+- name: Start front network
+  command: virsh net-start front
+  when: 'front_net is defined and front_net.stdout | search("Active:  *no")'
+
+- name: Set front network to autostart
+  command: virsh net-autostart front
+  when: 'front_net is defined and front_net.stdout | search("Autostart:  *no")'
+
+# Final steps
+
+- name: Allow libvirt for teuthology user
+  user:
+    name: "{{ teuthology_user }}"
+    groups: libvirtd
+    append: yes
+
+- name: Restart libvirt-bin
+  command: service libvirt-bin restart

--- a/roles/vmhost/tasks/main.yml
+++ b/roles/vmhost/tasks/main.yml
@@ -1,0 +1,8 @@
+- include: packages.yml
+  tags: packages
+
+- include: networking.yml
+  tags: networking
+
+- include: libvirt.yml
+  tags: libvirt

--- a/roles/vmhost/tasks/networking.yml
+++ b/roles/vmhost/tasks/networking.yml
@@ -1,0 +1,17 @@
+# front_mac = ansible_eth0.macaddress
+# front_ip = ansible_eth0.ipv4.address
+
+- name: Install /etc/network/interfaces
+  copy:
+    src: interfaces
+    dest: /etc/network/interfaces
+    force: yes
+    owner: root
+    group: root
+    mode: 0644
+    backup: yes
+  register: interface_install
+
+- name: Activate new network config
+  shell: /sbin/ifdown -a; /sbin/ifup -a
+  when: interface_install|changed

--- a/roles/vmhost/tasks/packages.yml
+++ b/roles/vmhost/tasks/packages.yml
@@ -1,0 +1,10 @@
+---
+- name: Install packages via apt
+  apt:
+    name: "{{ item }}"
+    state: latest
+    update_cache: yes
+    cache_valid_time: 600
+  with_items: "{{ vmhost_apt_packages }}"
+  tags:
+    - packages

--- a/roles/vmhost/vars/main.yml
+++ b/roles/vmhost/vars/main.yml
@@ -1,0 +1,5 @@
+---
+vmhost_apt_packages:
+  - qemu-kvm
+  - libvirt-bin
+  - bridge-utils

--- a/vmhost.yml
+++ b/vmhost.yml
@@ -1,0 +1,4 @@
+---
+- hosts: vps_hosts
+  roles:
+    - vmhost


### PR DESCRIPTION
This is mostly a transliteration, minus the unneeded/obsolete bits, of cookbook-vm-general.  It assumes that a host is installed and has had /srv/libvirtpool/vpmNNN set up to support the specific VMs that should live on this host.  For mira, that means the first vpm dir is on the root drive, and the 2-8th are on mounted filesystems.

Possible enhancement: make a map of vpm-to-vmhost in Ansible vars, and use it to drive the 'create /srv/libvirtpool' automatically.