### PR TITLE
cobbler: Set kernel_options for OpenSUSE distros

### DIFF
--- a/roles/cobbler_profile/defaults/main.yml
+++ b/roles/cobbler_profile/defaults/main.yml
@@ -110,7 +110,9 @@ distros:
       iso: "https://download.opensuse.org/distribution/leap/15.0/iso/openSUSE-Leap-15.0-DVD-x86_64.iso"
       sha256: c477428c7830ca76762d2f78603e13067c33952b936ff100189523e1fabe5a77
       kickstart: cephlab_opensuse_leap.xml
+      kernel_options: "install=http://@@http_server@@/cblr/links/{{ distro_name }}/"
   "openSUSE-15.1-x86_64":
       iso: "https://download.opensuse.org/distribution/leap/15.1/iso/openSUSE-Leap-15.1-DVD-x86_64.iso"
       sha256: c6d3ed19fe5cc25c4667bf0b46cc86aebcfbca3b0073aed0a288834600cb8b97
       kickstart: cephlab_opensuse_leap.xml
+      kernel_options: "install=http://@@http_server@@/cblr/links/{{ distro_name }}/"


### PR DESCRIPTION
This prevents the installer from pausing to ask for the install media

Signed-off-by: David Galloway <dgallowa@redhat.com>