### PR TITLE
vmhost: Allow task to fail but ignore errors

### DIFF
--- a/roles/vmhost/tasks/libvirt.yml
+++ b/roles/vmhost/tasks/libvirt.yml
@@ -87,7 +87,7 @@
 
 - name: Query for front network definition
   command: virsh net-info front
-  failed_when: false
+  ignore_errors: true
   register: front_net
 
 - name: Send front network definition file


### PR DESCRIPTION
With a recent update to ansible, the changed task would never return a
'failed' result with `failed_when` set.  `ignore_errors` is what we want
so the task fails but the playbook proceeds.

Signed-off-by: David Galloway <dgallowa@redhat.com>