### PR TITLE
long_running_cluster: Keep fewer logs & update postrotate

### DIFF
--- a/roles/long_running_cluster/templates/ceph-common.logrotate
+++ b/roles/long_running_cluster/templates/ceph-common.logrotate
@@ -1,10 +1,10 @@
 # {{ ansible_managed }}
 /var/log/ceph/*.log {
-    rotate 12
+    rotate 6
     compress
     sharedscripts
     postrotate
-        killall -q -1 ceph-mon ceph-mgr ceph-mds ceph-osd ceph-fuse radosgw || true
+        killall -q -1 ceph-mon ceph-mgr ceph-mds ceph-osd ceph-fuse radosgw || pkill -1 -x "ceph-mon|ceph-mgr|ceph-mds|ceph-osd|ceph-fuse|radosgw" || true
     endscript
     missingok
     notifempty


### PR DESCRIPTION
I guess the logrotate config was updated in the actual Ceph packages at some point so I'm updating this template to match.

Also, we need to keep fewer logs because the reesi keep filling up.

Signed-off-by: David Galloway <dgallowa@redhat.com>