### PR TITLE
testnodes: Disable ssl requirement for nrpe on rpm-based distros

### DIFF
--- a/roles/testnode/tasks/nagios.yml
+++ b/roles/testnode/tasks/nagios.yml
@@ -8,13 +8,19 @@
     mode: 0440
     validate: visudo -cf %s
 
-- name: Configure nagios nrpe settings.
-  template:
-    src: nagios/nagios-nrpe-server
-    dest: "/etc/default/{{ nrpe_service_name }}"
-    owner: root
-    group: root
-    mode: 0644
+- name: Configure nagios nrpe settings (Ubuntu)
+  lineinfile:
+    dest: /etc/default/{{ nrpe_service_name }}
+    regexp: "^DAEMON_OPTS"
+    line: "DAEMON_OPTS=\"--no-ssl\""
+  when: ansible_pkg_mgr == "apt"
+
+- name: Configure nagios nrpe settings (RHEL/CentOS)
+  lineinfile:
+    dest: /etc/sysconfig/{{ nrpe_service_name }}
+    regexp: "^NRPE_SSL_OPT"
+    line: "NRPE_SSL_OPT=\"-n\""
+  when: ansible_pkg_mgr == "yum"
 
 - name: Upload nagios nrpe config.
   template:

--- a/roles/testnode/templates/nagios/nagios-nrpe-server
+++ b/roles/testnode/templates/nagios/nagios-nrpe-server
@@ -1,1 +1,0 @@
-DAEMON_OPTS="--no-ssl"


### PR DESCRIPTION
The variable name the systemd nrpe service looks for is <code>NRPE_SSL_OPT</code>
See <code>/usr/lib/systemd/system/nrpe.service</code>
The variable name nrpe on Ubuntu looks for is <code>DAEMON_OPTS</code>

Since the variable name *and* default configuration location differ between distros, we can get rid of the <code>roles/testnode/templates/nagios/nagios-nrpe-server</code> template and just set the single variable instructing NRPE to not use SSL.

Signed-off-by: David Galloway <dgallowa@redhat.com>