### PR TITLE
testnodes: Disable firewalld service after reboot on RPM-based distros

### DIFF
--- a/roles/testnode/tasks/redhat/rhel_7.yml
+++ b/roles/testnode/tasks/redhat/rhel_7.yml
@@ -7,3 +7,4 @@
   service:
     name: firewalld
     state: stopped
+    enabled: no

--- a/roles/testnode/tasks/setup-centos.yml
+++ b/roles/testnode/tasks/setup-centos.yml
@@ -7,12 +7,14 @@
   service:
     name: iptables
     state: stopped
+    enabled: no
   when: ansible_distribution_major_version == "6"
 
 - name: Stop firewalld
   service:
     name: firewalld
     state: stopped
+    enabled: no
   when: ansible_distribution_major_version == "7"
 
 - include: imitate_ubuntu.yml

--- a/roles/testnode/tasks/setup-fedora.yml
+++ b/roles/testnode/tasks/setup-fedora.yml
@@ -13,3 +13,4 @@
   service:
     name: firewalld
     state: stopped
+    enabled: no


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/16455

Signed-off-by: David Galloway <dgallowa@redhat.com>