### PR TITLE
Repo changes for Ubuntu testnodes

### DIFF
--- a/roles/testnode/tasks/apt/repos.yml
+++ b/roles/testnode/tasks/apt/repos.yml
@@ -21,6 +21,8 @@
     mode: 0644
   register: apt_prefs
 
+# Starting with ubuntu 15.04 we no longer maintain our own package mirrors.
+# For anything ubuntu < 15.04 or debian <=7 we still do.
 - name: Add sources list
   template:
     dest: /etc/apt/sources.list
@@ -29,7 +31,8 @@
     group: root
     mode: 0644
   register: sources
-  when: ansible_architecture != "aarch64"
+  when: ansible_architecture != "aarch64" and
+        ansible_distribution_major_version|int < 15
 
 - name: Install apt keys
   apt_key:

--- a/roles/testnode/tasks/apt_systems.yml
+++ b/roles/testnode/tasks/apt_systems.yml
@@ -1,9 +1,6 @@
 ---
-# Starting with ubuntu 15.04 we no longer maintain our own package mirrors.
-# For anything ubuntu < 15.04 or debian <=7 we still do.
 - name: Setup local repo files.
   include: apt/repos.yml
-  when: ansible_distribution_major_version|int < 15
   tags:
     - repos
 

--- a/roles/testnode/vars/ubuntu.yml
+++ b/roles/testnode/vars/ubuntu.yml
@@ -1,8 +1,4 @@
 ---
-common_apt_repos:
-  # mod_fastcgi for radosgw
-  - "deb http://gitbuilder.ceph.com/libapache-mod-fastcgi-deb-{{ansible_distribution_release}}-x86_64-basic/ref/master/ {{ansible_distribution_release}} main"
-
 common_packages:
   # for apache
   - libfcgi0ldbl

--- a/roles/testnode/vars/ubuntu_14.yml
+++ b/roles/testnode/vars/ubuntu_14.yml
@@ -1,4 +1,8 @@
 ---
+apt_repos:
+  # mod_fastcgi for radosgw
+  - "deb http://gitbuilder.ceph.com/libapache-mod-fastcgi-deb-trusty-x86_64-basic/ref/master/ trusty main"
+
 packages:
   - libboost-thread1.54.0
   - mpich

--- a/roles/testnode/vars/ubuntu_14.yml
+++ b/roles/testnode/vars/ubuntu_14.yml
@@ -1,10 +1,4 @@
 ---
-# This is temporarily disabled because of:
-# http://tracker.ceph.com/issues/13572
-#apt_repos:
-#  # blkin libraries, only trusty has new enough lttng for these
-#  - "deb [arch=amd64] http://{{ mirror_host }}/blkin/ trusty main"
-
 packages:
   - libboost-thread1.54.0
   - mpich

--- a/roles/testnode/vars/ubuntu_16.yml
+++ b/roles/testnode/vars/ubuntu_16.yml
@@ -1,9 +1,7 @@
 ---
-# This is temporarily disabled because of:
-# http://tracker.ceph.com/issues/13572
-#apt_repos:
-#  # blkin libraries, only trusty has new enough lttng for these
-#  - "deb [arch=amd64] http://{{ mirror_host }}/blkin/ trusty main"
+apt_repos:
+  # http://tracker.ceph.com/issues/18126
+  - "deb [trusted=yes] https://chacra.ceph.com/r/valgrind/latest/HEAD/ubuntu/xenial/flavors/default/ xenial main"
 
 packages:
   - libboost-thread1.58.0
@@ -22,6 +20,8 @@ packages:
 packages_to_upgrade:
   # http://tracker.ceph.com/issues/13522#note-51
   - libgoogle-perftools4
+  # http://tracker.ceph.com/issues/18126#note-11
+  - valgrind
 
 non_aarch64_packages:
   - libgoogle-perftools4


### PR DESCRIPTION
This all started as just needing to add a custom repo to Xenial to fix http://tracker.ceph.com/issues/18126

Then I noticed that `apt/repos.yml` tasks were never getting run on Xenial testnodes and some of those tasks are important.  This explains why https://github.com/ceph/teuthology/pull/1034 and https://github.com/ceph/teuthology/pull/1032 were needed.  Those can be reverted once this PR is merged.