### PR TITLE
common: After reboot, wait longer before polling for connection

### DIFF
--- a/roles/common/tasks/yum_systems.yml
+++ b/roles/common/tasks/yum_systems.yml
@@ -27,7 +27,7 @@
 
 - name: Wait for reboot in case of systemd workaround
   wait_for_connection:
-    delay: 20
+    delay: 40
     timeout: 300
   when: '"Connection timed out" in current_tz.stderr'
   tags:


### PR DESCRIPTION
In some instances, the mira still hadn't rebooted before wait_for_connection ran.

Example: http://qa-proxy.ceph.com/teuthology/laura-2019-02-13_13:30:43-rados:mgr-wip-lpaduano-testing-26325-distro-basic-mira/3584174/teuthology.log

Signed-off-by: David Galloway <dgallowa@redhat.com>