### PR TITLE
cobbler: Install python-jwt on RPM-based testnodes

### DIFF
--- a/roles/cobbler/templates/snippets/cephlab_packages_rhel
+++ b/roles/cobbler/templates/snippets/cephlab_packages_rhel
@@ -10,6 +10,7 @@
 perl
 wget
 redhat-lsb-core
+python-jwt
 ## For ansible/NRPE
 smartmontools
 libselinux-python


### PR DESCRIPTION
This package is needed for ceph-mgr but is not available in the
base/default repos.  Therefore, we need to install it during kickstart
and bake it into our RHEL FOG images.

Fixes: https://tracker.ceph.com/issues/36653

Signed-off-by: David Galloway <dgallowa@redhat.com>