### PR TITLE
cobbler: Only install python-jwt on RHEL7.5 or later

### DIFF
--- a/roles/cobbler/templates/snippets/cephlab_packages_rhel
+++ b/roles/cobbler/templates/snippets/cephlab_packages_rhel
@@ -8,14 +8,17 @@
 @base
 #end if
 #if $distro == 'RHEL'
-#set distro_ver = $distro_ver.split(".")[0]
+#set distro_ver_major = $distro_ver.split(".")[0]
+#set distro_ver_minor = $distro_ver.split(".")[1]
 #end if
-#if not int($distro_ver) == 8
+#if not int($distro_ver_major) == 8
 libselinux-python
 libsemanage-python
 policycoreutils-python
 ntp
+#if int($distro_ver_minor) >= 5
 python-jwt
+#end if
 #else
 python3
 #end if


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/37395

Signed-off-by: David Galloway <dgallowa@redhat.com>