### PR TITLE
cobbler: Output message indicating Ansible is running after firstboot

### DIFF
--- a/roles/cobbler/templates/snippets/cephlab_rc_local
+++ b/roles/cobbler/templates/snippets/cephlab_rc_local
@@ -28,6 +28,8 @@ do
     echo "Waiting for network"
     sleep 3
 done
+# Output message to console indicating Ansible is being run
+echo -e "==================================\nInstructing Cobbler to run Ansible\n      Waiting for completion\n==================================" > /dev/console
 # Run the post-install trigger a second time
 wget --timeout=1800 -t1 -O /dev/null "http://$http_server:$http_port/cblr/svc/op/trig/mode/post/system/$system_name" || true
 touch $lockfile


### PR DESCRIPTION
Console output with this change looks like:

    [  OK  ] Started Postfix Mail Transport Agent.
    [  OK  ] Started Crash recovery kernel arming.
    [  OK  ] Created slice user-1000.slice.
    ==================================
    Instructing Cobbler to run Ansible
    ==================================
    [  OK  ] Created slice user-1100.slice.
         Starting Time & Date Service...
    [  OK  ] Started Time & Date Service.


Signed-off-by: David Galloway <dgallowa@redhat.com>