### PR TITLE
cobbler: Add kickstarts that will install to /dev/sdm

### DIFF
--- a/roles/cobbler/templates/kickstarts/cephlab_rhel_sdm.ks
+++ b/roles/cobbler/templates/kickstarts/cephlab_rhel_sdm.ks
@@ -1,0 +1,96 @@
+## {{ ansible_managed }}
+## This kickstart for use with systems where /dev/sdm is the root drive (e.g., mero)
+# kickstart template for Fedora 8 and later.
+# (includes %end blocks)
+# do not use with earlier distros
+
+#platform=x86, AMD64, or Intel EM64T
+# System authorization information
+auth  --useshadow  --enablemd5
+#set os_version = $getVar('os_version','')
+# Partition clearing information
+clearpart --all --initlabel
+# Use all of /dev/sdm for the root partition (20G minimum)
+part / --fstype="ext4" --ondisk=sdm --size=20000 --grow
+# Clear the Master Boot Record
+zerombr
+# System bootloader configuration
+#if $os_version == 'rhel7'
+    #set bootloader_args = "--location=mbr --boot-drive=sdm"
+#else
+    #set bootloader_args = "--location=mbr --driveorder=sdm"
+#end if
+bootloader $bootloader_args
+# Use text mode install
+text
+# Firewall configuration
+firewall --enabled
+# Run the Setup Agent on first boot
+firstboot --disable
+# System keyboard
+keyboard us
+# System language
+lang en_US
+# Use network installation
+url --url=$tree
+# If any cobbler repo definitions were referenced in the kickstart profile, include them here.
+$yum_repo_stanza
+# Network information
+network --bootproto=dhcp --device=$mac_address_eth0 --onboot=on
+# Reboot after installation
+reboot
+
+#Root password
+rootpw --iscrypted $default_password_crypted
+# SELinux configuration
+selinux --permissive
+# Do not configure the X Window System
+skipx
+# System timezone
+timezone Etc/UTC --utc
+# Install OS instead of upgrade
+install
+
+%pre
+$SNIPPET('log_ks_pre')
+$SNIPPET('kickstart_start')
+# Enable installation monitoring
+$SNIPPET('pre_anamon')
+%end
+
+%packages
+@core
+$SNIPPET('cephlab_packages_rhel')
+$SNIPPET('func_install_if_enabled')
+%end
+
+%post --nochroot
+$SNIPPET('log_ks_post_nochroot')
+%end
+
+%post
+$SNIPPET('log_ks_post')
+# Start yum configuration
+$yum_config_stanza
+# End yum configuration
+$SNIPPET('post_install_kernel_options')
+$SNIPPET('func_register_if_enabled')
+$SNIPPET('download_config_files')
+$SNIPPET('koan_environment')
+$SNIPPET('redhat_register')
+$SNIPPET('cobbler_register')
+# Enable post-install boot notification
+$SNIPPET('post_anamon')
+# Start final steps
+$SNIPPET('cephlab_hostname')
+$SNIPPET('cephlab_user')
+#set distro = $getVar('distro','').split("-")[0]
+#if $distro == 'RHEL'
+$SNIPPET('cephlab_rhel_rhsm')
+#end if
+# Update to latest kernel before rebooting
+yum -y update kernel
+$SNIPPET('cephlab_rc_local')
+$SNIPPET('kickstart_done')
+# End final steps
+%end

