### PR TITLE
cobbler_profile: Disable OS prober to prevent update-grub hang

### DIFF
--- a/roles/cobbler_profile/defaults/main.yml
+++ b/roles/cobbler_profile/defaults/main.yml
@@ -112,7 +112,7 @@ distros:
       iso: "http://cdimage.ubuntu.com/releases/18.04/release/ubuntu-18.04-server-amd64.iso"
       sha256: a7f5c7b0cdd0e9560d78f1e47660e066353bb8a79eb78d1fc3f4ea62a07e6cbc
       kickstart: cephlab_ubuntu.preseed
-      kernel_options: "netcfg/choose_interface=auto console=tty0 console=ttyS1,115200"
+      kernel_options: "netcfg/choose_interface=auto console=tty0 console=ttyS1,115200 GRUB_DISABLE_OS_PROBER=true"
       kernel_options_post: "pci=realloc=off console=tty0 console=ttyS1,115200"
   "openSUSE-15.0-x86_64":
       iso: "https://download.opensuse.org/distribution/leap/15.0/iso/openSUSE-Leap-15.0-DVD-x86_64.iso"


### PR DESCRIPTION
The Ubuntu installer appears to at least probe non-root disks during the `update-grub` step.  This was hanging on LVs leftover from previous installations on the smithi NVMe drives.

Settings this kernel option fixes it.

See https://bugs.launchpad.net/ubuntu/+source/debian-installer/+bug/1854839/comments/2

Signed-off-by: David Galloway <dgallowa@redhat.com>