### PR TITLE
teuthology: make sure beanstalkd is running

### DIFF
--- a/roles/teuthology/tasks/main.yml
+++ b/roles/teuthology/tasks/main.yml
@@ -42,3 +42,9 @@
 - import_tasks: setup_log_access.yml
   tags:
     - logs
+
+- name: Enable and start beanstalkd
+  service:
+    name: beanstalkd
+    state: started
+    enabled: yes


### PR DESCRIPTION
The beanstalkd service should be running before any
try to start workers up

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@gmail.com>