### PR TITLE
common: Change path to nrpe pid_file on RedHat/CentOS

### DIFF
--- a/roles/common/templates/nagios/nrpe.cfg
+++ b/roles/common/templates/nagios/nrpe.cfg
@@ -1,6 +1,10 @@
 # {{ ansible_managed }}
 log_facility=daemon
+{% if ansible_os_family == "Debian" %}
 pid_file=/var/run/nagios/nrpe.pid
+{% else %}
+pid_file=/var/run/nrpe/nrpe.pid
+{% endif %}
 server_port=5666
 nrpe_user={{ nrpe_user }}
 nrpe_group={{ nrpe_group }}


### PR DESCRIPTION
I can't find the exact commit in nrpe that caused this to change but the
path has changed and the nrpe service fails to start on CentOS/RHEL now.

Signed-off-by: David Galloway <dgallowa@redhat.com>