### PR TITLE
common: Delete leftover SELinux policy modules

### DIFF
--- a/roles/common/tasks/nrpe-selinux.yml
+++ b/roles/common/tasks/nrpe-selinux.yml
@@ -20,6 +20,15 @@
     state: yes
     persistent: yes
 
+# See http://tracker.ceph.com/issues/19126
+- name: nrpe - Clean up cephlab SELinux policy modules
+  file:
+    path: "/etc/selinux/targeted/active/modules/400/{{ item }}"
+    state: absent
+  with_items:
+    - mod_fastcgi
+    - nrpe
+
 - name: nrpe - Remove SELinux policy package
   command: semodule -r nrpe
   failed_when: false


### PR DESCRIPTION
Jobs were occasionally failing due to
/etc/selinux/targeted/active/modules/400/mod_fastcgi/lang_ext being
corrupt.  mod_fastcgi is removed and reinstalled with every
testnodes.yml run anyway so this just makes sure valid SELinux policy
modules are put in place.

Fixes: http://tracker.ceph.com/issues/19126

Signed-off-by: David Galloway <dgallowa@redhat.com>