### PR TITLE
users: Leave managed_admin_users' other group memberships alone

### DIFF
--- a/roles/users/tasks/create_users.yml
+++ b/roles/users/tasks/create_users.yml
@@ -13,6 +13,7 @@
     groups: sudo
     shell: /bin/bash
     state: present
+    append: yes
   with_items: "{{ managed_admin_users }}"
 
 - name: Create all users without sudo access.


### PR DESCRIPTION
This change is mainly so the users role can be run on vps_hosts.

Previously, in order to update the ubuntu user's authorized_keys on
vps_hosts, the testnodes role had to be run which caused ubuntu to be
removed from the libvirtd group.

The ubuntu user is in managed_admin_users on vps_hosts so this will
ensure the user is added to sudo and left in the libvirtd group.

managed_users, on the other hand, we want to make sure are only in
groups we specify so the "Create all users without sudo access." task is
left as-is (without append: yes).

Combine with https://github.com/ceph/ceph-sepia-secrets/pull/160

Signed-off-by: David Galloway <dgallowa@redhat.com>