### PR TITLE
testnode: Shuffle tasks around to make sure packages install first

### DIFF
--- a/roles/testnode/tasks/main.yml
+++ b/roles/testnode/tasks/main.yml
@@ -24,27 +24,6 @@
   tags:
     - hostname
 
-- include: zap_disks.yml
-  tags:
-    - zap
-
-- name: partition drives, if any are requested
-  include: drive_partitioning.yml
-  when: drives_to_partition is defined
-  tags:
-    - partition
-
-- name: set up LVM
-  include: lvm.yml
-  tags:
-    - lvm
-
-- name: mount /var/lib/ceph to specified partition
-  include: var_lib.yml
-  when: var_lib_partition is defined
-  tags:
-    - varlib
-
 - name: configure ssh
   include: ssh.yml
   tags:
@@ -87,6 +66,27 @@
 - name: configure debian specific things
   include: setup-debian.yml
   when: ansible_distribution == "Debian"
+
+- include: zap_disks.yml
+  tags:
+    - zap
+
+- name: partition drives, if any are requested
+  include: drive_partitioning.yml
+  when: drives_to_partition is defined
+  tags:
+    - partition
+
+- name: set up LVM
+  include: lvm.yml
+  tags:
+    - lvm
+
+- name: mount /var/lib/ceph to specified partition
+  include: var_lib.yml
+  when: var_lib_partition is defined
+  tags:
+    - varlib
 
 # Install and configure cpan and Amazon::S3
 - include: cpan.yml


### PR DESCRIPTION
I moved lvm.conf in https://github.com/ceph/ceph-cm-ansible/pull/342
because I wanted all the disk management tasks clustered together.  I
failed to take into account the fact that the lvm2 package might not be
installed yet (like on OVH nodes).

Signed-off-by: David Galloway <dgallowa@redhat.com>