### PR TITLE
Fixing srv_libvirtpool check syntax

### DIFF
--- a/roles/vmhost/tasks/libvirt.yml
+++ b/roles/vmhost/tasks/libvirt.yml
@@ -28,7 +28,7 @@
   stat:
     path: /srv/libvirtpool
   register: srv_libvirtpool
-  failed_when: srv_libvirtpool.stat.exists is False
+  failed_when: srv_libvirtpool.stat.exists == False
 
 - name: Ensure proper ownership in /srv/libvirtpool
   file: 


### PR DESCRIPTION
Signed-off-by: David Galloway <dgallowa@redhat.com>