### PR TITLE
testnode/tasks/ntp: remove '/etc/network/if-up.d/ntpdate' on Xenial

### DIFF
--- a/roles/testnode/tasks/ntp.yml
+++ b/roles/testnode/tasks/ntp.yml
@@ -15,6 +15,16 @@
   tags:
     - packages
 
+# See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=806556.
+# ifdown/ifup would often leave ntpd not running on xenial.
+# We do our own ntpdate dance in teuthology's clock task.
+- name: Remove racy /etc/network/if-up.d/ntpdate on xenial
+  file:
+    name: /etc/network/if-up.d/ntpdate
+    state: absent
+  when: ansible_distribution == "Ubuntu" and
+        ansible_distribution_major_version == '16'
+
 - name: Create the ntp.conf file.
   template:
     src: ntp.conf


### PR DESCRIPTION
It's buggy (see comment in code) and we don't need it, because
teuthology does what it would do anyway.  Supposed to be fixed in
a later version of the Debian package which is in Yakkety.

Fixes: http://tracker.ceph.com/issues/18837
Signed-off-by: Dan Mick <dan.mick@redhat.com>