### PR TITLE
testnode: drop gperftools-devel

### DIFF
--- a/roles/testnode/vars/centos_6.yml
+++ b/roles/testnode/vars/centos_6.yml
@@ -106,7 +106,6 @@ packages:
 
 epel_packages:
   # for running ceph
-  - gperftools-devel
   - cryptopp-devel
   - cryptopp
   - fcgi

--- a/roles/testnode/vars/centos_7.yml
+++ b/roles/testnode/vars/centos_7.yml
@@ -96,7 +96,6 @@ packages:
 
 epel_packages:
   # for running ceph
-  - gperftools-devel
   - cryptopp-devel
   - cryptopp
   - fcgi

--- a/roles/testnode/vars/redhat_6.yml
+++ b/roles/testnode/vars/redhat_6.yml
@@ -94,7 +94,6 @@ packages:
 
 epel_packages:
   # for running ceph
-  - gperftools-devel
   - cryptopp-devel
   - cryptopp
   - fcgi

--- a/roles/testnode/vars/redhat_7.yml
+++ b/roles/testnode/vars/redhat_7.yml
@@ -77,7 +77,6 @@ packages:
   - perl-CPAN
 
 epel_packages:
-  - gperftools-devel
   - cryptopp-devel
   - cryptopp
   - dbench


### PR DESCRIPTION
Stop installing the gperftools-devel package on testnodes, for the following reasons:

1. Ceph does not require gperftools-devel at runtime, so installing it unnecessarily just slows everything down at this point.

2. When we want to test newer builds of gperftools (say, from RHEL 7.3), if the corresponding "gperftools-devel" package is not available on the test node, then yum will fail the transaction.

(Additionally, gperftools-devel is no longer in EPEL 7, and it has moved to RHEL 7 Optional in RHEL 7.2 (https://bugzilla.redhat.com/1213879, https://access.redhat.com/errata/RHEA-2015:2293). The "epel" list is no longer the correct list for this package on redhat_7 and centos_7.)