### PR TITLE
common/testnode: Support skipping entitlements & packages

### DIFF
--- a/roles/common/tasks/yum_systems.yml
+++ b/roles/common/tasks/yum_systems.yml
@@ -43,10 +43,12 @@
   when: ansible_distribution == 'Fedora' and ansible_distribution_major_version|int >= 22
 
 # configure Red Hat entitlements with subscription-manager
+# skip_entitlements=true on OVH testnodes
 - import_tasks: rhel-entitlements.yml
   when:
     ansible_distribution == 'RedHat' and
-    beta_distro == false
+    beta_distro == false and
+    skip_entitlements|default(false)|bool != true
   tags:
     - entitlements
 

--- a/roles/testnode/tasks/yum_systems.yml
+++ b/roles/testnode/tasks/yum_systems.yml
@@ -59,8 +59,17 @@
   tags:
     - repos
 
+# skip_packaging=true set in group_vars for OVH testnodes.  We still want these
+# tasks to run on CentOS though so we set it back to false here.
+- set_fact:
+    skip_packaging: false
+  when: ansible_distribution != "RedHat"
+  tags:
+    - packages
+
 - name: Perform package related tasks.
   import_tasks: yum/packages.yml
+  when: skip_packaging|default(false)|bool != true
   tags:
     - packages
 


### PR DESCRIPTION
`skip_entitlements` and `skip_packaging` will be set to true in the
Ansible inventory for OVH nodes