### PR TITLE
cobbler: Don't break after first NIC is configured

### DIFF
--- a/roles/cobbler/templates/snippets/cephlab_rc_local
+++ b/roles/cobbler/templates/snippets/cephlab_rc_local
@@ -39,8 +39,6 @@ if [ ! -f /.cephlab_net_configured ]; then
       ifup $nic
       # Write our lockfile so this only gets run on firstboot
       touch /.cephlab_net_configured
-      # Quit loop after first NIC is configured
-      break
     else
       # Take the NIC back down if it's not connected
       ifconfig $nic down


### PR DESCRIPTION
In case the system has multiple NICs cabled (like Octo's bruuni and
pluto)

Signed-off-by: David Galloway <dgallowa@redhat.com>