### PR TITLE
Use epel mirrors

### DIFF
--- a/roles/common/tasks/epel.yml
+++ b/roles/common/tasks/epel.yml
@@ -37,7 +37,7 @@
   with_dict: "{{ epel_repos }}"
 
 - name: Update yum cache
-  shell: rm -rf /var/cache/yum/*; yum clean all; yum makecache
+  shell: yum clean all; yum makecache
 
 - name: Uncomment mirrorlist
   replace:

--- a/roles/common/tasks/epel.yml
+++ b/roles/common/tasks/epel.yml
@@ -27,21 +27,6 @@
     - epel-mirrorlist
     - epel-testing-mirrorlist
 
-# A few times a year, we'd see a bunch of 404 errors during yum transactions that involved epel mirrors.
-# It has to do with upstream EPEL being updated and mirrors lagging behind.
-- name: Temporarily comment mirrorlist so we can update yum cache
-  replace:
-    path: "/etc/yum.repos.d/{{ item.key }}.repo"
-    regexp: '^(.*mirror.*)'
-    replace: '#\1'
-  with_dict: "{{ epel_repos }}"
-
-- name: Update yum cache
-  shell: yum clean all; yum makecache
-
-- name: Uncomment mirrorlist
-  replace:
-    path: "/etc/yum.repos.d/{{ item.key }}.repo"
-    regexp: '^#(.*mirror.*)'
-    replace: '\1'
-  with_dict: "{{ epel_repos }}"
+- name: Clean yum cache
+  shell: yum clean all
+  when: epel_repo is defined and epel_repo is changed

--- a/roles/common/vars/centos_8.yml
+++ b/roles/common/vars/centos_8.yml
@@ -1,14 +1,4 @@
 ---
-epel_repos:
-  epel:
-    name: "Extra Packages for Enterprise Linux $releasever - $basearch"
-    metalink: https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever&arch=$basearch&infra=$infra&content=$contentdir
-    baseurl: "{{ epel_mirror_baseurl }}/{{ ansible_distribution_major_version }}/{% if ansible_distribution_major_version == '8' %}Everything/{% endif %}$basearch"
-    failovermethod: priority
-    # ternary requires ansible >= 1.9
-    enabled: "{{ enable_epel | ternary(1, 0) }}"
-    gpgcheck: 0
-
 nrpe_selinux_packages:
   - python3-libsemanage
   - python3-policycoreutils

--- a/roles/common/vars/redhat_8.yml
+++ b/roles/common/vars/redhat_8.yml
@@ -3,16 +3,6 @@ rhsm_repos:
   - rhel-8-for-x86_64-baseos-rpms
   - rhel-8-for-x86_64-appstream-rpms
 
-epel_repos:
-  epel:
-    name: "Extra Packages for Enterprise Linux $releasever - $basearch"
-    metalink: https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever&arch=$basearch&infra=$infra&content=$contentdir
-    baseurl: "{{ epel_mirror_baseurl }}/{{ ansible_distribution_major_version }}/{% if ansible_distribution_major_version == '8' %}Everything/{% endif %}$basearch"
-    failovermethod: priority
-    # ternary requires ansible >= 1.9
-    enabled: "{{ enable_epel | ternary(1, 0) }}"
-    gpgcheck: 0
-
 nrpe_selinux_packages:
   - python3-libsemanage
   - python3-policycoreutils


### PR DESCRIPTION
So here's the order of events that caused all the epel issues over the past year or so.

1. CentOS/RHEL 8 came out and I created a separate `epel_repos` var that used `metalink` instead of `mirrorlist`.  This was because the URL was slightly different (addition of `/Everything/` dir).
2. We saw intermittent 404 errors attempting to update epel metadata.
3. I added baseurl and some tasks to force yum to update the metadata from the upstream/official epel repo
4. We still continued to see occasional errors updating metadata
5. I added some jinja2 to add `/Everything/` to the baseurl and metalink URLs but we continued to see random yum failures
6. I realized (today) that we resolved all these errors in the past by using a mirrorlist and that's not what we're doing in RHEL/CentOS8 so I'm fixing it.