### PR TITLE
testnode: el8: drop python3-pytz dep

### DIFF
--- a/roles/testnode/vars/centos_8.yml
+++ b/roles/testnode/vars/centos_8.yml
@@ -42,8 +42,6 @@ packages:
   # for workunits,
   - gcc
   - git
-  # until python3-tempora is fixed,
-  - python3-pytz
   # qa/workunits/rados/test_python.sh
   - python3-nose
   # for cram tests

--- a/roles/testnode/vars/redhat_8.yml
+++ b/roles/testnode/vars/redhat_8.yml
@@ -43,8 +43,6 @@ packages:
   # for workunits,
   - gcc
   - git
-  # until python3-tempora is fixed,
-  - python3-pytz
   # qa/workunits/rados/test_python.sh
   - python3-nose
   # for cram tests


### PR DESCRIPTION
python3-tempora is now fixed to require this.

Signed-off-by: Sage Weil <sage@redhat.com>