### PR TITLE
testnode: Avoid job failure due to fs loop

### DIFF
--- a/roles/testnode/tasks/main.yml
+++ b/roles/testnode/tasks/main.yml
@@ -118,7 +118,9 @@
     - /var/log/
   register: ceph_test_artifacts
   changed_when: ceph_test_artifacts.stdout != ""
-  failed_when: ceph_test_artifacts.rc != 0 and "No such file or directory" not in ceph_test_artifacts.stderr
+  failed_when: ceph_test_artifacts.rc != 0 and
+               "No such file or directory" not in ceph_test_artifacts.stderr and
+               "File system loop detected" not in ceph_test_artifacts.stderr
 
 - name: Delete any leftover Ceph artifacts from previous jobs
   file:


### PR DESCRIPTION
Example:
```
changed: false
cmd: "find /var/run/ -name \"*ceph*\""
delta: "0:00:00.004976"
end: "2017-09-29 18:42:23.050412"
failed: true
failed_when_result: true
item: /var/run/
rc: 1
start: "2017-09-29 18:42:23.045436"
stderr: "find: File system loop detected; '/var/run/rpc_pipefs/gssd' is part of the same file system loop as '/var/run/rpc_pipefs'."
stderr_lines: 
  - "find: File system loop detected; '/var/run/rpc_pipefs/gssd' is part of the same file system loop as '/var/run/rpc_pipefs'."
stdout: ""
stdout_lines: []
```

Signed-off-by: David Galloway <dgallowa@redhat.com>