### PR TITLE
add GPG checking for RHEL 8

### DIFF
--- a/roles/common/vars/redhat_8.yml
+++ b/roles/common/vars/redhat_8.yml
@@ -11,9 +11,11 @@ beta_repos:
     name: "RHEL {{ ansible_distribution_version }} BaseOS (RPMs)"
     baseurl: "https://downloads.redhat.com/redhat/rhel/rhel-8-beta/baseos/x86_64/"
     enabled: 1
-    gpgcheck: 0
+    gpgcheck: 1
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
   rhel-beta-appstream:
     name: "RHEL {{ ansible_distribution_version }} AppStream (RPMs)"
     baseurl: "https://downloads.redhat.com/redhat/rhel/rhel-8-beta/appstream/x86_64/"
     enabled: 1
-    gpgcheck: 0
+    gpgcheck: 1
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release


### PR DESCRIPTION
The RHEL 8 beta is GPG-signed, so we might as well verify signatures.