### PR TITLE
cobbler: Change method used to ping Cobbler host in rc.local

### DIFF
--- a/roles/cobbler/templates/snippets/cephlab_rc_local
+++ b/roles/cobbler/templates/snippets/cephlab_rc_local
@@ -37,9 +37,15 @@ if [ ! -f /.cephlab_net_configured ]; then
       # Don't bail if NIC fails to come up
       set +e
       ifup $nic
+      attempts=0
+      # Try for 5 seconds to ping our Cobbler host
 #end raw
-      if ! timeout 5s ping -I $nic -nq -c1 $http_server 2>&1 >/dev/null; then
+      while ! ping -I $nic -nq -c1 $http_server && [ $attempts -lt 5 ]; do
 #raw
+        sleep 1
+        attempts=$[$attempts+1]
+      done
+      if [ $attempts == 5 ]; then
         # If we can't ping our Cobbler host, remove the DHCP config for this NIC.
         # It must either be on a non-routable network or has no reachable DHCP server.
         ifdown $nic


### PR DESCRIPTION
I've observed a *very* occasional race condition where dhclient
completes but the host can't ping Cobbler.  Instead of timing out
waiting for one ping packet to return, we'll try pinging X number of
times (based on $attempts number) and then give up.

Example of old behavior:
```
+ echo -e 'auto lo\niface lo inet loopback\n\nauto enp3s0f1\niface enp3s0f1 inet dhcp'
+ ifdown enp3s0f1
Killed old client process
Internet Systems Consortium DHCP Client 4.3.3
Copyright 2004-2015 Internet Systems Consortium.
All rights reserved.
For info, please visit https://www.isc.org/software/dhcp/

Listening on LPF/enp3s0f1/0c:c4:7a:8f:ce:7f
Sending on   LPF/enp3s0f1/0c:c4:7a:8f:ce:7f
Sending on   Socket/fallback
DHCPRELEASE on enp3s0f1 to 172.21.0.10 port 67 (xid=0x492dda3e)
+ set +e
+ ifup enp3s0f1
Internet Systems Consortium DHCP Client 4.3.3
Copyright 2004-2015 Internet Systems Consortium.
All rights reserved.
For info, please visit https://www.isc.org/software/dhcp/

Listening on LPF/enp3s0f1/0c:c4:7a:8f:ce:7f
Sending on   LPF/enp3s0f1/0c:c4:7a:8f:ce:7f
Sending on   Socket/fallback
DHCPDISCOVER on enp3s0f1 to 255.255.255.255 port 67 interval 3 (xid=0x42a2711e)
DHCPDISCOVER on enp3s0f1 to 255.255.255.255 port 67 interval 5 (xid=0x42a2711e)
DHCPREQUEST of 172.21.15.108 on enp3s0f1 to 255.255.255.255 port 67 (xid=0x1e71a242)
DHCPOFFER of 172.21.15.108 from 172.21.0.10
DHCPACK of 172.21.15.108 from 172.21.0.10
bound to 172.21.15.108 -- renewal in 19684 seconds.
+ timeout 5s ping -I enp3s0f1 -nq -c1 172.21.0.11
+ ifdown enp3s0f1
Killed old client process
Internet Systems Consortium DHCP Client 4.3.3
Copyright 2004-2015 Internet Systems Consortium.
All rights reserved.
For info, please visit https://www.isc.org/software/dhcp/

Listening on LPF/enp3s0f1/0c:c4:7a:8f:ce:7f
Sending on   LPF/enp3s0f1/0c:c4:7a:8f:ce:7f
Sending on   Socket/fallback
DHCPRELEASE on enp3s0f1 to 172.21.0.10 port 67 (xid=0x44ece490)
+ rm -f /etc/sysconfig/network-scripts/ifcfg-enp3s0f1
+ sed -i /enp3s0f1/d /etc/network/interfaces
+ set -e
+ touch /.cephlab_net_configured
+ break
```
Notice the network config file still gets deleted/modified even though the right NIC came up and should've been able to ping 172.21.0.11.

