### PR TITLE
testnode: Update nagios CPU load thresholds to be less strict

### DIFF
--- a/roles/testnode/templates/nagios/nrpe.cfg
+++ b/roles/testnode/templates/nagios/nrpe.cfg
@@ -15,7 +15,7 @@ command_timeout=60
 connection_timeout=300
 
 command[check_users]={{ nagios_plugins_directory }}/check_users --warning=5 --critical=10
-command[check_load]={{ nagios_plugins_directory }}/check_load --percpu --warning=0.7,0.6,0.5 --critical=0.9,0.8,0.7
+command[check_load]={{ nagios_plugins_directory }}/check_load --percpu --warning=1.5,1.4,1.3 --critical=2.0,1.9,1.8
 command[check_hda1]={{ nagios_plugins_directory }}/check_disk --warning=20% --critical=10% --partition=/dev/hda1
 command[check_root]={{ nagios_plugins_directory }}/check_disk --warning=10% --critical=5% --units=GB --path=/
 command[check_zombie_procs]={{ nagios_plugins_directory }}/check_procs --warning=5 --critical=10 --state=Z


### PR DESCRIPTION
nagios monitoring still needs to be moved to the `common` role eventually but this should cut down on the noise .. mainly from irvingi06 and senta01.

Signed-off-by: David Galloway <dgallowa@redhat.com>