### PR TITLE
cobbler: Install ethtool on reimage

### DIFF
--- a/roles/cobbler/templates/kickstarts/cephlab_ubuntu.preseed
+++ b/roles/cobbler/templates/kickstarts/cephlab_ubuntu.preseed
@@ -101,9 +101,9 @@ d-i user-setup/encrypt-home boolean false
 #if $os_version == 'precise'
 d-i pkgsel/include string wget ntpdate bash sudo openssh-server
 #else if int($distro_ver_major) >= 16
-d-i pkgsel/include string u-boot-tools pastebinit initramfs-tools wget linux-firmware ntpdate bash devmem2 fbset sudo openssh-server udev-discover gawk gdisk
+d-i pkgsel/include string u-boot-tools pastebinit initramfs-tools wget linux-firmware ntpdate bash devmem2 fbset sudo openssh-server udev-discover gawk gdisk ethtool
 #else
-d-i pkgsel/include string u-boot-tools pastebinit initramfs-tools wget linux-firmware linux-firmware-nonfree ntpdate bash devmem2 fbset sudo openssh-server udev-discover gawk gdisk
+d-i pkgsel/include string u-boot-tools pastebinit initramfs-tools wget linux-firmware linux-firmware-nonfree ntpdate bash devmem2 fbset sudo openssh-server udev-discover gawk gdisk ethtool
 #end if
 
 # Whether to upgrade packages after debootstrap.


### PR DESCRIPTION
ethtool is used in the new rc.local hackery

Signed-off-by: David Galloway <dgallowa@redhat.com>