### PR TITLE
Use "become: true" for users role

### DIFF
--- a/users.yml
+++ b/users.yml
@@ -2,3 +2,4 @@
 - hosts: all
   roles:
     - users
+  become: true


### PR DESCRIPTION
This is needed if the users role is called manually.  Typically it's
called via the common role and "become: true" is inherited.

But in the case of just needing to update update the teuthology_user's pubkeys with @all.pub, just calling the users role manually is quicker.  sudo access is obviously required to modify users and groups.

Just tested by running `ansible-playbook users.yml --limit="vps_hosts"`

Signed-off-by: David Galloway <dgallowa@redhat.com>