### PR TITLE
common: Add baseurl to epel repo files

### DIFF
--- a/roles/common/vars/centos_8.yml
+++ b/roles/common/vars/centos_8.yml
@@ -3,6 +3,7 @@ epel_repos:
   epel:
     name: "Extra Packages for Enterprise Linux $releasever - $basearch"
     metalink: https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever&arch=$basearch&infra=$infra&content=$contentdir
+    baseurl: "{{ epel_mirror_baseurl }}/{{ ansible_distribution_major_version }}/{% if ansible_distribution_major_version == '8' %}Everything/{% endif %}$basearch"
     failovermethod: priority
     # ternary requires ansible >= 1.9
     enabled: "{{ enable_epel | ternary(1, 0) }}"

--- a/roles/common/vars/redhat_8.yml
+++ b/roles/common/vars/redhat_8.yml
@@ -7,6 +7,7 @@ epel_repos:
   epel:
     name: "Extra Packages for Enterprise Linux $releasever - $basearch"
     metalink: https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever&arch=$basearch&infra=$infra&content=$contentdir
+    baseurl: "{{ epel_mirror_baseurl }}/{{ ansible_distribution_major_version }}/{% if ansible_distribution_major_version == '8' %}Everything/{% endif %}$basearch"
     failovermethod: priority
     # ternary requires ansible >= 1.9
     enabled: "{{ enable_epel | ternary(1, 0) }}"


### PR DESCRIPTION
Honestly not even sure how this was working at all but in order for https://github.com/ceph/ceph-cm-ansible/pull/487 to work, the repo file needs to actually point to upstream epel to refresh the yum metadata.

Signed-off-by: David Galloway <dgallowa@redhat.com>