### PR TITLE
cobbler: Just output to ttyS1

### DIFF
--- a/roles/cobbler/templates/snippets/cephlab_rc_local
+++ b/roles/cobbler/templates/snippets/cephlab_rc_local
@@ -8,16 +8,11 @@
 #else
 #set script = '/etc/rc.local'
 #end if
-# Search for 'ttyS' in kernel_options and set $console accordingly
-# so rc.local output gets sent to the proper tty
-#import re
-#set kernel_options = $getVar('kernel_options','ttyS1')
-#set console = re.match('.*(ttyS\d+).*', $kernel_options).groups()[0]
 
 cat > $script <<\EOF
 #!/bin/bash
 # Redirect rc.local output to our console so it's in teuthology console logs
-exec 2> /dev/$console
+exec 2> /dev/ttyS1
 exec 1>&2
 set -ex
 


### PR DESCRIPTION
This covers all baremetal types except mira.  Cheetah/Cobbler templating
was breaking with commit
https://github.com/ceph/ceph-cm-ansible/pull/389/commits/de871c037f4ae227bed00933eee24f849a4551b0.

The problem is if there is more than one kernel option type (like
console, ksdevice, etc.), $kernel_options gets expanded into a json
dictionary and breaks the templating.

E.g., {'ksdevice': 'bootif', 'lang': ' ', 'console': ['tty0', 'ttyS1,115200'], 'text': None, 'netcfg/choose_interface': 'auto'}

Rather than fight with that, we'll just output to ttyS1.

Signed-off-by: David Galloway <dgallowa@redhat.com>