### PR TITLE
cobbler: Prevent systemd from renaming NICs

### DIFF
--- a/roles/cobbler_profile/defaults/main.yml
+++ b/roles/cobbler_profile/defaults/main.yml
@@ -62,5 +62,5 @@ distros:
       iso: "http://releases.ubuntu.com/16.04/ubuntu-16.04-server-amd64.iso"
       sha256: b8b172cbdf04f5ff8adc8c2c1b4007ccf66f00fc6a324a6da6eba67de71746f6
       kickstart: cephlab_ubuntu.preseed
-      kernel_options: "netcfg/choose_interface=auto biosdevname=0 console=tty0 console=ttyS1,115200"
-      kernel_options_post: "pci=realloc=off console=tty0 console=ttyS1,115200"
+      kernel_options: "netcfg/choose_interface=auto biosdevname=0 net.ifnames=0 console=tty0 console=ttyS1,115200"
+      kernel_options_post: "pci=realloc=off console=tty0 console=ttyS1,115200 biosdevname=0 net.ifnames=0"


### PR DESCRIPTION
systemd in Xenial was renaming NICs to `eno1`.

Since we ship a static `/etc/network/interfaces` file with `eth0` as the only NIC name, networking wouldn't come up on boot.

Tested on clara and magna node.

Signed-off-by: David Galloway <dgallowa@redhat.com>