### PR TITLE
testnodes: Install perl-CPAN on yum systems

### DIFF
--- a/roles/testnode/vars/centos_7.yml
+++ b/roles/testnode/vars/centos_7.yml
@@ -89,6 +89,10 @@ packages:
   - nfs-utils
   # for xfstests
   - ncurses-devel
+  # for s3 tests
+  - python-devel
+  - python-virtualenv
+  - perl-CPAN
 
 epel_packages:
   # for running ceph

--- a/roles/testnode/vars/redhat_7.yml
+++ b/roles/testnode/vars/redhat_7.yml
@@ -74,6 +74,7 @@ packages:
   # for s3 tests
   - python-devel
   - python-virtualenv
+  - perl-CPAN
 
 epel_packages:
   - gperftools-devel


### PR DESCRIPTION
perl-CPAN is required to install Amazon::S3 using the 'cpan' command

Signed-off-by: David Galloway <dgallowa@redhat.com>