### PR TITLE
testnodes: Configure per-OS nrpe user and group name

### DIFF
--- a/roles/testnode/tasks/nagios.yml
+++ b/roles/testnode/tasks/nagios.yml
@@ -34,6 +34,6 @@
 
 - name: Make sure nagios nrpe service is running.
   service:
-    name: "{{nrpe_service_name}}"
+    name: "{{ nrpe_service_name }}"
     enabled: yes
     state: started

--- a/roles/testnode/templates/nagios/90-nagios
+++ b/roles/testnode/templates/nagios/90-nagios
@@ -1,2 +1,2 @@
 ## {{ ansible_managed }}
-nagios ALL=NOPASSWD: /usr/sbin/megacli, /usr/sbin/cli64, /usr/sbin/smartctl, /usr/sbin/smartctl
+{{ nrpe_user }} ALL=NOPASSWD: /usr/sbin/megacli, /usr/sbin/cli64, /usr/sbin/smartctl, /usr/sbin/smartctl

--- a/roles/testnode/templates/nagios/nrpe.cfg
+++ b/roles/testnode/templates/nagios/nrpe.cfg
@@ -2,8 +2,8 @@
 log_facility=daemon
 pid_file=/var/run/nagios/nrpe.pid
 server_port=5666
-nrpe_user=nagios
-nrpe_group=nagios
+nrpe_user={{ nrpe_user }}
+nrpe_group={{ nrpe_group }}
 
 # These should eventually be in a secrets group_var
 # 172. address is sepia nagios server

--- a/roles/testnode/vars/apt_systems.yml
+++ b/roles/testnode/vars/apt_systems.yml
@@ -3,6 +3,8 @@ ntp_service_name: ntp
 ssh_service_name: ssh
 nfs_service: nfs-kernel-server
 nrpe_service_name: nagios-nrpe-server
+nrpe_user: nagios
+nrpe_group: nagios
 nagios_plugins_directory: /usr/lib/nagios/plugins
 
 ceph_packages_to_remove:

--- a/roles/testnode/vars/yum_systems.yml
+++ b/roles/testnode/vars/yum_systems.yml
@@ -2,6 +2,8 @@
 ntp_service_name: ntpd
 ssh_service_name: sshd
 nrpe_service_name: nrpe
+nrpe_user: nrpe
+nrpe_group: nrpe
 nagios_plugins_directory: /usr/lib64/nagios/plugins
 
 # ceph packages that we ensure do not exist


### PR DESCRIPTION
NRPE on CentOS/RHEL ignore the nrpe_user variable in nrpe.cfg due to the
systemd init file.  See https://github.com/NagiosEnterprises/nrpe/issues/28

The 'nagios' user is created by default on *.deb
The 'nrpe' user is created by default on *.rpm

Further reading: https://www.mooash.me/2014/10/24/nagios-nrpe-ansible-role/

Signed-off-by: David Galloway <dgallowa@redhat.com>