### PR TITLE
generate-fog-csv: Support setting alternate 'Host Primary Disk' in FOG

### DIFF
--- a/tools/roles/generate-fog-csv/templates/csv.j2
+++ b/tools/roles/generate-fog-csv/templates/csv.j2
@@ -1,3 +1,3 @@
 {% for host in groups['cobbler_managed'] %}
-"{{ hostvars[host]['mac'] }}","{{ hostvars[host]['inventory_hostname_short'] }}","","","1","0","","","fog","","","","","","","","","{{ hostvars[host]['kernel_options'] }}","","/dev/sda","","","","","0000-00-00 00:00:00","110","","",""
+"{{ hostvars[host]['mac'] }}","{{ hostvars[host]['inventory_hostname_short'] }}","","","1","0","","","fog","","","","","","","","","{{ hostvars[host]['kernel_options'] }}","","{{ hostvars[host]['fog_install_drive']|default('/dev/sda') }}","","","","","0000-00-00 00:00:00","110","","",""
 {% endfor %}


### PR DESCRIPTION
Signed-off-by: David Galloway <dgallowa@redhat.com>