### PR TITLE
cobbler: Install ntp package on RHEL/CentOS during kickstart

### DIFF
--- a/roles/cobbler/templates/snippets/cephlab_packages_rhel
+++ b/roles/cobbler/templates/snippets/cephlab_packages_rhel
@@ -16,5 +16,6 @@ libselinux-python
 libsemanage-python
 policycoreutils-python
 selinux-policy-targeted
+ntp
 ## For disk partitioning
 gdisk


### PR DESCRIPTION
Apparently doesn't come stock with CentOS 7.4 which was causing the
Cobbler ansible-playbook post-install run to fail.

Signed-off-by: David Galloway <dgallowa@redhat.com>