### PR TITLE
testnode: Define a few empty variables for ansible v2.2 compatibility

### DIFF
--- a/roles/testnode/defaults/main.yml
+++ b/roles/testnode/defaults/main.yml
@@ -29,8 +29,14 @@ epel_packages: []
 # version, distro or package type
 common_packages: []
 
+# common packages that aren't available in aarch64 architecture
+non_aarch64_packages: []
+non_aarch64_packages_to_upgrade: []
+non_aarch64_common_packages: []
+
 # packages used by ceph we want to ensure are removed
 ceph_packages_to_remove: []
+ceph_dependency_packages_to_remove: []
 packages_to_remove: []
 packages_to_upgrade: []
 

--- a/roles/testnode/tasks/apt/repos.yml
+++ b/roles/testnode/tasks/apt/repos.yml
@@ -8,7 +8,7 @@
 
 - name: Remove custom repos
   file: path=/etc/apt/sources.list.d/{{ item }} state=absent
-  with_items: "{{ custom_repos.stdout_lines }}"
+  with_items: "{{ custom_repos.stdout_lines|default([]) }}"
   # Ignore changes here because we will be removing repos that we end up re-adding later
   changed_when: false
 


### PR DESCRIPTION
Tested using ansible v2.2 on a smithi running Ubuntu 14.04, a smithi running CentOS 7.2, and a magna running RHEL 7.2.

`roles/testnode/vars/yum_systems.yml` isn't included on playbook runs where `ansible_pkg_mgr != apt`.  Even though the tasks relying on those vars are skipped, the tasks were still fatally failing because the vars weren't defined.  Defining empty defaults gets around that.

Signed-off-by: David Galloway <dgallowa@redhat.com>