### PR TITLE
Add support for testing RHEL beta distros using internal repos

### DIFF
--- a/roles/cobbler/templates/snippets/cephlab_packages_rhel
+++ b/roles/cobbler/templates/snippets/cephlab_packages_rhel
@@ -9,6 +9,7 @@
 #end if
 perl
 wget
+redhat-lsb-core
 ## For ansible/NRPE
 smartmontools
 libselinux-python

--- a/roles/common/README.rst
+++ b/roles/common/README.rst
@@ -43,6 +43,8 @@ your own local epel mirror.
 ``enable_epel`` is a boolean that sets whether epel repos should be enabled.
 Defined in ``roles/common/defaults/main.yml``.
 
+``beta_repos`` is a dict of internal Red Hat beta repos used to create repo files in /etc/yum.repos.d.  We have these defined in the secrets repo.  See ``epel_repos`` for dict syntax.
+
 ``yum_timeout`` is an integer used to set the yum timeout.  Defined in
 ``roles/common/defaults/main.yml``.
 

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -28,5 +28,12 @@ epel_repos:
     enabled: 0
     gpgcheck: 0
 
+# Override in secrets repo
+beta_repos: []
+
+# Default to false.  A task in roles/common/tasks/yum_systems.yml
+# will set this to true if lsb_release indicates the distro is an Alpha/Beta release
+beta_distro: false
+
 enable_epel: true
 yum_timeout: 300

--- a/roles/common/tasks/beta_repos.yml
+++ b/roles/common/tasks/beta_repos.yml
@@ -1,0 +1,15 @@
+---
+- name: Configure internal beta repos in /etc/yum.repos.d/
+  template:
+    src: yum_repo.j2
+    dest: /etc/yum.repos.d/{{ item.key }}.repo
+    owner: root
+    group: root
+    mode: 0644
+  register: beta_repo
+  with_dict: "{{ beta_repos }}"
+  no_log: true
+
+- name: Clean yum cache
+  shell: yum clean all
+  when: beta_repo is defined and beta_repo|changed

--- a/roles/common/tasks/yum_systems.yml
+++ b/roles/common/tasks/yum_systems.yml
@@ -48,9 +48,27 @@
     state: present
   when: ansible_distribution == 'Fedora' and ansible_distribution_major_version|int >= 22
 
+- name: Determine if distro is a Beta or Alpha release
+  set_fact:
+    beta_distro: true
+  when:
+    ansible_distribution == 'RedHat' and
+    ('Beta' in ansible_lsb.description or
+     'Alpha' in ansible_lsb.description)
+
+# include internal repos when distro is a Beta or Alpha release
+- include: beta_repos.yml
+  when:
+    ansible_distribution == 'RedHat' and
+    beta_distro == true
+  tags:
+    - repos
+
 # configure Red Hat entitlements with subscription-manager
 - include: rhel-entitlements.yml
-  when: ansible_distribution == 'RedHat'
+  when:
+    ansible_distribution == 'RedHat' and
+    beta_distro == false
   tags:
     - entitlements
 


### PR DESCRIPTION
Combine with ceph-octo-secrets PR# 77

Tested on RHEL7.2 and RHEL7.3 using stock cobbler images.  RHEL7.2 gets subscribed to CDN as it should and RHEL7.3 uses the internal repos.  Also tested CentOS 7.2 for sanity and to verify `redhat-lsb-core` package is available.

`no_log: true` is ignored (https://github.com/ansible/ansible/issues/11253) for now but since logs are internal, it's not a big deal.  The only 'sensitive' info that gets output is the internal repo path.