### PR TITLE
testnode: Install libtool-bin for building xfstests

### DIFF
--- a/roles/testnode/vars/ubuntu_16.yml
+++ b/roles/testnode/vars/ubuntu_16.yml
@@ -16,6 +16,8 @@ packages:
   ###
   - libcrypto++9v5
   ###
+  # for building xfstests #18067
+  - libtool-bin
 
 non_aarch64_packages:
   - libgoogle-perftools4


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/18067

Signed-off-by: David Galloway <dgallowa@redhat.com>