### PR TITLE
Updates to downstream_setup role

### DIFF
--- a/roles/downstream-setup/defaults/main.yml
+++ b/roles/downstream-setup/defaults/main.yml
@@ -34,3 +34,6 @@ disable_yum_repos: []
 # NOTE: this does not work on repo files with multiple entries in them,
 # it will only enable the first entry in the repo file.
 enable_yum_repos: []
+
+# defining empty var for ansible v2.2 compatibility.
+repos_to_remove: []

--- a/roles/downstream-setup/tasks/main.yml
+++ b/roles/downstream-setup/tasks/main.yml
@@ -1,9 +1,13 @@
 ---
+# re: 'static: no' -- See https://github.com/ansible/ansible/issues/18483
+# Can be removed once that fix makes it into Ansible
+
 # These are tasks which perform actions corresponding to the names of
 # the variables they use.  For example, `disable_yum_repos` would actually
 # disable all repos defined in that list.
 - include: setup.yml
   when: not cleanup and (ansible_distribution == "CentOS" or ansible_distribution == "RedHat")
+  static: no
 
 # These are tasks which reverse the actions corresponding to the names of
 # the variables they use. For example, `disable_yum_repos` would actually
@@ -12,3 +16,4 @@
 # for the test run but then re-enable them during the teuthology cleanup process.
 - include: cleanup.yml
   when: cleanup and (ansible_distribution == "CentOS" or ansible_distribution == "RedHat")
+  static: no


### PR DESCRIPTION
Vasu started seeing errors about `repos_to_remove` not being defined after we un-pinned Ansible from 2.1.  This goes back to the issue where task files that aren't even included or run are still being evaluated.  If they don't have empty variables set, the playbook fails.

So I defined an empty list for the var but was still getting:

`FAILED! => {"failed": true, "msg": "{{ repos_to_remove.split(',') }}: 'list object' has no attribute 'split'"}`

I found https://github.com/ansible/ansible/issues/18483 and have set both `setup.yml` and `cleanup.yml` when conditionals to be evaluated dynamically in https://github.com/ceph/ceph-cm-ansible/commit/adbc0903d3944d850be643e1a6dab169090eab7b

Fixes: http://tracker.ceph.com/issues/17922