### PR TITLE
temporarily require python3-pytz

### DIFF
--- a/roles/testnode/vars/centos_8.yml
+++ b/roles/testnode/vars/centos_8.yml
@@ -42,6 +42,8 @@ packages:
   # for workunits,
   - gcc
   - git
+  # until python3-tempora is fixed,
+  - python3-pytz
 
 epel_packages: []
 


### PR DESCRIPTION
This is until the python3-tempora package is fixed

Signed-off-by: Sage Weil <sage@redhat.com>