### PR TITLE
Updating ISO Image for Ubuntu-16-04

### DIFF
--- a/roles/cobbler_profile/defaults/main.yml
+++ b/roles/cobbler_profile/defaults/main.yml
@@ -85,7 +85,7 @@ distros:
       kernel_options: "netcfg/choose_interface=auto console=tty0 console=ttyS1,115200"
       kernel_options_post: "pci=realloc=off console=tty0 console=ttyS1,115200"
   "Ubuntu-16.04-server-x86_64":
-      iso: "http://releases.ubuntu.com/16.04/ubuntu-16.04.3-server-amd64.iso"
+      iso: "http://releases.ubuntu.com/16.04/ubuntu-16.04.6-server-amd64.iso"
       sha256: a06cd926f5855d4f21fb4bc9978a35312f815fbda0d0ef7fdc846861f4fc4600
       kickstart: cephlab_ubuntu.preseed
       kernel_options: "netcfg/choose_interface=auto console=tty0 console=ttyS1,115200"


### PR DESCRIPTION
The copy of the image wore too old to work with kickstart

Signed-off-by: Adam Kraitman <akraitma@redhat.com>