### PR TITLE
cobbler: break at the appropriate location in rc.local

### DIFF
--- a/roles/cobbler/templates/snippets/cephlab_rc_local
+++ b/roles/cobbler/templates/snippets/cephlab_rc_local
@@ -51,13 +51,15 @@ if [ ! -f /.cephlab_net_configured ]; then
         ifdown $nic
         rm -f /etc/sysconfig/network-scripts/ifcfg-$nic
         sed -i "/$nic/d" /etc/network/interfaces
+        # Go back to bailing if anything fails bringing the next NIC up
+        set -e
+      else
+        # We found our routable NIC!
+        # Write our lockfile so this only gets run on firstboot
+        touch /.cephlab_net_configured
+        # Break out of the loop once we've found our routable NIC
+        break
       fi
-      # Go back to bailing if anything fails bringing the next NIC up
-      set -e
-      # Write our lockfile so this only gets run on firstboot
-      touch /.cephlab_net_configured
-      # Break out of the loop once we've found our routable NIC
-      break
     else
       # Take the NIC back down if it's not connected
       ifconfig $nic down


### PR DESCRIPTION
Before this change, if the first NIC on a machine had a link but wasn't
the uplinked NIC, the break would still get called and no NICs would be
left up.

Now we'll break only after we can ping the Cobbler host.