### PR TITLE
Fixes http://tracker.ceph.com/issues/14729

### DIFF
--- a/roles/cobbler/templates/snippets/cephlab_packages_rhel
+++ b/roles/cobbler/templates/snippets/cephlab_packages_rhel
@@ -1,8 +1,8 @@
 ## {{ ansible_managed }}
 ## @base group no longer exists in >=Fedora-22
 #set distro = $getVar('distro','').split("-")[0]
-#set distro_ver = $int($getVar('distro','').split("-")[1])
-#if $distro == 'Fedora' and $distro_ver >= 22
+#set distro_ver = $getVar('distro','').split("-")[1]
+#if $distro == 'Fedora' and int($distro_ver) >= 22
 @^infrastructure-server-environment
 #else
 @base

--- a/roles/cobbler/templates/snippets/cephlab_rc_local
+++ b/roles/cobbler/templates/snippets/cephlab_rc_local
@@ -2,8 +2,8 @@
 #set lockfile = '/.cephlab_rc_local'
 # Set proper location for firstboot ansible post-install trigger
 #set distro = $getVar('distro','').split("-")[0]
-#set distro_ver = $int($getVar('distro','').split("-")[1])
-#if $distro == 'Fedora' and $distro_ver >= 22
+#set distro_ver = $getVar('distro','').split("-")[1]
+#if $distro == 'Fedora' and int($distro_ver) >= 22
 #set script = '/etc/rc.d/rc.local'
 #else
 #set script = '/etc/rc.local'


### PR DESCRIPTION
Cobbler would fail to create kickstart because non-Fedora distros would return 7.X, for example, as the integer resulting in non-Fedora kickstart creation to fail

Fixes: #14790

Signed-off-by: David Galloway <dgallowa@redhat.com>