### PR TITLE
cobbler: Remove DHCP config for NICs if ifup fails in rc.local

### DIFF
--- a/roles/cobbler/templates/snippets/cephlab_rc_local
+++ b/roles/cobbler/templates/snippets/cephlab_rc_local
@@ -36,7 +36,16 @@ if [ ! -f /.cephlab_net_configured ]; then
       fi
       # Bounce the NIC so it gets a DHCP address
       ifdown $nic
+      # Don't bail if NIC fails to come up
+      set +e
       ifup $nic
+      if [ $? -ne 0 ]; then
+        # If the NIC failed to DHCP, delete its ifcfg script.  Must be static or tagged
+        rm -f /etc/sysconfig/network-scripts/ifcfg-$nic
+        ifdown $nic
+      fi
+      # Go back to bailing if anything above fails on the next NIC
+      set -e
       # Write our lockfile so this only gets run on firstboot
       touch /.cephlab_net_configured
     else


### PR DESCRIPTION
An issue was discovered where rc.local bails if a testnode has multiple
NICs cabled but each NIC doesn't have a DHCP reservation.  For example,
some of the magnas have a second NIC cabled but are cabled to a tagged
port on the switch so they can pass traffic via multiple VLANs.

Fixes: http://tracker.ceph.com/issues/22651

Signed-off-by: David Galloway <dgallowa@redhat.com>