### PR TITLE
Add RHEL8!

### DIFF
--- a/ansible_managed.yml
+++ b/ansible_managed.yml
@@ -3,10 +3,10 @@
 # sudoer settings needed for ansible to manage a node.
 - hosts: all
   strategy: free
-  # assuming the nodes we run this on will most likely
-  # have an ubuntu user already created.
+# this used to be set to ubuntu but the {{ cm_user }} is the only
+# user that gets created during kickstart
   vars:
-    ansible_ssh_user: ubuntu
+    ansible_ssh_user: "{{ cm_user }}"
   roles:
     - ansible-managed
   become: true

--- a/cephlab.yml
+++ b/cephlab.yml
@@ -1,4 +1,6 @@
 ---
+- import_playbook: set_python_path.yml
+
 # ensure the node is setup to be managed by ansible
 # eventually, most of the things here will be done by
 # cobbler / downburst / cloud-init.

--- a/roles/cobbler/templates/snippets/cephlab_packages_rhel
+++ b/roles/cobbler/templates/snippets/cephlab_packages_rhel
@@ -7,16 +7,21 @@
 #else
 @base
 #end if
-perl
-wget
-redhat-lsb-core
-python-jwt
-## For ansible/NRPE
-smartmontools
+#if $distro == 'RHEL'
+#set distro_ver = $distro_ver.split(".")[0]
+#end if
+#if not int($distro_ver) == 8
 libselinux-python
 libsemanage-python
 policycoreutils-python
-selinux-policy-targeted
 ntp
-## For disk partitioning
+python-jwt
+#else
+python3
+#end if
+perl
+wget
+redhat-lsb-core
+smartmontools
+selinux-policy-targeted
 gdisk

--- a/roles/cobbler/templates/snippets/cephlab_rc_local
+++ b/roles/cobbler/templates/snippets/cephlab_rc_local
@@ -3,7 +3,10 @@
 # Set proper location for firstboot ansible post-install trigger
 #set distro = $getVar('distro','').split("-")[0]
 #set distro_ver = $getVar('distro','').split("-")[1]
-#if $distro == 'Fedora' and int($distro_ver) >= 22
+#if $distro == 'RHEL'
+#set distro_ver = $distro_ver.split(".")[0]
+#end if
+#if ($distro == 'Fedora' and int($distro_ver) >= 22) or ($distro == 'RHEL' and int($distro_ver) >= 8)
 #set script = '/etc/rc.d/rc.local'
 #else if $distro == 'openSUSE'
 #set script = '/etc/init.d/boot.local'
@@ -144,7 +147,7 @@ set +x
 echo -e "==================================\nInstructing Cobbler to run Ansible\n      Waiting for completion\n==================================" > /dev/console
 set -x
 # Run the post-install trigger a second time
-wget --timeout=1800 -t1 -O /dev/null "http://$http_server:$http_port/cblr/svc/op/trig/mode/post/system/$system_name" || true
+curl --max-time 1800 --silent "http://$http_server:$http_port/cblr/svc/op/trig/mode/post/system/$system_name" -o /dev/null || true
 touch $lockfile
 EOF
 

--- a/roles/cobbler/templates/triggers/install/post/cephlab_ansible.sh
+++ b/roles/cobbler/templates/triggers/install/post/cephlab_ansible.sh
@@ -26,8 +26,18 @@ pushd $ANSIBLE_CM_PATH
 flock --close ./.lock git pull
 export ANSIBLE_SSH_PIPELINING=1
 export ANSIBLE_HOST_KEY_CHECKING=False
+
+# Set ansible_python_interpeter var if RHEL8
+# https://docs.ansible.com/ansible/2.7/reference_appendices/python_3_support.html
+if [[ $(cobbler system dumpvars --name $2 | grep os_version | awk '{ print $3 }') == "rhel8" ]]; then
+  # Nagios packages aren't available in the RHEL8 beta image so we'll skip those tasks
+  ANSIBLE_EXTRAVAR="-e ansible_python_interpreter=/usr/bin/python3 --skip-tags nagios"
+else
+  ANSIBLE_EXTRAVAR=""
+fi
+
 # Tell ansible to create users, populate authorized_keys, and zap non-root disks
