### PR TITLE
Adding rook-recovery role which can be used for deploying the rook je…

### DIFF
--- a/roles/rook-recovery/README.rst
+++ b/roles/rook-recovery/README.rst
@@ -1,0 +1,8 @@
+rook-recovery
+==========
+
+This role is used to deploy the rook jenkins instance in the rook CI aws vpc, The deployed instance will have two ebs volumes where the jobs and the jobs configuration data is located 
+
+Notes
++++++
+In order to make him available the to public network once the instance is deployed you will need to add him to the load balancing target group under the rook ci vpc

--- a/roles/rook-recovery/meta/main.yml
+++ b/roles/rook-recovery/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: secrets

--- a/roles/rook-recovery/tasks/main.yml
+++ b/roles/rook-recovery/tasks/main.yml
@@ -1,0 +1,66 @@
+---
+  - name: Include secrets
+    include_vars: "{{ secrets_path | mandatory }}/aws.yaml"
+    no_log: true
+    tags:
+      - always
+
+  - name: Launch instance
+    ec2:
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      key_name: "{{ keypair }}"
+      group: "{{ security_group }}"
+      instance_type: "{{ instance_type }}"
+      image: "{{ image }}"
+      wait: true
+      region: "{{ region }}"
+      vpc_subnet_id: "{{ vpc_subnet_id }}" 
+      assign_public_ip: yes
+      instance_tags: "{{ aws_tags }}"
+      wait: yes
+    register: ec2_instances
+
+  - name: print ec2 facts
+    debug:
+      var: ec2_instances
+
+  - name: Set name tag for AWS instance
+    ec2_tag:
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      region: "{{ region }}"
+      resource: "{{ item.1.id }}"
+      tags:
+        Name: "{{ aws_tags.Name }}-{{ '%02d' | format(item.0 + 1) }}"
+    with_indexed_items: "{{ ec2_instances.instances }}"
+    loop_control:
+      label: "{{ item.1.id }} - {{ aws_tags.Name }}-{{ '%02d' | format(item.0 + 1) }}"
+
+  - name: Wait for SSH to come up
+    wait_for: host={{ item.public_ip }} port=22 delay=60 timeout=320 state=started
+    with_items: '{{ ec2_instances.instances }}'
+    loop_control:
+      label: "{{ item.id }} - {{ item.public_ip }}"
+
+  - name: Remove jenkins docker old container
+    command: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@"{{ item.public_ip }}" sudo docker rm jenkins
+    with_items: '{{ ec2_instances.instances }}'
+    loop_control:
+      label: "{{ item.id }} - {{ item.public_ip }}"
+
+  - name: Start jenkins container
+    command: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no ubuntu@"{{ item.public_ip }}" sudo docker run -d --name jenkins -p 8080:8080 -p 50000:50000 -v /mnt/jenkins/jenkins:/var/jenkins_home "{{ jenkins_image }}" 
+    with_items: '{{ ec2_instances.instances }}'
+    loop_control:
+      label: "{{ item.id }} - {{ item.public_ip }}"
+
+  - name: The instance was succssfuly started  
+    debug:
+      msg:
+      - "The Rook Jenkins is up and running the instance is named: {{ aws_tags.Name }}-{{ '%02d' | format(item.0 + 1) }}" 
+      - "In order to make him avalible to public network you will need to add him to the load balancing target group"
+    with_indexed_items: "{{ ec2_instances.instances }}"
+    loop_control:
+      label: "{{ item.1.id }} - {{ aws_tags.Name }}-{{ '%02d' | format(item.0 + 1) }}"
+

--- a/roles/rook-recovery/vars/main.yml
+++ b/roles/rook-recovery/vars/main.yml
@@ -1,0 +1,12 @@
+---
+jenkins_image: jenkins/jenkins:2.190.1
+keypair: root-jenkins-new-key
+instance_type: m4.large
+security_group: rook-jenkins-group
+image: ami-09c003703cafa9056
+region: us-east-1
+vpc_subnet_id: subnet-c72b609b
+instance_name: Recovery-Rook-Jenkins
+aws_tags:
+  Name: "{{ instance_name }}"
+  Application: "Jenkins"

--- a/rook-recovery.yml
+++ b/rook-recovery.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  gather_facts: False
+  roles:
+    - rook-recovery 


### PR DESCRIPTION
…nkins instance in the rook CI aws vpc, The deployied instance will have two ebs volumes were the jobs and the jobs configuration data is located

Signed-off-by: Adam Kraitman <akraitma@redhat.com>