### PR TITLE
DNM: Add support for Red Hat Satellite subscription

### DIFF
--- a/roles/common/README.rst
+++ b/roles/common/README.rst
@@ -31,6 +31,14 @@ secrets repo.
 ``rhsm_repos`` is a list of Red Hat repos that a system should subscribe to.  We
 have them defined in ``roles/common/vars/redhat_{6,7}.yml``.
 
+``use_satellite`` is a boolean that sets whether a local Red Hat Satellite server is available and should be used instead of Red Hat's CDN.  If ``use_satellite`` is set to true, you must also define ``subscription_manager_activationkey``, ``subscription_manager_org``, and ``satellite_cert_rpm`` in your secrets repo.  See example::
+
+    # Red Hat Satellite vars
+    use_satellite: true
+    satellite_cert_rpm: "http://satellite.example.com/pub/katello-ca-consumer-latest.noarch.rpm"
+    subscription_manager_org: "Your Org"
+    subscription_manager_activationkey: "abc123"
+
 ``epel_mirror_baseurl`` is self explanatory and defined in
 ``roles/common/defaults/main.yml``.  Can be overwritten in secrets if you run
 your own local epel mirror.

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -8,6 +8,9 @@ subscription_manager_org: ""
 # Repos to enable in Red Hat Subscription Manager
 rhsm_repos: []
 
+# Defines whether to use a Red Hat Satellite server
+use_satellite: false
+
 kerberos_realm: EXAMPLE.COM
 
 epel_mirror_baseurl: "http://dl.fedoraproject.org/pub/epel"

--- a/roles/common/tasks/rhel-entitlements.yml
+++ b/roles/common/tasks/rhel-entitlements.yml
@@ -18,6 +18,13 @@
   set_fact:
     have_entitlements: "{{ subscription_manager_org != '' and subscription_manager_activationkey != ''}}"
 
+- name: Install CA Cert from Satellite Server
+  yum:
+    name: "{{ satellite_cert_rpm }}"
+    state: present
+    validate_certs: no
+  when: use_satellite == true
+
 - name: Determine if node is registered with subscription-manager.
   command: subscription-manager identity
   register: subscription

--- a/roles/common/tasks/yum_systems.yml
+++ b/roles/common/tasks/yum_systems.yml
@@ -53,6 +53,7 @@
     beta_distro: true
   when:
     ansible_distribution == 'RedHat' and
+    ansible_lsb.description is defined and
     ('Beta' in ansible_lsb.description or
      'Alpha' in ansible_lsb.description)
 


### PR DESCRIPTION
If you want to read about subscribing RHEL hosts to a Satellite server, see https://access.redhat.com/documentation/en/red-hat-satellite/6.2/paged/host-configuration-guide/65-automated-host-registration-with-activation-keys