-ansible-playbook testnodes.yml -v --limit $name* --tags user,pubkeys,zap 2>&1 > /var/log/ansible/$name.log
+ansible-playbook $ANSIBLE_EXTRAVAR testnodes.yml -v --limit $name* --tags user,pubkeys,zap 2>&1 > /var/log/ansible/$name.log
 # Now run the rest of the playbook. If it fails, at least we have access.
 # Background it so that the request doesn't block for this part and end up 
 # causing the client to retry, thus spawning this trigger multiple times
@@ -37,5 +47,5 @@ if [[ $profile == *"-stock" ]]
 then
     exit 0
 fi
-ansible-playbook testnodes.yml -v --limit $name* --skip-tags user,pubkeys,zap 2>&1 >> /var/log/ansible/$name.log &
+ansible-playbook $ANSIBLE_EXTRAVAR testnodes.yml -v --limit $name* --skip-tags user,pubkeys,zap 2>&1 >> /var/log/ansible/$name.log &
 popd

--- a/roles/common/tasks/kerberos.yml
+++ b/roles/common/tasks/kerberos.yml
@@ -2,7 +2,7 @@
 # Install and Configure a Kerberos client
 
 - name: Install Kerberos Packages (RedHat)
-  yum:
+  package:
     name: krb5-workstation
     state: present
   when: ansible_os_family == 'RedHat'

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -16,7 +16,7 @@
 
 # configure things specific to yum systems
 - import_tasks: yum_systems.yml
-  when: ansible_pkg_mgr == "yum"
+  when: ansible_os_family == "RedHat"
 
 # configure things specific to apt systems
 - import_tasks: apt_systems.yml
@@ -41,9 +41,11 @@
     - monitoring-scripts
     - nagios
 
-# configure nagios
+# configure nagios (Except OpenSUSE and RHEL8)
 - import_tasks: nagios.yml
-  when: ansible_pkg_mgr != "zypper"
+  when:
+    - ansible_pkg_mgr != "zypper"
+    - not (ansible_distribution == "RedHat" and ansible_distribution_major_version == "8")
   tags:
     - nagios
 
@@ -57,6 +59,7 @@
 # configure selinux for nagios
 - import_tasks: nrpe-selinux.yml
   when: ansible_os_family == "RedHat" and
+        ansible_distribution_major_version != "8" and
         (selinux_status is defined and selinux_status.stdout != "Disabled")
   tags:
     - nagios

--- a/roles/common/tasks/nagios.yml
+++ b/roles/common/tasks/nagios.yml
@@ -5,7 +5,7 @@
 
 - name: Include yum_systems vars
   include_vars: yum_systems.yml
-  when: ansible_pkg_mgr == "yum"
+  when: ansible_os_family == "RedHat"
 
 # Returns 0 if found and 1 if not found
 # Task fails if not found.  Hence ignore_errors: true
@@ -14,11 +14,11 @@
   register: have_epel
   no_log: true
   ignore_errors: true
-  when: ansible_pkg_mgr == "yum"
+  when: ansible_os_family == "RedHat"
 
 # This task is only run when epel isn't present
 - name: Install nrpe without epel
-  yum:
+  package:
     name: "{{ item }}"
     state: present
   with_items:
@@ -26,20 +26,24 @@
     - http://{{ mirror_host }}/lab-extras/rhel7/x86_64/nrpe-2.15-7.el7.x86_64.rpm
     - http://{{ mirror_host }}/lab-extras/rhel7/x86_64/nagios-plugins-2.0.3-3.el7.x86_64.rpm
     - http://{{ mirror_host }}/lab-extras/rhel7/x86_64/nagios-plugins-load-2.0.3-3.el7.x86_64.rpm
-  when: ansible_pkg_mgr == "yum" and
-        have_epel.rc == 1
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version <= 7
+    - have_epel.rc == 1
 
 - name: Install nrpe package and dependencies (RHEL/CentOS)
