### PR TITLE
common: Don't mess with pcp selinux modules

### DIFF
--- a/roles/common/tasks/nrpe-selinux.yml
+++ b/roles/common/tasks/nrpe-selinux.yml
@@ -20,41 +20,6 @@
     state: yes
     persistent: yes
 
-# See http://tracker.ceph.com/issues/19126 and 
-# http://tracker.ceph.com/issues/21403 for details on next 5 tasks
-- name: nrpe - Clean up cephlab SELinux policy modules
-  file:
-    path: "/etc/selinux/targeted/active/modules/400/{{ item }}"
-    state: absent
-  with_items:
-    - mod_fastcgi
-    - nrpe
-
-# We don't remove the pcpupstream module in the previous task because the
-# pcp role gets run before common so we have to check it individually
-- name: Check for corrupt pcpupstream SELinux policy module
-  stat:
-    path: /etc/selinux/targeted/active/modules/400/pcpupstream/lang_ext
-  register: pcpupstream_module_status
-
-- name: Reinstall pcp-selinux if pcpupstream module is corrupt
-  shell: yum -y remove pcp-selinux && yum -y install pcp-selinux
-  ignore_errors: true
-  when:
-    - pcpupstream_module_status is defined
-    - pcpupstream_module_status.stat.size == 0
-
-- name: Check for any empty SELinux module files
-  shell: find /etc/selinux/targeted/active/modules/100 -type f -empty -name lang_ext
-  register: selinux_module_status
-
-# ignore_errors in case the package isn't available or installed.
-# The ansible yum module doesn't appear to have a reinstall option.
-- name: Reinstall selinux-policy-targeted if modules are corrupt
-  command: yum -y reinstall selinux-policy-targeted
-  when: selinux_module_status.stdout != ''
-  ignore_errors: true
-
 - name: nrpe - Remove SELinux policy package
   command: semodule -r nrpe
   failed_when: false


### PR DESCRIPTION
Not only are we not using pcp anymore but we also reimage machines before every job so they modules can't get corrupt in the first place.

Signed-off-by: David Galloway <dgallowa@redhat.com>