### PR TITLE
testnode: remove multipath

### DIFF
--- a/roles/testnode/vars/apt_systems.yml
+++ b/roles/testnode/vars/apt_systems.yml
@@ -3,6 +3,10 @@ ntp_service_name: ntp
 ssh_service_name: ssh
 nfs_service: nfs-kernel-server
 
+packages_to_remove:
+  # multipath interferes with krbd tests
+  - multipath-tools
+
 ceph_packages_to_remove:
   - ceph
   - ceph-common

--- a/roles/testnode/vars/yum_systems.yml
+++ b/roles/testnode/vars/yum_systems.yml
@@ -2,6 +2,10 @@
 ntp_service_name: ntpd
 ssh_service_name: sshd
 
+packages_to_remove:
+  # multipath interferes with krbd tests
+  - device-mapper-multipath
+
 # ceph packages that we ensure do not exist
 ceph_packages_to_remove:
   - ceph

--- a/roles/testnode/vars/zypper_systems.yml
+++ b/roles/testnode/vars/zypper_systems.yml
@@ -6,6 +6,10 @@ nrpe_user: nrpe
 nrpe_group: nrpe
 nagios_plugins_directory: /usr/lib64/nagios/plugins
 
+packages_to_remove:
+  # multipath interferes with krbd tests
+  - multipath-tools
+
 # ceph packages that we ensure do not exist
 ceph_packages_to_remove:
   - ceph


### PR DESCRIPTION
multipath can interfere with krbd tests, particularly with
krbd_udev_enumerate.yaml.  Much like udev, multipath opens block
devices behind the scenes, making the block device busy when it
shouldn't be.

None of the lab tests depend on multipath (it's not installed on
ubuntu), so just remove it rather than messing with /etc/multipath.conf
and restarting multipathd.  If the need for multipath comes up, rbd
devices would need to be blacklisted like so:

  blacklist {
          devnode "^rbd[0-9]+"
  }

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>