### PR TITLE
use 120s instead of default 12s for cmd timeout

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,3 +3,4 @@ ansible_managed = This file is managed by ansible, don't make changes here - the
 # this works when testing from my laptop, but will need to
 # be changed when it lives in a production environment
 vault_password_file = ~/.vault_pass.txt
+timeout = 120


### PR DESCRIPTION
Increase timeout from 12s to 120s for ansible cmds

Signed-off-by: Vasu Kulkarni vasu@redhat.com