### PR TITLE
public_facing: Support blocking multiple ports in ufw fail2ban action

### DIFF
--- a/roles/public_facing/templates/f2b_ufw.conf.j2
+++ b/roles/public_facing/templates/f2b_ufw.conf.j2
@@ -8,4 +8,6 @@ actionstart =
 actionstop = 
 actioncheck = 
 actionban = ufw insert 1 deny from <ip> to any port <port>
+            ufw insert 1 deny proto tcp from <ip> to any port <port>
 actionunban = ufw delete deny from <ip> to any port <port>
+              ufw delete deny proto tcp from <ip> to any port <port>


### PR DESCRIPTION
UFW requires the protocol be specified when multiple ports are given for
a deny rule.