-  yum:
+  package:
     name: "{{ item }}"
     state: latest
     enablerepo: epel
   with_items: "{{ nrpe_packages }}"
-  when: ansible_pkg_mgr == "yum" and
-        have_epel.rc == 0
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version <= 7
+    - have_epel.rc == 0
 
 - name: Install nrpe package and dependencies (Ubuntu)
-  apt:
+  package:
     name: "{{ item }}"
     state: latest
   with_items: "{{ nrpe_packages }}"
@@ -74,14 +78,14 @@
     dest: /etc/sysconfig/{{ nrpe_service_name }}
     regexp: "^NRPE_SSL_OPT"
     line: "NRPE_SSL_OPT=\"-n\""
-  when: ansible_pkg_mgr == "yum"
+  when: ansible_os_family == "RedHat"
 
 - name: Check firewalld status
   command: systemctl status firewalld
   register: firewalld
   ignore_errors: true
   no_log: true
-  when: ansible_pkg_mgr == "yum"
+  when: ansible_os_family == "RedHat"
 
 - name: Open nrpe port if firewalld enabled
   firewalld:
@@ -89,7 +93,7 @@
     state: enabled
     permanent: yes
     immediate: yes
-  when: ansible_pkg_mgr == "yum" and (firewalld is defined and firewalld.stdout.find('running') != -1)
+  when: ansible_os_family == "RedHat" and (firewalld is defined and firewalld.stdout.find('running') != -1)
 
 - name: Upload nagios nrpe config.
   template:

--- a/roles/common/tasks/rhel-entitlements.yml
+++ b/roles/common/tasks/rhel-entitlements.yml
@@ -47,6 +47,9 @@
   until: entitled|success
   retries: 5
   delay: 10
+  failed_when:
+    - entitled.rc != 0
+    - '"Beta" not in ansible_lsb.description'
 
 - name: Set rhsm_registered if we just registered
   set_fact:
@@ -61,7 +64,10 @@
   shell: "subscription-manager release --list | grep -E '[0-9]'"
   register: rhsm_release_list
   changed_when: false
-  failed_when: rhsm_release_list.rc != 0 and "Beta" not in ansible_lsb.description
+  failed_when:
+    - rhsm_release_list.rc != 0
+    - ansible_lsb.description is defined
+    - '"Beta" not in ansible_lsb.description'
 
 # We don't need to be registered to CDN since there's no packages available
 # for this Beta/Alpha/RC installation

--- a/roles/common/tasks/yum_systems.yml
+++ b/roles/common/tasks/yum_systems.yml
@@ -9,7 +9,7 @@
 
 - name: Get the current timezone (RHEL/CentOS 7)
   shell: 'timedatectl | grep -E "Time ?zone" | sed -e "s/.*: \(.*\) (.*/\1/"'
-  when: ansible_distribution_major_version == "7"
+  when: ansible_distribution_major_version >= "7"
   register: current_tz
   changed_when: false
   tags:
@@ -26,10 +26,10 @@
   tags:
     - timezone
 
-- name: Set the timezone (RHEL/CentOS 7)
+- name: Set the timezone (RHEL/CentOS >= 7)
   command: timedatectl set-timezone {{ timezone }}
   # Default is used below to avoid breaking check mode
-  when: ansible_distribution_major_version == "7" and current_tz.stdout|default("") != timezone
+  when: ansible_distribution_major_version >= "7" and current_tz.stdout|default("") != timezone
   tags:
     - timezone
 

