### PR TITLE
testnode: Update SELinux policy when configuring NRPE

### DIFF
--- a/roles/testnode/tasks/nrpe-selinux.yml
+++ b/roles/testnode/tasks/nrpe-selinux.yml
@@ -9,6 +9,11 @@
     pkg: policycoreutils-python
     state: installed
 
+- name: nrpe - Ensure SELinux policy is up to date
+  yum:
+    pkg: selinux-policy-targeted
+    state: latest
+
 - name: nrpe - Set SELinux boolean nagios_run_sudo true
   seboolean:
     name: nagios_run_sudo


### PR DESCRIPTION
The 'nagios_run_sudo' boolean was added after RHEL7.1 GA.

Attempting to set the boolean when it's not present causes ansible
to fail.  NRPE will cause SELinux failures in test jobs unless set
so the only other option would be to disable NRPE on
RHEL/CentOS <= 7.1

This change ensures the testnode has the latest version of SELinux
policy installed, and thus, ensuring the boolean exists.

Signed-off-by: David Galloway <dgallowa@redhat.com>