### PR TITLE
Network configuration for gateway role

### DIFF
--- a/roles/gateway/README.rst
+++ b/roles/gateway/README.rst
@@ -152,6 +152,5 @@ To Do
 
 - Support installation of new OpenVPN gateway from scratch
 - Generate and pull (to secrets?) CA, keys, and certificates
-- Configure log rotation
 
 .. _Sepia: https://ceph.github.io/sepia/

--- a/roles/gateway/README.rst
+++ b/roles/gateway/README.rst
@@ -8,6 +8,9 @@ This role supports CentOS 7.2 only at this time.  Its current intended use
 is to maintain the existing OpenVPN gateway in our Sepia_ lab.
 
 It does the following:
+- Configures network devices
+- Configures firewalld
+- Configures fail2ban
 - Installs and updates necessary packages
 - Maintains user list
 
@@ -58,6 +61,64 @@ A list of users that don't have their ssh pubkey added to the ``teuthology_user`
     openvpn_users:
       - ovpn: user@host etc...
 
+The following vars are used to populate ``/etc/resolv.conf``.  Defined in the
+secrets repo::
+
+    gw_resolv_search: []
+    # Example: gw_resolv_search: "front.example.com"
+
+    gw_resolv_ns: []
+    # Example:
+    gw_resolv_ns:
+      - 1.2.3.4
+      - 8.8.8.8
+
+The ``gw_networks`` dictionary assumes you have individual NICs for each
+VLAN in your lab.  The subelements ``peerdns`` and ``dns{1,2}`` are optional for
+all but one NIC.  These are what set your nameservers in
+``/etc/resolv.conf``.
+``dns1`` and ``dns2`` should be defined under a single NIC and ``peerdns``
+should be set to ``"yes"``.  Defined in the
+secrets repo::
+
+    # Example:
+    gw_networks:
+      private:
+        ifname: "eth0"
+        mac: "de:ad:be:ef:12:34"
+        ip4: "192.168.1.100"
+        netmask: "255.255.240.0"
+        gw4: "192.168.1.1"
+        defroute: "yes"
+        peerdns: "yes"
+        search "private.example.com"
+        dns1: "192.168.1.1"
+        dns2: "8.8.8.8"
+      public:
+        ifname: "eth1"
+        etc...
+
+The *fail2ban* vars are explained in /etc/fail2ban/jail.conf.  We've set
+defaults in ``roles/gateway/defaults/main.yml`` but they can be overridden in
+the secrets repo::
+
+    gw_f2b_ignoreip: "127.0.0.1/8"
+    gw_f2b_bantime: "43200"
+    gw_f2b_findtime: "600"
+    gw_f2b_maxretry: "5"
+
+``gw_f2b_services`` is a dictionary listing services fail2ban should monitor.  Defined in
+``roles/gateway/defaults/main.yml``.  See example below::
+
+    gw_f2b_services:
+      sshd:
+        enabled: "true"
+        port: "ssh"
+        logpath: "%(sshd_log)s"
+      apache:
+        enabled: "true"
+        port: "http"
+
 Tags
 ++++
 
@@ -66,6 +127,17 @@ packages
 
 users
     Update OpenVPN users list
+
+networking
+    Configure basic networking (NICs, IP forwarding, resolv.conf)
+
+firewall
+    Configure firewalld
+
+**NOTE:** Ansible v2.1 or later is required for the initial firewall setup as the ``masquerade`` parameter is new to that version.
+
+fail2ban
+    Configure fail2ban
 
 Dependencies
 ++++++++++++
@@ -80,9 +152,6 @@ To Do
 
 - Support installation of new OpenVPN gateway from scratch
 - Generate and pull (to secrets?) CA, keys, and certificates
-- Configure networking
-- Configure firewall
-- Configure fail2ban
 - Configure log rotation
 
 .. _Sepia: https://ceph.github.io/sepia/

