### PR TITLE
If a YAML error is hit, log the raw object

### DIFF
--- a/callback_plugins/failure_log.py
+++ b/callback_plugins/failure_log.py
@@ -40,7 +40,10 @@ def log_failure(host, result):
         failure[host] = result
         if ANSIBLE_MAJOR >= 2:
             failure = sanitize_dict(failure)
-        log.error(yaml.safe_dump(failure))
+        try:
+            log.error(yaml.safe_dump(failure))
+        except Exception:
+            log.exception("Failure object was: %s", str(failure))
 
 
 def sanitize_dict(obj):


### PR DESCRIPTION
We are seeing: "RepresenterError: cannot represent an object: pcp"

Signed-off-by: Zack Cerza <zack@redhat.com>