### PR TITLE
cobbler: Don't set ansible_python_interpreter manually anymore

### DIFF
--- a/roles/cobbler/templates/triggers/install/post/cephlab_ansible.sh
+++ b/roles/cobbler/templates/triggers/install/post/cephlab_ansible.sh
@@ -27,17 +27,8 @@ flock --close ./.lock git pull
 export ANSIBLE_SSH_PIPELINING=1
 export ANSIBLE_HOST_KEY_CHECKING=False
 
-# Set ansible_python_interpeter var if RHEL8
-# https://docs.ansible.com/ansible/2.7/reference_appendices/python_3_support.html
-os=$(cobbler system dumpvars --name $2 | grep os_version | awk '{ print $3 }')
-if [ $os == "rhel8" -o $os == "centos8" ]; then
-  ANSIBLE_EXTRAVAR="-e ansible_python_interpreter=/usr/bin/python3"
-else
-  ANSIBLE_EXTRAVAR=""
-fi
-
 # Tell ansible to create users, populate authorized_keys, and zap non-root disks
-ansible-playbook $ANSIBLE_EXTRAVAR testnodes.yml -v --limit $name* --tags user,pubkeys,zap 2>&1 > /var/log/ansible/$name.log
+ansible-playbook testnodes.yml -v --limit $name* --tags user,pubkeys,zap 2>&1 > /var/log/ansible/$name.log
 # Now run the rest of the playbook. If it fails, at least we have access.
 # Background it so that the request doesn't block for this part and end up 
 # causing the client to retry, thus spawning this trigger multiple times
@@ -47,5 +38,5 @@ if [[ $profile == *"-stock" ]]
 then
     exit 0
 fi
-ansible-playbook $ANSIBLE_EXTRAVAR testnodes.yml -v --limit $name* --skip-tags user,pubkeys,zap 2>&1 >> /var/log/ansible/$name.log &
+ansible-playbook testnodes.yml -v --limit $name* --skip-tags user,pubkeys,zap 2>&1 >> /var/log/ansible/$name.log &
 popd


### PR DESCRIPTION
Both cobbler hosts (cobbler.front.sepia.ceph.com and magna001.ceph.redhat.com) are now running versions of ansible that handle python interpreter discovery automatically.

Setting this manually was actually causing issues because some ceph-cm-ansible tasks get delegated to localhost (Like 'Clone the keys repo' in the Users role).  So when setting -e ansible_python_interpreter=/usr/bin/python3, ansible looks for that binary on the localhost.  magna001 doesn't have python3 so the playbook run would fail.

Signed-off-by: David Galloway <dgallowa@redhat.com>