### PR TITLE
public_facing: Create separate task yml for letsencrypt/nginx/ipv6 hosts

### DIFF
--- a/roles/public_facing/tasks/download.ceph.com.yml
+++ b/roles/public_facing/tasks/download.ceph.com.yml
@@ -68,30 +68,4 @@
     minute: "0"
     job: "/usr/libexec/make_timestamp"
 
-- name: Cron entry for letsencrypt cert renewal
-  cron:
-    name: "Renew letsencrypt certificate"
-    minute: "0"
-    hour: "0"
-    day: "1,15"
-    job: "/usr/bin/letsencrypt renew >> /var/log/letsencrypt.log && service nginx reload"
-
-# Get letsencrypt authority server IPv4 address
-- local_action: shell dig -4 +short acme-v01.api.letsencrypt.org | tail -n 1
-  register: letsencrypt_ipv4_address
-
-# This task really only needs to be run the first time download.ceph.com is set up.
-# An entry matching *letsencrypt* in /etc/hosts is required for the cronjob in the next task however.
-- name: Create entry for letsencrypt authority server in /etc/hosts
-  lineinfile:
-    path: /etc/hosts
-    regexp: '(.*)letsencrypt(.*)'
-    line: '{{ letsencrypt_ipv4_address.stdout }}    acme-v01.api.letsencrypt.org'
-    state: present
-
-# 'letsencrypt renew' fails because it can't reach the letsencrypt authority server using IPv6
-- name: Create cron entry to force IPv4 connectivity to letsencrypt authority server
-  cron:
-    name: "Forces letsencrypt to use IPv4 when accessing acme-v01.api.letsencrypt.org"
-    hour: "0"
-    job: "IP=$(dig -4 +short acme-v01.api.letsencrypt.org | tail -n 1) && sed -i \"s/.*letsencrypt.*/$IP\tacme-v01.api.letsencrypt.org/g\" /etc/hosts"
+- include: letsencrypt_nginx.yml

--- a/roles/public_facing/tasks/letsencrypt_nginx.yml
+++ b/roles/public_facing/tasks/letsencrypt_nginx.yml
@@ -1,0 +1,28 @@
+---
+- name: Cron entry for letsencrypt cert renewal
+  cron:
+    name: "Renew letsencrypt certificate"
+    minute: "0"
+    hour: "0"
+    day: "1,15"
+    job: "/usr/bin/letsencrypt renew >> /var/log/letsencrypt.log && service nginx reload"
+
+# Get letsencrypt authority server IPv4 address
+- local_action: shell dig -4 +short acme-v01.api.letsencrypt.org | tail -n 1
+  register: letsencrypt_ipv4_address
+
+# This task really only needs to be run the first time download.ceph.com is set up.
+# An entry matching *letsencrypt* in /etc/hosts is required for the cronjob in the next task however.
+- name: Create entry for letsencrypt authority server in /etc/hosts
+  lineinfile:
+    path: /etc/hosts
+    regexp: '(.*)letsencrypt(.*)'
+    line: '{{ letsencrypt_ipv4_address.stdout }}    acme-v01.api.letsencrypt.org'
+    state: present
+
+# 'letsencrypt renew' fails because it can't reach the letsencrypt authority server using IPv6
+- name: Create cron entry to force IPv4 connectivity to letsencrypt authority server
+  cron:
+    name: "Forces letsencrypt to use IPv4 when accessing acme-v01.api.letsencrypt.org"
+    hour: "0"
+    job: "IP=$(dig -4 +short acme-v01.api.letsencrypt.org | tail -n 1) && sed -i \"s/.*letsencrypt.*/$IP\tacme-v01.api.letsencrypt.org/g\" /etc/hosts"

--- a/roles/public_facing/tasks/www.ceph.com.yml
+++ b/roles/public_facing/tasks/www.ceph.com.yml
@@ -1,20 +1,4 @@
 ---
-- name: Cron entry for letsencrypt cert renewal
-  cron:
-    name: "Renew letsencrypt certificate"
-    minute: "0"
-    hour: "0"
-    day: "1,15"
-    job: "/usr/bin/letsencrypt renew >> /var/log/letsencrypt.log"
-
-- name: Cron entry for reloading nginx
-  cron:
-    name: "Reload nginx to keep SSL cert updated"
-    minute: "5"
-    hour: "0"
-    day: "1,15"
-    job: "/bin/systemctl reload nginx"
-
 # Wordpress has its own cron system that only runs queued jobs when the site
 # is visited.  We want certain jobs to run regardless of page visits.
 # 5 minutes was used because that's the most frequent any job is queued.
@@ -24,3 +8,5 @@
     name: "Call wp-cron.php to run Wordpress cronjobs"
     minute: "*/5"
     job: "/usr/bin/wget -q -O - http://ceph.com/wp-cron.php?doing_wp_cron"
+
+- include: letsencrypt_nginx.yml


### PR DESCRIPTION
Discovered www.ceph.com was hitting this problem as well ever since an IPv6 address was added.  Makes sense to move it to a separate playbook at this point.

Signed-off-by: David Galloway <dgallowa@redhat.com>