--- a/roles/common/vars/redhat_8.yml
+++ b/roles/common/vars/redhat_8.yml
@@ -1,0 +1,19 @@
+---
+# RHEL8 repos are not yet available via RHSM
+rhsm_repos: []
+
+# Don't use satellite until RHEL8 is GAed
+use_satellite: false
+
+# These are temporary until RHEL8 is GAed
+beta_repos:
+  rhel-beta-baseos:
+    name: "RHEL {{ ansible_distribution_version }} BaseOS (RPMs)"
+    baseurl: "https://downloads.redhat.com/redhat/rhel/rhel-8-beta/baseos/x86_64/"
+    enabled: 1
+    gpgcheck: 0
+  rhel-beta-appstream:
+    name: "RHEL {{ ansible_distribution_version }} AppStream (RPMs)"
+    baseurl: "https://downloads.redhat.com/redhat/rhel/rhel-8-beta/appstream/x86_64/"
+    enabled: 1
+    gpgcheck: 0

--- a/roles/testnode/tasks/main.yml
+++ b/roles/testnode/tasks/main.yml
@@ -31,7 +31,7 @@
 
 - name: configure things specific to yum systems
   import_tasks: yum_systems.yml
-  when: ansible_pkg_mgr == "yum"
+  when: ansible_os_family == "RedHat"
 
 - name: configure things specific to apt systems
   import_tasks: apt_systems.yml
@@ -95,6 +95,9 @@
 - import_tasks: cpan.yml
   tags:
     - cpan
+  when:
+    - ansible_os_family != "RedHat"
+    - ansible_distribution_major_version != 8
 
 # configure ntp
 - import_tasks: ntp.yml

--- a/roles/testnode/tasks/yum/packages.yml
+++ b/roles/testnode/tasks/yum/packages.yml
@@ -1,14 +1,20 @@
 ---
 # this is needed for the yum-complete-transation command next
 - name: Ensure yum_utils is present.
-  yum:
+  package:
     name: yum-utils
     state: present
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version <= 7
 
 - name: Removing saved yum transactions
   command: yum-complete-transaction --cleanup-only
   register: transaction_cleanup
   changed_when: "'Cleaning up' in transaction_cleanup.stdout"
+  when:
+    - ansible_os_family == "RedHat"
+    - ansible_distribution_major_version <= 7
 
 - name: Check if ceph-debuginfo is installed
   command: rpm -q ceph-debuginfo
@@ -25,7 +31,7 @@
     - remove-ceph
 
 - name: Ensure ceph packages are not present.
-  yum:
+  package:
     name: "{{ item }}"
     state: absent
   with_items: "{{ ceph_packages_to_remove }}"
@@ -33,7 +39,7 @@
     - remove-ceph
 
 - name: Ensure ceph dependency packages are not present.
-  yum:
+  package:
     name: "{{ item }}"
     state: absent
   with_items: "{{ ceph_dependency_packages_to_remove }}"
@@ -42,14 +48,14 @@
 
 
 - name: Install packages
-  yum:
+  package:
     name: "{{ item }}"
     state: present 
   with_items: "{{ packages }}"
   when: packages|length > 0
 
 - name: Install epel packages
-  yum:
+  package:
     name: "{{ item }}"
     state: present
     enablerepo: epel
@@ -57,14 +63,14 @@
   when: epel_packages|length > 0
 
 - name: Remove packages
-  yum:
+  package:
     name: "{{ item }}"
     state: absent
   with_items: "{{ packages_to_remove }}"
   when: packages_to_remove|length > 0
 
 - name: Upgrade packages
-  yum:
+  package:
     name: "{{ item }}"
     state: latest
   with_items: "{{ packages_to_upgrade }}"

--- a/roles/testnode/tasks/zap_disks.yml
+++ b/roles/testnode/tasks/zap_disks.yml
@@ -13,7 +13,7 @@
   when: ansible_os_family == "Debian"
 
 - name: Make sure rpm dependencies are installed
-  yum:
+  package:
     name: "{{ item }}"
     state: present
   with_items:

