### PR TITLE
common: rm yum cache that doesn't get cleaned yum `yum clean`

### DIFF
--- a/roles/common/tasks/epel.yml
+++ b/roles/common/tasks/epel.yml
@@ -37,7 +37,7 @@
   with_dict: "{{ epel_repos }}"
 
 - name: Update yum cache
-  shell: yum clean all; yum makecache
+  shell: rm -rf /var/cache/yum/*; yum clean all; yum makecache
 
 - name: Uncomment mirrorlist
   replace:


### PR DESCRIPTION
Why is this even necessary?

Signed-off-by: David Galloway <dgallowa@redhat.com>