### PR TITLE
cobbler: set testnodes timezone during kickstart

### DIFF
--- a/roles/cobbler/templates/kickstarts/cephlab_rhel.ks
+++ b/roles/cobbler/templates/kickstarts/cephlab_rhel.ks
@@ -33,7 +33,7 @@ selinux --permissive
 # Do not configure the X Window System
 skipx
 # System timezone
-timezone  America/New_York
+timezone Etc/UTC --utc
 # Install OS instead of upgrade
 install
 

--- a/roles/cobbler/templates/kickstarts/cephlab_ubuntu.preseed
+++ b/roles/cobbler/templates/kickstarts/cephlab_ubuntu.preseed
@@ -31,11 +31,17 @@ d-i mirror/suite string $os_version
 # Stop Ubuntu from installing random kernel choice
 #d-i base-installer/kernel/image select none
 
+# Controls whether or not the hardware clock is set to UTC.
+d-i clock-setup/utc boolean true
+#
+# # You may set this to any valid setting for $TZ; see the contents of
+# # /usr/share/zoneinfo/ for valid values.
+d-i time/zone string Etc/UTC
+
 # Controls whether to use NTP to set the clock during the install
 d-i clock-setup/ntp boolean true
 # NTP server to use. The default is almost always fine here.
 d-i clock-setup/ntp-server string pool.ntp.org
-
 
 # This makes partman automatically partition without confirmation.
 #d-i partman/confirm_write_new_label boolean true


### PR DESCRIPTION
testnodes get set to UTC as part of the testnodes playbook anyway.

This particular commit sets the right timezone from firstboot so no DHCP/NetworkManager/ntp confusion happens.
See http://tracker.ceph.com/issues/15126#note-2
And https://bugzilla.redhat.com/show_bug.cgi?id=1093803

Signed-off-by: David Galloway <dgallowa@redhat.com>