### PR TITLE
nameserver: Double max amount of concurrent connections

### DIFF
--- a/roles/nameserver/tasks/config.yml
+++ b/roles/nameserver/tasks/config.yml
@@ -25,3 +25,10 @@
     name: named_write_master_zones
     state: yes
     persistent: yes
+
+# Helps prevent accidental DoS
+- name: Double maximum configured connections
+  sysctl:
+    name: net.nf_conntrack_max
+    value: 131072
+    state: present


### PR DESCRIPTION
I observed an unintentional DoS on ns1.front last night right as most of
the nightly scheduled jobs started up.  Lots of "nf_conntrack: table
full, dropping packet" messages in the syslog.

Doubling it should be safe.

Signed-off-by: David Galloway <dgallowa@redhat.com>