### PR TITLE
defaults: beta_repos must be a dict

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -29,7 +29,7 @@ epel_repos:
     gpgcheck: 0
 
 # Override in secrets repo
-beta_repos: []
+beta_repos: {}
 
 # Default to false.  A task in roles/common/tasks/yum_systems.yml
 # will set this to true if lsb_release indicates the distro is an Alpha/Beta release


### PR DESCRIPTION
The incorrect default causes ceph-cm-ansible to fail every teuthology job: 'with_dict expects a dict'

Signed-off-by: Josh Durgin <jdurgin@redhat.com>