### PR TITLE
pcp: Correct /var/log/pcp permissions for collectors

### DIFF
--- a/roles/pcp/tasks/collector.yml
+++ b/roles/pcp/tasks/collector.yml
@@ -23,6 +23,8 @@
   when:
     ansible_pkg_mgr == "dnf"
 
+- include: permissons.yml
+
 - name: Restart pcp
   service:
     name: "{{ pmcd_service }}"

--- a/roles/pcp/tasks/manager.yml
+++ b/roles/pcp/tasks/manager.yml
@@ -72,12 +72,7 @@
     mode: 0644
   register: target_discovery
 
-- name: Ensure /var/log/pcp is owned by pcp
-  file:
-    path: /var/log/pcp
-    owner: "{{ pcp_user }}"
-    group: "{{ pcp_user }}"
-    recurse: yes
+- include: permissons.yml
 
 # This greatly speeds up polling for hosts
 - name: Set PMCD_CONNECT_TIMEOUT in pmmgr.options

--- a/roles/pcp/tasks/permissons.yml
+++ b/roles/pcp/tasks/permissons.yml
@@ -1,0 +1,7 @@
+---
+- name: Ensure /var/log/pcp is owned by pcp
+  file:
+    path: /var/log/pcp
+    owner: "{{ pcp_user }}"
+    group: "{{ pcp_user }}"
+    recurse: yes


### PR DESCRIPTION
http://tracker.ceph.com/issues/15575

Some hosts were getting a /var/log/pcp/pmmgr that was owned by root:root
for some reason.

Signed-off-by: Zack Cerza <zack@redhat.com>