### PR TITLE
cobbler: testnode post-install rc.local fixes

### DIFF
--- a/roles/cobbler/templates/snippets/cephlab_rc_local
+++ b/roles/cobbler/templates/snippets/cephlab_rc_local
@@ -21,10 +21,15 @@ if [ -e $lockfile ]; then
     exit 0
 fi
 
-# Wait just a bit for the network to come up
-sleep 30
+# Wait until we get 10 ping responses from Cobbler host
+# before calling post-install trigger
+until ping -nq -c10 $http_server
+do
+    echo "Waiting for network"
+    sleep 3
+done
 # Run the post-install trigger a second time
-wget -t1 -O /dev/null "http://$http_server:$http_port/cblr/svc/op/trig/mode/post/system/$system_name" || true
+wget --timeout=1800 -t1 -O /dev/null "http://$http_server:$http_port/cblr/svc/op/trig/mode/post/system/$system_name" || true
 touch $lockfile
 EOF
 


### PR DESCRIPTION
- Instead of sleeping for 30 secs and hoping network is up, wait until we can
reliably ping the Cobbler host.
- Give ansible more time to run before wget's built-in 15min timeout is reached.  Otherwise ansible will still run and finish but the lockfile won't get touched.

Signed-off-by: David Galloway <dgallowa@redhat.com>