### PR TITLE
cobbler: More kickstart adjustments for Fedora 31

### DIFF
--- a/roles/cobbler/templates/snippets/cephlab_packages_rhel
+++ b/roles/cobbler/templates/snippets/cephlab_packages_rhel
@@ -5,7 +5,7 @@
 #if $distro == 'Fedora' and int($distro_ver) >= 22 and int($distro_ver) < 31
 @^infrastructure-server-environment
 #else if $distro == 'Fedora' and int($distro_ver) >= 31
-@^infrastructure-server
+## We can't figure out what the new server group name is in F31 but we do need python3 so...
 python3
 #else
 @base

--- a/roles/cobbler/templates/snippets/cephlab_packages_rhel
+++ b/roles/cobbler/templates/snippets/cephlab_packages_rhel
@@ -32,6 +32,7 @@ python3
 #end if
 #end if
 ## These packages should be installed on all distros and versions
+ethtool
 wget
 smartmontools
 selinux-policy-targeted


### PR DESCRIPTION
Let's just hope the basic packages we'd need to at least get ceph-cm-ansible running exist in the base Fedora 31 DVD image.

We can't figure out the @base -> @infrastructure-server-environment -> @???? group name progression/changes so forget it.

Signed-off-by: David Galloway <dgallowa@redhat.com>