### PR TITLE
teuthology: Correct MIME type spec for log files

### DIFF
--- a/roles/teuthology/templates/nginx.conf
+++ b/roles/teuthology/templates/nginx.conf
@@ -6,5 +6,7 @@ server {
         location /teuthology {
           alias /home/teuthworker/archive;
         }
-        default_type text/plain;
+        types {
+            text/plain log;
+        }
 }


### PR DESCRIPTION
Gzipped files were being served as text/plain. Instead of applying text/plain to everythincg, extend the default MIME configuration to serve *.log as text/plain.

Signed-off-by: Zack Cerza <zack@redhat.com>