### PR TITLE
Use the profile_tasks plugin

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,6 +4,7 @@ ansible_managed = This file is managed by ansible, don't make changes here - the
 # be changed when it lives in a production environment
 vault_password_file = ~/.vault_pass.txt
 timeout = 120
+callback_whitelist = profile_tasks
 
 [ssh_connection]
 retries = 5


### PR DESCRIPTION
This will cause ansible to display timing information for tasks,
allowing us to see what's slow and potentially improve speed.

I've been using this locally for a while now. It's nice.

Signed-off-by: Zack Cerza <zack@redhat.com>