--- a/roles/cobbler/templates/kickstarts/cephlab_ubuntu_sdm.preseed
+++ b/roles/cobbler/templates/kickstarts/cephlab_ubuntu_sdm.preseed
@@ -1,0 +1,145 @@
+## {{ ansible_managed }}
+## This preseed only for systems where /dev/sdm is the root drive (e.g., mero)
+
+# Fetch the os_version from the distro using this profile.
+#set os_version = $getVar('os_version','')
+
+# Fetch Ubuntu version (e.g., 14.04)
+#set distro_ver = $getVar('distro','').split("-")[1]
+
+# Fetch Ubuntu major version (e.g., 14)
+#set distro_ver_major = $distro_ver.split(".")[0]
+
+### Apt setup
+# You can choose to install non-free and contrib software.
+#d-i apt-setup/non-free boolean true
+#d-i apt-setup/contrib boolean true
+
+# Preseeding only locale sets language, country and locale.
+d-i debian-installer/locale string en_US
+
+# Keyboard selection.
+# Disable automatic (interactive) keymap detection.
+d-i console-setup/ask_detect boolean false
+
+# If you select ftp, the mirror/country string does not need to be set.
+#d-i mirror/protocol string ftp
+d-i mirror/country string manual
+d-i mirror/http/hostname string archive.ubuntu.com
+d-i mirror/http/directory string /ubuntu
+d-i mirror/suite string $os_version
+
+#Removes the prompt about missing modules:
+# Continue without installing a kernel?
+#d-i base-installer/kernel/skip-install boolean true
+# Continue the install without loading kernel modules?
+#d-i anna/no_kernel_modules boolean true
+
+# Stop Ubuntu from installing random kernel choice
+#d-i base-installer/kernel/image select none
+
+# Controls whether or not the hardware clock is set to UTC.
+d-i clock-setup/utc boolean true
+#
+# # You may set this to any valid setting for $TZ; see the contents of
+# # /usr/share/zoneinfo/ for valid values.
+d-i time/zone string Etc/UTC
+
+# Controls whether to use NTP to set the clock during the install
+d-i clock-setup/ntp boolean true
+# NTP server to use. The default is almost always fine here.
+d-i clock-setup/ntp-server string pool.ntp.org
+
+# This makes partman automatically partition without confirmation.
+#d-i partman/confirm_write_new_label boolean true
+#d-i partman/choose_partition select finish
+#d-i partman/confirm boolean true
+#d-i partman/choose_partition select finish
+d-i partman-basicfilesystems/no_swap boolean false
+d-i partman-basicfilesystems/no_swap seen true
+d-i partman-auto/disk string /dev/sdm
+d-i partman-auto/method string regular
+#d-i partman-auto/purge_lvm_from_device boolean true
+d-i partman-auto/confirm_nooverwrite  boolean true
+d-i partman-auto/choose_partition select finish
+
+
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman-partitioning/confirm_write_new_label boolean true
+d-i partman/default_filesystem string ext4
+d-i partman-auto/expert_recipe string                         \
+           root ::                                            \
+              500 10000 1000000000 ext4                       \
+                      $primary{ } $bootable{ }                \
+                      method{ format } format{ }              \
+                      use_filesystem{ } filesystem{ ext4 }    \
+                      mountpoint{ / }                         \
+              .                                               
+#\
+#              64 512 1% linux-swap                            \
+#                      method{ swap } format{ }                \
+#              .
+d-i partman/confirm_write_new_label boolean true
+d-i partman/choose_partition \
+       select Finish partitioning and write changes to disk
+d-i partman/confirm boolean true
+
+d-i grub-pc/install_devices multiselect /dev/sdm
+
+#User account.
+d-i passwd/root-login boolean false 
+d-i passwd/make-user boolean true
+d-i passwd/user-fullname string {{ cm_user }}
+d-i passwd/username string {{ cm_user }}
+d-i passwd/user-password-crypted password $default_password_crypted
+d-i passwd/user-uid string {{ cm_user_uid }}
+d-i user-setup/allow-password-weak boolean false
+d-i user-setup/encrypt-home boolean false
+
+# Individual additional packages to install
+#if $os_version == 'precise'
+d-i pkgsel/include string wget ntpdate bash sudo openssh-server
+#else if int($distro_ver_major) == 16
+d-i pkgsel/include string u-boot-tools pastebinit initramfs-tools wget linux-firmware ntpdate bash devmem2 fbset sudo openssh-server udev-discover gawk gdisk ethtool
+#else if int($distro_ver_major) == 18
+d-i pkgsel/include string u-boot-tools pastebinit initramfs-tools wget linux-firmware ntpdate bash devmem2 fbset sudo openssh-server gawk gdisk ethtool net-tools ifupdown python ntp
+#else
+d-i pkgsel/include string u-boot-tools pastebinit initramfs-tools wget linux-firmware linux-firmware-nonfree ntpdate bash devmem2 fbset sudo openssh-server udev-discover gawk gdisk ethtool
+#end if
+
+# Whether to upgrade packages after debootstrap.
+# Allowed values: none, safe-upgrade, full-upgrade
+d-i pkgsel/upgrade select safe-upgrade
+
+# Policy for applying updates. May be "none" (no automatic updates),
+# "unattended-upgrades" (install security updates automatically), or
+# "landscape" (manage system with Landscape).
+d-i pkgsel/update-policy select none
+
+# Set GRUB bootdev to '/dev/sdm' if Xenial or later
+#if int($distro_ver_major) >= 16
+d-i grub-installer/bootdev  string /dev/sdm
+#end if
+
+# During installations from serial console, the regular virtual consoles
+# (VT1-VT6) are normally disabled in /etc/inittab. Uncomment the next
+# line to prevent this.
+d-i finish-install/keep-consoles boolean true
+
+# Avoid that last message about the install being complete.
+d-i finish-install/reboot_in_progress note
+
+# This command is run just before the install finishes, but when there is
+# still a usable /target directory. You can chroot to /target and use it
+# directly, or use the apt-install and in-target commands to easily install
+# packages and run commands in the target system.
+
+# cephlab_preseed_late lives in /var/lib/cobbler/scripts
+# It is passed to the cobbler xmlrpc generate_scripts function where it's rendered.
+# This means that snippets or other templating features can be used.
+d-i preseed/late_command string \
+in-target wget http://$http_server/cblr/svc/op/script/system/$system_name/?script=cephlab_preseed_late -O /tmp/postinst.sh; \
+in-target /bin/chmod 755 /tmp/postinst.sh; \
+in-target /tmp/postinst.sh;


### PR DESCRIPTION
The root drive on mero nodes is /dev/sdm.  Since Cobbler is only used to
provision testnodes prior to a FOG image capture, I didn't think it'd be
worth the time/effort to automate this further.

The kickstart will have to be manually selected if the Cobbler Web UI is
used.  I'll automate setting the kickstart when the octo-fog-images
Jenkins job runs.