### PR TITLE
testnode: Move dbench to epel_packages so it gets installed

### DIFF
--- a/roles/testnode/vars/redhat_8.yml
+++ b/roles/testnode/vars/redhat_8.yml
@@ -59,10 +59,10 @@ packages:
   # for pjd tests
   - libacl-devel
   # for fs tests,
-  - dbench
   - autoconf
 
-epel_packages: []
+epel_packages:
+  - dbench
 
 nfs_service: nfs-server
 


### PR DESCRIPTION
Octo lab doesn't use epel by default but by moving this package to `epel_packages`, it will get installed during this task: https://github.com/ceph/ceph-cm-ansible/blob/master/roles/testnode/tasks/yum/packages.yml#L58

Signed-off-by: David Galloway <dgallowa@redhat.com>