### PR TITLE
testnode: Avoid an unmountable /var/lib/ceph

### DIFF
--- a/roles/testnode/tasks/var_lib.yml
+++ b/roles/testnode/tasks/var_lib.yml
@@ -12,6 +12,8 @@
     dev: "{{ var_lib_partition }}"
     fstype: xfs
     force: yes
+    # Don't use a version 5 superblock as it's too new for some kernels
+    opts: "-m crc=0,finobt=0"
 
 - name: "Mount {{ var_lib_partition }} to /var/lib/ceph"
   mount:

--- a/roles/testnode/tasks/var_lib.yml
+++ b/roles/testnode/tasks/var_lib.yml
@@ -18,4 +18,6 @@
     path: "/var/lib/ceph"
     src: "{{ var_lib_partition }}"
     fstype: xfs
+    # Don't fail to boot if the mount fails
+    opts: defaults,nofail
     state: mounted


### PR DESCRIPTION
We've been seeing a lot of this:
http://tracker.ceph.com/issues/21989

I believe the issue is the XFS filesystem being created by tools that default to a version 5 superblock - a version too new for some of our testing kernels.

This is not widely tested - we can talk about it when you're back