### PR TITLE
testnode: Don't set priority for additional repos

### DIFF
--- a/roles/testnode/vars/centos_7.yml
+++ b/roles/testnode/vars/centos_7.yml
@@ -7,13 +7,11 @@ yum_repos:
     baseurl: "http://{{ gitbuilder_host }}/mod_fastcgi-rpm-centos7-x86_64-basic/ref/master/"
     enabled: 1
     gpgcheck: 0
-    priority: 2
   lab-extras:
     name: lab-extras
     baseurl: "http://{{ mirror_host }}/lab-extras/centos7/"
     enabled: 1
     gpgcheck: 0
-    priority: 2
 
 packages:
   - '@core'

--- a/roles/testnode/vars/redhat_7.6.yml
+++ b/roles/testnode/vars/redhat_7.6.yml
@@ -7,13 +7,11 @@ common_yum_repos:
     baseurl: "http://{{ gitbuilder_host }}/mod_fastcgi-rpm-rhel7-x86_64-basic/ref/master/"
     enabled: 1
     gpgcheck: 0
-    priority: 2
   lab-extras:
     name: "lab-extras"
     baseurl: "http://{{ mirror_host }}/lab-extras/rhel7/"
     enabled: 1
     gpgcheck: 0
-    priority: 2
 
 packages:
   - '@core'

--- a/roles/testnode/vars/redhat_7.yml
+++ b/roles/testnode/vars/redhat_7.yml
@@ -7,13 +7,11 @@ common_yum_repos:
     baseurl: "http://{{ gitbuilder_host }}/mod_fastcgi-rpm-rhel7-x86_64-basic/ref/master/"
     enabled: 1
     gpgcheck: 0
-    priority: 2
   lab-extras:
     name: "lab-extras"
     baseurl: "http://{{ mirror_host }}/lab-extras/rhel7/"
     enabled: 1
     gpgcheck: 0
-    priority: 2
 
 packages:
   - '@core'


### PR DESCRIPTION
Downstream QE was seeing an issue where a newer version of a package was required but the version in lab-extras was being pinned because the priority was set to high.

IMO, we should be letting whichever repo (regardless of source) install the latest package(s).

Signed-off-by: David Galloway <dgallowa@redhat.com>