### PR TITLE
common: Replace bad epel mirror

### DIFF
--- a/roles/common/templates/epel-mirrorlist
+++ b/roles/common/templates/epel-mirrorlist
@@ -3,5 +3,5 @@
 # local yum mirrorlist for epel-{{ ansible_distribution_major_version }}
 http://mirrors.cat.pdx.edu/epel/{{ ansible_distribution_major_version }}/$basearch
 http://mirror.pnl.gov/epel/{{ ansible_distribution_major_version }}/$basearch
-http://fedora-epel.mirror.lstn.net/{{ ansible_distribution_major_version }}/$basearch
+http://ftp.linux.ncsu.edu/pub/epel/{{ ansible_distribution_major_version }}/$basearch
 http://mirror.oss.ou.edu/epel/{{ ansible_distribution_major_version }}/$basearch


### PR DESCRIPTION
Mirror fedora-epel.mirror.lstn.net is almost a week out of date and
causing yum package transactions to fail due to bad repodata.  Replacing
with a mirror closer to the sepia and octo labs.

Fixes: http://tracker.ceph.com/issues/15539

Signed-off-by: David Galloway <dgallowa@redhat.com>