### PR TITLE
testnode: install dnf-utils on el8

### DIFF
--- a/roles/testnode/vars/centos_8.yml
+++ b/roles/testnode/vars/centos_8.yml
@@ -6,6 +6,8 @@ common_yum_repos: {}
 packages:
   - '@core'
   - '@base'
+  # for package-cleanup
+  - dnf-utils
   - sysstat
   - libedit
   - boost-thread

--- a/roles/testnode/vars/redhat_8.yml
+++ b/roles/testnode/vars/redhat_8.yml
@@ -6,6 +6,8 @@ common_yum_repos: {}
 packages:
   - '@core'
   - '@base'
+  # for package-cleanup
+  - dnf-utils
   - git-all
   - sysstat
   - libedit


### PR DESCRIPTION
Needed for package-cleanup, which is used by the kernel task.

Signed-off-by: Sage Weil <sage@redhat.com>