Here's the new behavior showing what happens if the NIC can't ping the IP provided.  I gave it a bogus IP for demonstration purposes.
```
+ echo -e 'auto lo\niface lo inet loopback\n\nauto enp3s0f1\niface enp3s0f1 inet dhcp'
+ ifdown enp3s0f1
Killed old client process
Internet Systems Consortium DHCP Client 4.3.3
Copyright 2004-2015 Internet Systems Consortium.
All rights reserved.
For info, please visit https://www.isc.org/software/dhcp/

Listening on LPF/enp3s0f1/0c:c4:7a:8f:ce:7f
Sending on   LPF/enp3s0f1/0c:c4:7a:8f:ce:7f
Sending on   Socket/fallback
DHCPRELEASE on enp3s0f1 to 172.21.0.10 port 67 (xid=0x51ffba7c)
+ set +e
+ ifup enp3s0f1
Internet Systems Consortium DHCP Client 4.3.3
Copyright 2004-2015 Internet Systems Consortium.
All rights reserved.
For info, please visit https://www.isc.org/software/dhcp/

Listening on LPF/enp3s0f1/0c:c4:7a:8f:ce:7f
Sending on   LPF/enp3s0f1/0c:c4:7a:8f:ce:7f
Sending on   Socket/fallback
DHCPDISCOVER on enp3s0f1 to 255.255.255.255 port 67 interval 3 (xid=0x78b50955)
DHCPDISCOVER on enp3s0f1 to 255.255.255.255 port 67 interval 4 (xid=0x78b50955)
DHCPREQUEST of 172.21.15.108 on enp3s0f1 to 255.255.255.255 port 67 (xid=0x5509b578)
DHCPOFFER of 172.21.15.108 from 172.21.0.10
DHCPACK of 172.21.15.108 from 172.21.0.10
bound to 172.21.15.108 -- renewal in 16755 seconds.
+ attempts=0
+ ping -I enp3s0f1 -nq -c1 172.21.0.253
PING 172.21.0.253 (172.21.0.253) from 172.21.15.108 enp3s0f1: 56(84) bytes of data.

--- 172.21.0.253 ping statistics ---
1 packets transmitted, 0 received, +1 errors, 100% packet loss, time 0ms

+ '[' 0 -lt 5 ']'
+ sleep 1
+ attempts=1
+ ping -I enp3s0f1 -nq -c1 172.21.0.253
PING 172.21.0.253 (172.21.0.253) from 172.21.15.108 enp3s0f1: 56(84) bytes of data.

--- 172.21.0.253 ping statistics ---
1 packets transmitted, 0 received, +1 errors, 100% packet loss, time 0ms

+ '[' 1 -lt 5 ']'
+ sleep 1
+ attempts=2
+ ping -I enp3s0f1 -nq -c1 172.21.0.253
PING 172.21.0.253 (172.21.0.253) from 172.21.15.108 enp3s0f1: 56(84) bytes of data.

--- 172.21.0.253 ping statistics ---
1 packets transmitted, 0 received, +1 errors, 100% packet loss, time 0ms

+ '[' 2 -lt 5 ']'
+ sleep 1
+ attempts=3
+ ping -I enp3s0f1 -nq -c1 172.21.0.253
PING 172.21.0.253 (172.21.0.253) from 172.21.15.108 enp3s0f1: 56(84) bytes of data.

--- 172.21.0.253 ping statistics ---
1 packets transmitted, 0 received, +1 errors, 100% packet loss, time 0ms

+ '[' 3 -lt 5 ']'
+ sleep 1
+ attempts=4
+ ping -I enp3s0f1 -nq -c1 172.21.0.253
PING 172.21.0.253 (172.21.0.253) from 172.21.15.108 enp3s0f1: 56(84) bytes of data.

--- 172.21.0.253 ping statistics ---
1 packets transmitted, 0 received, +1 errors, 100% packet loss, time 0ms

+ '[' 4 -lt 5 ']'
+ sleep 1
+ attempts=5
+ ping -I enp3s0f1 -nq -c1 172.21.0.253
PING 172.21.0.253 (172.21.0.253) from 172.21.15.108 enp3s0f1: 56(84) bytes of data.

--- 172.21.0.253 ping statistics ---
1 packets transmitted, 0 received, +1 errors, 100% packet loss, time 0ms

+ '[' 5 -lt 5 ']'
+ '[' 5 == 5 ']'
+ ifdown enp3s0f1
Killed old client process
Internet Systems Consortium DHCP Client 4.3.3
Copyright 2004-2015 Internet Systems Consortium.
All rights reserved.
For info, please visit https://www.isc.org/software/dhcp/

Listening on LPF/enp3s0f1/0c:c4:7a:8f:ce:7f
Sending on   LPF/enp3s0f1/0c:c4:7a:8f:ce:7f
Sending on   Socket/fallback
DHCPRELEASE on enp3s0f1 to 172.21.0.10 port 67 (xid=0x48dd4370)
+ rm -f /etc/sysconfig/network-scripts/ifcfg-enp3s0f1
+ sed -i /enp3s0f1/d /etc/network/interfaces
```

And finally, just showing successful behavior:

```
+ echo -e 'auto lo\niface lo inet loopback\n\nauto enp3s0f1\niface enp3s0f1 inet dhcp'
+ ifdown enp3s0f1
ifdown: interface enp3s0f1 not configured
+ set +e
+ ifup enp3s0f1
Internet Systems Consortium DHCP Client 4.3.3
Copyright 2004-2015 Internet Systems Consortium.
All rights reserved.
For info, please visit https://www.isc.org/software/dhcp/

Listening on LPF/enp3s0f1/0c:c4:7a:8f:ce:7f
Sending on   LPF/enp3s0f1/0c:c4:7a:8f:ce:7f
Sending on   Socket/fallback
DHCPDISCOVER on enp3s0f1 to 255.255.255.255 port 67 interval 3 (xid=0x38703a40)
DHCPREQUEST of 172.21.15.108 on enp3s0f1 to 255.255.255.255 port 67 (xid=0x403a7038)
DHCPOFFER of 172.21.15.108 from 172.21.0.10
DHCPACK of 172.21.15.108 from 172.21.0.10
bound to 172.21.15.108 -- renewal in 19256 seconds.
+ attempts=0
+ ping -I enp3s0f1 -nq -c1 172.21.0.11
PING 172.21.0.11 (172.21.0.11) from 172.21.15.108 enp3s0f1: 56(84) bytes of data.

--- 172.21.0.11 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 0.401/0.401/0.401/0.000 ms
+ '[' 0 == 5 ']'
+ set -e
+ break
```

Signed-off-by: David Galloway <dgallowa@redhat.com>