### PR TITLE
cobbler: Set SELinux = enforcing by default

### DIFF
--- a/roles/cobbler/templates/kickstarts/cephlab_rhel.ks
+++ b/roles/cobbler/templates/kickstarts/cephlab_rhel.ks
@@ -29,7 +29,7 @@ reboot
 #Root password
 rootpw --iscrypted $default_password_crypted
 # SELinux configuration
-selinux --permissive
+selinux --enforcing
 # Do not configure the X Window System
 skipx
 # System timezone

--- a/roles/cobbler/templates/kickstarts/cephlab_rhel_sdm.ks
+++ b/roles/cobbler/templates/kickstarts/cephlab_rhel_sdm.ks
@@ -43,7 +43,7 @@ reboot
 #Root password
 rootpw --iscrypted $default_password_crypted
 # SELinux configuration
-selinux --permissive
+selinux --enforcing
 # Do not configure the X Window System
 skipx
 # System timezone


### PR DESCRIPTION
Requested by downstream QE.  This shouldn't be an issue since only
downstream QE needs SELinux in Enforcing mode.  They don't use
ceph-cm-ansible which sets it to Permissive in the testnodes role.

Fixes: http://tracker.ceph.com/issues/37338

Signed-off-by: David Galloway <dgallowa@redhat.com>