### PR TITLE
common: Reinstall selinux-policy-targeted if needed

### DIFF
--- a/roles/common/tasks/nrpe-selinux.yml
+++ b/roles/common/tasks/nrpe-selinux.yml
@@ -20,7 +20,7 @@
     state: yes
     persistent: yes
 
-# See http://tracker.ceph.com/issues/19126
+# See http://tracker.ceph.com/issues/19126 for details on next 3 tasks
 - name: nrpe - Clean up cephlab SELinux policy modules
   file:
     path: "/etc/selinux/targeted/active/modules/400/{{ item }}"
@@ -28,6 +28,21 @@
   with_items:
     - mod_fastcgi
     - nrpe
+
+# abrt was just chosen since it's first in the dir and
+# included with the selinux-policy-targeted package.
+- name: Check for empty SELinux module file
+  stat:
+    path: /etc/selinux/targeted/active/modules/100/abrt/lang_ext
+  register: selinux_module_status
+
+# ignore_errors in case the package isn't available or installed.
+# The ansible yum module doesn't appear to have a reinstall option.
+- name: Reinstall selinux-policy-targeted if modules are corrupt
+  command: yum -y reinstall selinux-policy-targeted
+  when: selinux_module_status.stat.exists == true and
+        selinux_module_status.stat.size == 0
+  ignore_errors: true
 
 - name: nrpe - Remove SELinux policy package
   command: semodule -r nrpe


### PR DESCRIPTION
This ensures module file integrity so we can build the nrpe selinux
module in the proceeding tasks.

Fixes: http://tracker.ceph.com/issues/19126

Signed-off-by: David Galloway <dgallowa@redhat.com>