### PR TITLE
testnode: Exclude dm devices from list of physical volumes

### DIFF
--- a/roles/testnode/tasks/configure_lvm.yml
+++ b/roles/testnode/tasks/configure_lvm.yml
@@ -9,7 +9,7 @@
 
 - name: Combine list of non-root disks
   set_fact:
-      disks_for_vg: "{{ ansible_devices.keys() | sort | reject('match',root_disk) | reject('match','loop') | reject('match','ram') | map('regex_replace','^','/dev/') | join(',') }}"
+      disks_for_vg: "{{ ansible_devices.keys() | sort | reject('match',root_disk) | reject('match','loop') | reject('match','ram') | reject('match','dm-') | map('regex_replace','^','/dev/') | join(',') }}"
   when: quick_lvs_to_create is defined
 
 - set_fact: vg_name=vg_hdd


### PR DESCRIPTION
This was actually happening because when the playbook first runs, the
setup module is run and sees the device mapper devices.  We zap them
later in the playbook but ansible doesn't know that.  We could just
re-run the setup module but this method will instead guarantee we don't
use dm-* devices.

Fixes: https://tracker.ceph.com/issues/23845

Signed-off-by: David Galloway <dgallowa@redhat.com>