### PR TITLE
testnode: add check to make sure NRPE service is running

### DIFF
--- a/roles/testnode/README.rst
+++ b/roles/testnode/README.rst
@@ -183,7 +183,7 @@ monitoring-scripts
     Uploads custom disk monitoring scripts. See, ``roles/testnode/tasks/disk_monitoring.yml``.
 
 nagios
-    Configure nagios nrpe server for apt systems. 
+    Configure nagios nrpe service. 
 
 nfs
     Install and start nfs.

--- a/roles/testnode/tasks/nagios.yml
+++ b/roles/testnode/tasks/nagios.yml
@@ -31,3 +31,9 @@
     mode: 0644
   notify:
     - restart nagios-nrpe-server
+
+- name: Make sure nagios nrpe service is running.
+  service:
+    name: "{{nrpe_service_name}}"
+    enabled: yes
+    state: started


### PR DESCRIPTION
Nothing had previously enabled the service to start at boot.
<pre>
[root@smithi014 ~]# systemctl list-unit-files nrpe.service
UNIT FILE    STATE   
nrpe.service disabled
</pre>

Signed-off-by: David Galloway <dgallowa@redhat.com>