--- a/roles/testnode/templates/ssh/sshd_config_redhat_8
+++ b/roles/testnode/templates/ssh/sshd_config_redhat_8
@@ -1,0 +1,38 @@
+# {{ ansible_managed }}
+#	$OpenBSD: sshd_config,v 1.90 2013/05/16 04:09:14 dtucker Exp $
+
+# This is the sshd server system-wide configuration file.  See
+# sshd_config(5) for more information.
+
+# This sshd was compiled with PATH=/usr/local/bin:/usr/bin
+
+HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
+
+SyslogFacility AUTHPRIV
+
+AuthorizedKeysFile	.ssh/authorized_keys
+
+PasswordAuthentication yes
+
+ChallengeResponseAuthentication no
+
+# GSSAPI options
+GSSAPIAuthentication yes
+GSSAPICleanupCredentials yes
+
+UsePAM yes
+
+X11Forwarding yes
+UsePrivilegeSeparation sandbox		# Default for new installations.
+
+# Accept locale-related environment variables
+AcceptEnv LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES
+AcceptEnv LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT
+AcceptEnv LC_IDENTIFICATION LC_ALL LANGUAGE
+AcceptEnv XMODIFIERS
+
+# override default of no subsystems
+Subsystem	sftp	/usr/libexec/openssh/sftp-server
+
+MaxSessions 1000

--- a/roles/testnode/vars/dnf_systems.yml
+++ b/roles/testnode/vars/dnf_systems.yml
@@ -1,0 +1,1 @@
+yum_systems.yml

--- a/roles/testnode/vars/redhat_8.yml
+++ b/roles/testnode/vars/redhat_8.yml
@@ -1,0 +1,36 @@
+---
+# vars specific to any rhel 8.x version
+
+common_yum_repos: {}
+
+packages:
+  - '@core'
+  - '@base'
+  - sysstat
+  - libedit
+  - boost-thread
+  - xfsprogs
+  - gdisk
+  - parted
+  - libgcrypt
+  - fuse-libs
+  - openssl
+  - libuuid
+  - attr
+  - ant
+  - lsof
+  - gettext
+  - bc
+  - xfsdump
+  - blktrace
+  - usbredir
+  - libev-devel
+  # for xfstests
+  - ncurses-devel
+  # for s3 tests
+
+epel_packages: []
+
+nfs_service: nfs-server
+
+ntp_service_name: chronyd

--- a/set_python_path.yml
+++ b/set_python_path.yml
@@ -1,0 +1,18 @@
+---
+# This will set ansible_python_interpreter to use python3
+# if the shell module fails (like it will on RHEL8 since
+# /usr/bin/python is no more).
+- hosts: all
+  gather_facts: false
+  vars:
+    ansible_ssh_user: "{{ cm_user }}"
+  become: true
+  tasks:
+    - name: Check for /usr/bin/python
+      shell: echo marco
+      register: polo
+      ignore_errors: true
+    - name: Set ansible_python_interpreter=/usr/bin/python3
+      set_fact:
+        ansible_python_interpreter: /usr/bin/python3
+      when: polo.rc != 0


### PR DESCRIPTION
### cobbler
- `libselinux-python, libsemanage-python, policycoreutils-python, ntp, python-jwt` are not available in RHEL8 so they're skipped in the `cephlab_packages_rhel` snippet.
- Replaced `wget` with `curl` in `snippets/cephlab_rc_local` since curl is universally available and installed by default.  At the time I first started working on these changes, wget wasn't packaged for RHEL8 yet.

### common
- `s/ansible_pkg_mgr/ansible_os_family` - `ansible_pkg_mgr` was skipping a lot of tasks because `ansible_pkg_mgr=dnf` for RHEL8.
- `s/yum:/package:` - `package` is a package-manager-agnostic module that will use dnf or yum.
- In `rhel-entitlements.yml`, the `Register with subscription-manager.` task would return 0 but there aren't any RHEL8 repos in RHSM yet.  So the play doesn't successfully identify the OS as Beta.  I added a few additional `failed_when` to ensure RHEL7 and RHEL8 Beta distros get identified so `beta_repos.yml` is called.
- There is no nagios or epel for RHEL8 yet so those tasks are skipped for now

### testnode
- `yum-complete-transaction`, `yum-utils` are not available in RHEL8.  Since we use FOG now, those tasks are irrelevant anyway because the yum cache is updated earlier in the play.
- CPAN installation fails on RHEL8