### PR TITLE
users: Tasks to allow skipping of role if all users/keys are already up to date

### DIFF
--- a/roles/users/README.rst
+++ b/roles/users/README.rst
@@ -88,6 +88,14 @@ A list of usernames whose access is to be revoked::
 
     revoked_users: []
 
+The users role writes a sentinel file, ``/keys-repo-sha1``, to indicate the sha1 of the keys repo when ceph-cm-ansible last ran.  If the sha1 in that file matches the current keys repo HEAD sha1, users tasks will be skipped unless you set ``force_users_update: True``::
+
+    force_users_update: False
+
+By default, the users and pubkeys should be updated.  A task in ``main.yml`` changes this to ``False`` if the machine's users and keys are already up to date (unless ``force_users_update: True``)::
+
+    perform_users_role: True
+
 Tags
 ++++
 

--- a/roles/users/defaults/main.yml
+++ b/roles/users/defaults/main.yml
@@ -27,3 +27,9 @@ revoked_users: []
 keys_repo: "https://github.com/ceph/keys"
 # Where to clone keys_repo on the *local* disk
 keys_repo_path: "~/.cache/src/keys"
+
+# If the keys git repo HEAD sha1 matches the sha1 of the host's /keys-repo-sha1 file, the users role will get skipped to save time.
+# Update users and pubkeys by default (this is changed to False during the play if keys_repo_head.stdout == sentinel_sha1.stdout)
+perform_users_role: True
+# Set this to True if you want to run the users tasks anyway
+force_users_update: False

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -1,17 +1,53 @@
 ---
+- name: Check keys_repo HEAD sha1
+  shell: "git ls-remote {{ keys_repo }} HEAD | awk '{ print $1 }'"
+  register: keys_repo_head
+  become: false
+  when: keys_repo is defined
+  connection: local
+  run_once: true
+  retries: 5
+  delay: 10
+  # perform_users_role is True by default so no need to fail the play if there's an error.
+  ignore_errors: true
+
+- name: Check host's /keys-repo-sha1 sentinel file
+  command: cat /keys-repo-sha1
+  register: sentinel_sha1
+  # perform_users_role is True by default so no need to fail the play if there's an error.
+  failed_when: false
+
+- name: Determine if we can skip users and pubkeys updates
+  set_fact:
+    perform_users_role: False
+  # perform_users_role is True by default so no need to fail the play if there's an error.
+  ignore_errors: true
+  when: (keys_repo_head.stdout == sentinel_sha1.stdout) and
+        not force_users_update
+
 - import_tasks: filter_users.yml
+  when: perform_users_role
   tags:
     - always
 
 - import_tasks: create_users.yml
+  when: perform_users_role
   tags:
     - user
 
 - import_tasks: update_keys.yml
+  when: perform_users_role
   tags:
     - pubkeys
 
 - import_tasks: revoke_users.yml
+  when: perform_users_role
   tags:
     - user
     - revoke
+
+- name: Write /keys-repo-sha1 sentinel file
+  copy:
+    content: "{{ keys_repo_head.stdout }}"
+    dest: /keys-repo-sha1
+  when: keys_repo_head is defined


### PR DESCRIPTION
I'd like some input on this.

1) Is there a better way to do https://github.com/ceph/ceph-cm-ansible/compare/wip-skip-users?expand=1#diff-9ac36c3dbec0caf35aa4369ba60b54bdR20-R29

2) I couldn't find an ansible module to do https://github.com/ceph/ceph-cm-ansible/compare/wip-skip-users?expand=1#diff-9ac36c3dbec0caf35aa4369ba60b54bdR15 better than just `cat`ing the file.  Did I miss something?  `slurp:` didn't do what I wanted.

3) Am I missing any edge cases where this could go wrong?  I tried to get it so that if there are any problems with `git` locally or reading the sentinel file that the tasks would still run.

As long as we keep the FOG images up to date when we add new lab users, this would save a minute per testnode per job.

Signed-off-by: David Galloway <dgallowa@redhat.com>