### PR TITLE
testnode: Disable firewalld and iptables regardless of OS version

### DIFF
--- a/roles/testnode/tasks/redhat/rhel_6.yml
+++ b/roles/testnode/tasks/redhat/rhel_6.yml
@@ -2,9 +2,4 @@
 - name: Fix broken cloud-init
   include: ../cloud-init.yml
 
-- name: Stop iptables
-  service:
-    name: iptables
-    state: stopped
-
 - include: ../imitate_ubuntu.yml

--- a/roles/testnode/tasks/redhat/rhel_7.yml
+++ b/roles/testnode/tasks/redhat/rhel_7.yml
@@ -2,9 +2,3 @@
 - include: ../nfs.yml
   tags:
     - nfs
-
-- name: Stop firewalld
-  service:
-    name: firewalld
-    state: stopped
-    enabled: no

--- a/roles/testnode/tasks/setup-centos.yml
+++ b/roles/testnode/tasks/setup-centos.yml
@@ -3,18 +3,4 @@
   include: cloud-init.yml
   when: ansible_distribution_major_version == "6"
 
-- name: Stop iptables
-  service:
-    name: iptables
-    state: stopped
-    enabled: no
-  when: ansible_distribution_major_version == "6"
-
-- name: Stop firewalld
-  service:
-    name: firewalld
-    state: stopped
-    enabled: no
-  when: ansible_distribution_major_version == "7"
-
 - include: imitate_ubuntu.yml

--- a/roles/testnode/tasks/setup-fedora.yml
+++ b/roles/testnode/tasks/setup-fedora.yml
@@ -8,9 +8,3 @@
     owner: root
     group: root
     mode: 0644
-
-- name: Disable firewalld
-  service:
-    name: firewalld
-    state: stopped
-    enabled: no

--- a/roles/testnode/tasks/yum/firewall.yml
+++ b/roles/testnode/tasks/yum/firewall.yml
@@ -1,0 +1,18 @@
+---
+# There have been instances where iptables is installed on EL7 testnodes.
+# This task will make sure both services are stopped and disabled regardless
+# of OS version.
+
+- name: Stop and disable firewalld
+  service:
+    name: firewalld
+    state: stopped
+    enabled: no
+  ignore_errors: true
+
+- name: Stop and disable iptables
+  service:
+    name: iptables
+    state: stopped
+    enabled: no
+  ignore_errors: true

--- a/roles/testnode/tasks/yum_systems.yml
+++ b/roles/testnode/tasks/yum_systems.yml
@@ -64,6 +64,9 @@
   tags:
     - packages
 
+- name: Disable firewall
+  include: yum/firewall.yml
+
 - name: Enable SELinux
   selinux: state=permissive policy=targeted
   tags:


### PR DESCRIPTION
iptables was recently found installed and running on a RHEL7 system.
Previous testnode playbook runs wouldn't catch this since it shouldn't
be installed in the first place.  This change ensures firewalld and
iptables are stopped on all RPM-based distros.

Fixes: http://tracker.ceph.com/issues/16809

Signed-off-by: David Galloway <dgallowa@redhat.com>