### PR TITLE
cobbler: Add RHEL7.8

### DIFF
--- a/cobbler.yml
+++ b/cobbler.yml
@@ -16,6 +16,7 @@
     - { role: cobbler_profile, distro_name: RHEL-7.5-Server-x86_64, tags: ['rhel7.5'] }
     - { role: cobbler_profile, distro_name: RHEL-7.6-Server-x86_64, tags: ['rhel7.6'] }
     - { role: cobbler_profile, distro_name: RHEL-7.7-Server-x86_64, tags: ['rhel7.7'] }
+    - { role: cobbler_profile, distro_name: RHEL-7.8-Server-x86_64, tags: ['rhel7.8'] }
     - { role: cobbler_profile, distro_name: RHEL-8.0-Server-x86_64, tags: ['rhel8.0'] }
     - { role: cobbler_profile, distro_name: Fedora-22-Server-x86_64, tags: ['fedora22'] }
     - { role: cobbler_profile, distro_name: CentOS-6.7-x86_64, tags: ['centos6.7'] }

--- a/roles/cobbler_profile/defaults/main.yml
+++ b/roles/cobbler_profile/defaults/main.yml
@@ -30,6 +30,8 @@ distros:
       iso: ""
   "RHEL-7.7-Server-x86_64":
       iso: ""
+  "RHEL-7.8-Server-x86_64":
+      iso: ""
   "RHEL-8.0-Server-x86_64":
       iso: ""
   "Fedora-22-Server-x86_64":

--- a/roles/testnode/vars/redhat_7.8.yml
+++ b/roles/testnode/vars/redhat_7.8.yml
@@ -1,0 +1,87 @@
+---
+# vars specific to any rhel 7.x version
+
+common_yum_repos:
+  rhel-7-fcgi-ceph:
+    name: "RHEL 7 Local fastcgi Repo"
+    baseurl: "http://{{ gitbuilder_host }}/mod_fastcgi-rpm-rhel7-x86_64-basic/ref/master/"
+    enabled: 1
+    gpgcheck: 0
+  lab-extras:
+    name: "lab-extras"
+    baseurl: "http://{{ mirror_host }}/lab-extras/rhel7/"
+    enabled: 1
+    gpgcheck: 0
+
+packages:
+  - '@core'
+  - '@base'
+  - yum-plugin-priorities
+  - yum-plugin-fastestmirror
+  - redhat-lsb
+  - sysstat
+  - gdb
+  - git-all
+  - python-configobj
+  - gcc-c++
+  - libedit
+  - openssl098e
+  - boost-thread
+  - xfsprogs
+  - xfsprogs-devel
+  - gdisk
+  - parted
+  - libgcrypt
+  - fuse
+  - fuse-libs
+  - lvm2
+  - openssl
+  - libuuid
+  - btrfs-progs
+  - attr
+  - valgrind
+  - python-nose
+  - mpich
+  - ant
+  - lsof
+  - iozone
+  - libtool
+  - automake
+  - gettext
+  - libuuid-devel
+  - libacl-devel
+  - bc
+  - xfsdump
+  - blktrace
+  - numpy
+  - python-matplotlib
+  - qemu-kvm
+  - usbredir
+  - genisoimage
+  - httpd
+  - httpd-devel
+  - httpd-tools
+  - mod_ssl
+  - mod_fastcgi-2.4.7-1.ceph.el7
+  - perl-XML-Twig
+  - java-1.6.0-openjdk-devel
+  - junit4
+  - nfs-utils
+  # for xfstests
+  - ncurses-devel
+  # for s3 tests
+  - python-devel
+  - python-virtualenv
+  - perl-CPAN
+
+epel_packages:
+  - cryptopp-devel
+  - cryptopp
+  - dbench
+  - fcgi
+  - fuse-sshfs
+  - perl-JSON-XS
+  - leveldb
+  - xmlstarlet
+
+nfs_service: nfs-server


### PR DESCRIPTION
A separate `packages` list was required because podman and libev-devel are missing (from the beta at least).

Signed-off-by: David Galloway <dgallowa@redhat.com>