### PR TITLE
cobbler: Use MAC address specified in ansible inventory instead of eth0

### DIFF
--- a/roles/cobbler/templates/kickstarts/cephlab_rhel.ks
+++ b/roles/cobbler/templates/kickstarts/cephlab_rhel.ks
@@ -22,7 +22,7 @@ url --url=$tree
 # If any cobbler repo definitions were referenced in the kickstart profile, include them here.
 $yum_repo_stanza
 # Network information
-network --bootproto=dhcp --device=eth0 --onboot=on
+network --bootproto=dhcp --device=$mac_address_eth0 --onboot=on
 # Reboot after installation
 reboot
 


### PR DESCRIPTION
I concede.  Name it whatever you want, RHEL.

This will allow the OS to use the "predictable naming" during anaconda
and after firstboot preventing NIC names from switching like we're
seeing in http://tracker.ceph.com/issues/22732 and http://tracker.ceph.com/issues/22643

Signed-off-by: David Galloway <dgallowa@redhat.com>