--- a/roles/gateway/defaults/main.yml
+++ b/roles/gateway/defaults/main.yml
@@ -9,3 +9,6 @@ secrets_repo:
 openvpn_server_name: server
 
 openvpn_data_dir: /etc/openvpn/data
+
+gw_allow_http: "true"
+gw_allow_https: "true"

--- a/roles/gateway/defaults/main.yml
+++ b/roles/gateway/defaults/main.yml
@@ -12,3 +12,15 @@ openvpn_data_dir: /etc/openvpn/data
 
 gw_allow_http: "true"
 gw_allow_https: "true"
+
+# fail2ban-specific vars
+gw_f2b_ignoreip: "127.0.0.1/8"
+gw_f2b_bantime: "43200" # 12hrs
+gw_f2b_findtime: "600" # 10min
+gw_f2b_maxretry: "5"
+
+gw_f2b_services:
+  sshd:
+    enabled: "true"
+    port: "ssh"
+    logpath: "%(sshd_log)s"

--- a/roles/gateway/files/openvpn.logrotate
+++ b/roles/gateway/files/openvpn.logrotate
@@ -1,0 +1,9 @@
+/var/log/openvpn.log {
+	daily
+	size 100M
+	rotate 14
+	compress
+	missingok
+	copytruncate
+	create 644 nobody nobody
+}

--- a/roles/gateway/handlers/main.yml
+++ b/roles/gateway/handlers/main.yml
@@ -4,3 +4,15 @@
   service:
     name: network
     state: restarted
+
+# Restart fail2ban
+- name: restart fail2ban
+  service:
+    name: fail2ban
+    state: restarted
+
+# Reload fail2ban
+- name: reload fail2ban
+  service:
+    name: fail2ban
+    state: reloaded

--- a/roles/gateway/handlers/main.yml
+++ b/roles/gateway/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+# Restart networking
+- name: restart networking
+  service:
+    name: network
+    state: restarted

