### PR TITLE
common: Workaround for ansible bug conditional evaluation

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -51,6 +51,7 @@
 
 # configure selinux for nagios
 - include: nrpe-selinux.yml
-  when: selinux_status is defined and selinux_status.stdout != "Disabled"
+  when: ansible_os_family == "RedHat" and
+        (selinux_status is defined and selinux_status.stdout != "Disabled")
   tags:
     - nagios


### PR DESCRIPTION
Prior to ansible v2.2.2.0, if the first conditional (`selinux_status is defined` in this case) was false, the second
conditional wasn't checked.

This change makes sure nrpe-selinux is only included on RHEL/CentOS
which are the only OSes that will have stdout for the selinux_status
var.

Successfully tested cephlab.yml run on
smithi202 - Xenial
smithi163 - Trusty
smithi032 - CentOS 7.3

Signed-off-by: David Galloway <dgallowa@redhat.com>