### PR TITLE
common: Change method of detecting beta distro

### DIFF
--- a/roles/common/tasks/rhel-entitlements.yml
+++ b/roles/common/tasks/rhel-entitlements.yml
@@ -25,7 +25,7 @@
   changed_when: false
   no_log: true
 
-- name: Set rhsm_registered
+- name: Set rhsm_registered if we're already registered
   set_fact:
     rhsm_registered: "{{ subscription.rc == 0 }}"
 
@@ -40,10 +40,41 @@
   retries: 5
   delay: 10
 
-- name: Get list of enabled repos
-  shell: sudo subscription-manager repos --list | grep -B4 'Enabled:.*1' | grep 'Repo ID:' | sed -e 's/Repo ID:\s*\(.*\)/\1/' | sort
+- name: Set rhsm_registered if we just registered
+  set_fact:
+    rhsm_registered: true
+  when: entitled|success
+
+# Output of this command is, for example:
+# 7.1
+# 7.2
+# 7Server
+- name: List CDN releases available to system
+  shell: "subscription-manager release --list | grep -E '[0-9]'"
+  register: rhsm_release_list
+  changed_when: false
+
+# We don't need to be registered to CDN since there's no packages available
+# for this Beta/Alpha/RC installation
+- name: Unregister Beta/Alpha/RC system with subscription-manager
+  command: subscription-manager unregister
+  when: ansible_distribution_version not in rhsm_release_list.stdout_lines
+  register: unregistered_beta_distro
+
+# Setting rhsm_registered back to false allows the rest of the playbook
+# (except beta_repos.yml) to be skipped
+- name: Set rhsm_registered to false if Beta/Alpha/RC release
+  set_fact:
+    rhsm_registered: false
+  when: not unregistered_beta_distro|skipped
+
+- name: Run beta_repos.yml playbook for Beta/Alpha/RC release
+  include: beta_repos.yml
+  when: ansible_distribution_version not in rhsm_release_list.stdout_lines
+
+- name: Get list of enabled RHSM repos
+  shell: subscription-manager repos --list | grep -B4 'Enabled:.*1' | grep 'Repo ID:' | sed -e 's/Repo ID:\s*\(.*\)/\1/' | sort
   register: repo_list_cmd
-  # This only needs to happen if we are not newly-subscribed
   when: rhsm_registered == true
   changed_when: false
 
@@ -52,31 +83,34 @@
     repo_list: "{{ repo_list_cmd.stdout.split('\n') }}"
   when: repo_list_cmd is defined and not repo_list_cmd|skipped
 
-- name: Set replace_repos if entitlements are missing
+- name: Set replace_repos false if entitlements are missing or if we unregistered
   set_fact:
     replace_repos: false
-  when: have_entitlements == false
+  when: have_entitlements == false or unregistered_beta_distro|changed
 
-- name: Set replace_repos if rhsm_repos differs from repo_list
+- name: Set replace_repos true if rhsm_repos differs from repo_list
   set_fact:
     replace_repos: "{{ repo_list|sort != rhsm_repos|sort }}"
   when: repo_list is defined
 
-- name: Set replace_repos if newly-subscribed
+- name: Set replace_repos true if newly-subscribed
   set_fact:
     replace_repos: true
-  when: entitled|changed and entitled.rc == 0
+  when: rhsm_registered == true and
+        (entitled|changed and entitled.rc == 0)
 
 - name: Disable all rhsm repos
   command: subscription-manager repos --disable '*'
-  when: replace_repos|bool == true
+  when: rhsm_registered == true and
+        replace_repos|bool == true
   # This produces an absurd amount of useless output
   no_log: true
 
 - name: Enable necessary rhsm repos
   command: subscription-manager repos --enable {{ item }}
   with_items: "{{ rhsm_repos }}"
-  when: replace_repos
+  when: rhsm_registered == true and
+        replace_repos|bool == true
 
 - name: Remove old apt-mirror repository definition.
   file:

--- a/roles/common/tasks/yum_systems.yml
+++ b/roles/common/tasks/yum_systems.yml
@@ -48,22 +48,6 @@
     state: present
   when: ansible_distribution == 'Fedora' and ansible_distribution_major_version|int >= 22
 
-- name: Determine if distro is a Beta or Alpha release
-  set_fact:
-    beta_distro: true
-  when:
-    ansible_distribution == 'RedHat' and
-    ('Beta' in ansible_lsb.description or
-     'Alpha' in ansible_lsb.description)
-
-# include internal repos when distro is a Beta or Alpha release
-- include: beta_repos.yml
-  when:
-    ansible_distribution == 'RedHat' and
-    beta_distro == true
-  tags:
-    - repos
-
 # configure Red Hat entitlements with subscription-manager
 - include: rhel-entitlements.yml
   when:


### PR DESCRIPTION
Tested on:
RHEL7.3 Beta
- Unregistered

RHEL7.3 RC2
- Unregistered

RHEL7.2
- Unregistered
- Already registered with expected repos from `rhsm_repos`
- Already registered with additional repos not in `rhsm_repos`

It was recently discovered that Release Candidate ISOs of RHEL don't output "Beta" or
"Alpha" in `lsb_release` output.  Therefore, RHEL RC Distros were
registering with CDN and not putting beta_repos in place.

This new method registers every RHEL system with CDN, checks if there are
any available matching repos based on ansible_distribution_version, and
either:
  - Unregisters from CDN and runs beta_distros.yml if there are no CDN repos
  - Continues with setting up desired rhsm_repos

I also added some additional working to task descriptions to hopefully
claer up what's going on in this playbook since there are a lot of when
and if statements.

Signed-off-by: David Galloway <dgallowa@redhat.com>