### PR TITLE
cobbler: Update RHEL disk partition snippet for RHEL8

### DIFF
--- a/roles/cobbler/templates/snippets/cephlab_rhel_disks
+++ b/roles/cobbler/templates/snippets/cephlab_rhel_disks
@@ -9,6 +9,9 @@ zerombr
 # System bootloader configuration
 #if $os_version == 'rhel7'
     #set bootloader_args = "--location=mbr --boot-drive=sda"
+#else if $os_version == 'rhel8'
+    #set bootloader_args = "--location=mbr --boot-drive=sda"
+ignoredisk --only-use=sda
 #else
     #set bootloader_args = "--location=mbr --driveorder=sda"
 #end if


### PR DESCRIPTION
Syntax was incorrect and caused issues on systems where /dev/sda isn't the first disk in the system.

Signed-off-by: David Galloway <dgallowa@redhat.com>