### PR TITLE
testnode: install gcc-c++ on RPM-based systems

### DIFF
--- a/roles/testnode/vars/centos_7.yml
+++ b/roles/testnode/vars/centos_7.yml
@@ -25,6 +25,7 @@ packages:
   - gdb
   - git-all
   - python-configobj
+  - gcc-c++
   # for running ceph
   - libedit
   - openssl098e

--- a/roles/testnode/vars/redhat_7.yml
+++ b/roles/testnode/vars/redhat_7.yml
@@ -25,6 +25,7 @@ packages:
   - gdb
   - git-all
   - python-configobj
+  - gcc-c++
   - libedit
   - openssl098e
   - boost-thread


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/35989