--- a/roles/gateway/tasks/fail2ban.yml
+++ b/roles/gateway/tasks/fail2ban.yml
@@ -1,0 +1,41 @@
+---
+- name: Write fail2ban defaults conf file
+  template:
+    src: templates/f2b.jail.local.j2
+    dest: /etc/fail2ban/jail.local
+  notify: restart fail2ban
+
+# Set a var equal to our ansible_managed var since ansible_managed
+# can't be called directly in the next task.
+# See https://github.com/ansible/ansible/issues/11317
+- name: Set f2b_grep_var to ansible_managed string
+  set_fact:
+    f2b_grep_var: "This file is managed by ansible, don't make changes here - they will be overwritten."
+
+# Remove all service files in case a malformed config was previously shipped.
+# Malformed service files cause fail2ban to not start.
+- name: Clean up ansible-written service conf files
+  shell: for file in $(grep -l {{ f2b_grep_var|quote }} /etc/fail2ban/jail.d/*); do rm -vf $file; done
+  register: f2b_rm_out
+
+# Show what files were deleted
+- debug: var=f2b_rm_out.stdout
+
+- name: Write fail2ban service conf files
+  template:
+    src: templates/f2b.service.j2
+    dest: "/etc/fail2ban/jail.d/{{ item.key }}.local"
+  with_dict: "{{ gw_f2b_services }}"
+  notify: reload fail2ban
+
+- name: Make sure fail2ban service is running
+  service:
+    name: fail2ban
+    state: started
+
+- name: Check fail2ban status
+  shell: fail2ban-client status
+  register: fail2ban_status
+
+# Show fail2ban status
+- debug: var=fail2ban_status.stdout_lines

--- a/roles/gateway/tasks/firewall.yml
+++ b/roles/gateway/tasks/firewall.yml
@@ -1,0 +1,60 @@
+---
+- name: Make sure iptables isn't running
+  service:
+    name: iptables
+    state: stopped
+    enabled: false
+  ignore_errors: true
+
+- name: Make sure firewalld is enabled
+  service:
+    name: firewalld
+    state: started
+    enabled: yes
+
+- name: firewalld | Allow openvpn traffic
+  firewalld:
+    service: openvpn
+    zone: public
+    state: enabled
+    permanent: true
+    immediate: yes
+
+- name: firewalld | Allow http traffic
+  firewalld:
+    service: http
+    zone: public
+    state: enabled
+    permanent: true
+    immediate: yes
+  when: gw_allow_http == "true"
+
+- name: firewalld | Allow https traffic
+  firewalld:
+    service: https
+    zone: public
+    state: enabled
+    permanent: true
+    immediate: yes
+  when: gw_allow_https =="true"
+
+# The following two tasks require Ansible v2.1 due to the 'masquerade'
+# and 'interface' parameters being new to that version.  They only need to be
+# run the first time the role is run so it's okay for them to be skipped.
+- name: firewalld | Add connection masquerading
+  firewalld:
+    masquerade: yes
+    zone: public
+    state: enabled
+    permanent: true
+    immediate: yes
+  when: "{{ ansible_version.major }} >= 2 and {{ ansible_version.minor }} >= 1"
+
+- name: firewalld | Add tun0 to internal zone
+  firewalld:
+    zone: internal
+    interface: tun0
+    state: enabled
+    permanent: true
+    immediate: yes
+  when: "{{ ansible_version.major }} >= 2 and {{ ansible_version.minor }} >= 1"

--- a/roles/gateway/tasks/main.yml
+++ b/roles/gateway/tasks/main.yml
@@ -15,6 +15,11 @@
   tags:
     - networking
 
+# Configure firewalld
+- include: firewall.yml
+  tags:
+    - firewall
+
 - name: Ensure data directory exists
   file:
     path: "{{ openvpn_data_dir }}"

--- a/roles/gateway/tasks/main.yml
+++ b/roles/gateway/tasks/main.yml
@@ -10,6 +10,11 @@
   tags:
     - packages
 
+# Configure networking
+- include: network.yml
+  tags:
+    - networking
+
 - name: Ensure data directory exists
   file:
     path: "{{ openvpn_data_dir }}"

--- a/roles/gateway/tasks/main.yml
+++ b/roles/gateway/tasks/main.yml
@@ -49,3 +49,8 @@
     name: "openvpn@{{ openvpn_server_name }}"
     state: started
     enabled: yes
+
+- name: Write logrotate conf file
+  copy:
+    src: files/openvpn.logrotate
+    dest: /etc/logrotate.d/openvpn

--- a/roles/gateway/tasks/main.yml
+++ b/roles/gateway/tasks/main.yml
@@ -20,6 +20,11 @@
   tags:
     - firewall
 
+# Configure fail2ban
+- include: fail2ban.yml
+  tags:
+    - fail2ban
+
 - name: Ensure data directory exists
   file:
     path: "{{ openvpn_data_dir }}"

--- a/roles/gateway/tasks/network.yml
+++ b/roles/gateway/tasks/network.yml
@@ -1,0 +1,36 @@
+---
+- name: Write ifcfg scripts
+  template:
+    src: ifcfg.j2
+    dest: "/etc/sysconfig/network-scripts/ifcfg-{{ item.value.ifname }}"
+  with_dict: "{{ gw_networks }}"
+  register: interfaces
+
+# Restart networking right away if changes made.  This makes sure
+# the public interface is up and ready for OpenVPN to bind to.
+- name: Restart networking
+  service:
+    name: network
+    state: restarted
+  when: interfaces.changed
+
+- name: Write resolv.conf
+  template:
+    src: resolvconf.j2
+    dest: "/etc/resolv.conf"
+
+- name: Disable IPv6
+  sysctl:
+    name: net.ipv6.conf.all.disable_ipv6
+    value: 1
+    sysctl_set: yes
+    state: present
+    reload: yes
+
+- name: Enable IPv4 forwarding
+  sysctl:
+    name: net.ipv4.ip_forward
+    value: 1
+    sysctl_set: yes
+    state: present
+    reload: yes

--- a/roles/gateway/templates/f2b.jail.local.j2
+++ b/roles/gateway/templates/f2b.jail.local.j2
@@ -1,0 +1,8 @@
+#
+# {{ ansible_managed }}
+#
+[DEFAULT]
+ignoreip = {{ gw_f2b_ignoreip }}
+bantime = {{ gw_f2b_bantime }}
+findtime = {{ gw_f2b_findtime }}
+maxretry = {{ gw_f2b_maxretry }}

--- a/roles/gateway/templates/f2b.service.j2
+++ b/roles/gateway/templates/f2b.service.j2
@@ -1,0 +1,9 @@
+#
+# {{ ansible_managed }}
+#
+[{{ item.key }}]
+enabled = {{ item.value.enabled }}
+port = {{ item.value.port }}
+{% if item.value.logpath is defined %}
+logpath = {{ item.value.logpath }}
+{% endif %}

--- a/roles/gateway/templates/ifcfg.j2
+++ b/roles/gateway/templates/ifcfg.j2
@@ -1,0 +1,27 @@
+#
+# {{ ansible_managed }}
+#
+NAME="{{ item.key }}"
+DEVICE="{{ item.value.ifname }}"
+HWADDR="{{ item.value.mac }}"
+NM_CONTROLLED="no"
+ONBOOT="yes"
+BOOTPROTO="static"
+IPADDR="{{ item.value.ip4 }}"
+NETMASK="{{ item.value.netmask }}"
+GATEWAY="{{ item.value.gw4 }}"
+DEFROUTE="{{ item.value.defroute }}"
+
+# Optional values
+{% if item.value.search is defined %}
+SEARCH="{{ item.value.search }}"
+{% endif %}
+{% if item.value.peerdns is defined %}
+PEERDNS="{{ item.value.peerdns }}"
+{% endif %}
+{% if item.value.dns1 is defined %}
+DNS1="{{ item.value.dns1 }}"
+{% endif %}
+{% if item.value.dns2 is defined %}
+DNS2="{{ item.value.dns2 }}"
+{% endif %}

--- a/roles/gateway/templates/resolvconf.j2
+++ b/roles/gateway/templates/resolvconf.j2
@@ -1,0 +1,7 @@
+#
+# {{ ansible_managed }}
+#
+search {{ gw_resolv_search }}
+{% for nameserver in gw_resolv_ns %}
+nameserver {{ nameserver }}
+{% endfor %}

--- a/roles/gateway/vars/packages.yml
+++ b/roles/gateway/vars/packages.yml
@@ -7,6 +7,7 @@ packages:
   - ipmitool
   - git
   - fail2ban
+  - fail2ban-firewalld
   ## VPN-specific stuff
   - openvpn
   - easy-rsa

--- a/roles/gateway/vars/packages.yml
+++ b/roles/gateway/vars/packages.yml
@@ -10,7 +10,6 @@ packages:
   ## VPN-specific stuff
   - openvpn
   - easy-rsa
-  - iptables-services
   ## monitoring
   - nrpe
   - nagios-plugins-all


### PR DESCRIPTION
Tested on fresh CentOS 7.2 VM in RHEV.  To test the role and avoid IP conflicts, check out the wip-gw-networking branch from the secrets repo and change the following:

- In `ansible/inventory/sepia`, replace gw.sepia.ceph.com with the VM's internal IP under `[gateway]`
- In `ansible/secrets/gateway.yml`, change the `local` line in the OpenVPN server config to a free public IP (I used 8.43.84.133)
- In `ansible/secrets/gateway.yml`, change the `server` line in the OpenVPN server config to something like `server 172.21.50.0 255.255.255.0`

A RHEV VM is the only place the role can really be tested since no other machines are configured to be reachable from the WAN.

This should *not* be run on the existing OpenVPN server.

21JUN2016 EDIT: Now that we've moved the gw into RHEV, the role can be tested using public IP 8.43.84.134.  The role can also safely be run on the existing gw VM (172.21.0.100).