### PR TITLE
ansible.cfg: do not set vault_password_file

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,4 +2,4 @@
 ansible_managed = This file is managed by ansible, don't make changes here - they will be overwritten.
 # this works when testing from my laptop, but will need to
 # be changed when it lives in a production environment
-vault_password_file = ~/.vault_pass.txt
+#vault_password_file = ~/.vault_pass.txt


### PR DESCRIPTION
So that ansible-playbook can run from the root of the repository and not
pick up this value which is unlikely to be correct.

http://tracker.ceph.com/issues/14914 Fixes: #14914

Signed-off-by: Loic Dachary <loic@dachary.org>