### PR TITLE
testnode: Use mirrorlists for CentOS 8 repos

### DIFF
--- a/roles/testnode/README.rst
+++ b/roles/testnode/README.rst
@@ -93,6 +93,22 @@ A list of copr repos to enable using ``dnf copr enable``::
     copr_repos:
       - ktdreyer/ceph-el8
 
+A list of mirrorlist template **filenames** to upload to ``/etc/yum.repos.d/``.
+Mirrorlist templates should live in ``roles/testnode/vars/mirrorlists/{{ ansible_distribution_major_version }}/``
+We were already doing this with epel mirrorlists in the ``common`` role but started seeing metalink issues with CentOS repos::
+
+    yum_mirrorlists: []
+
+    # Example:
+    yum_mirrorlists:
+      - CentOS-AppStream-mirrorlist
+
+    $ cat roles/testnode/templates/mirrorlists/8/CentOS-AppStream-mirrorlist
+    # {{ ansible_managed }}
+    https://download-cc-rdu01.fedoraproject.org/pub/centos/{{ ansible_lsb.release }}/AppStream/x86_64/os/
+    https://path/to/another/mirror
+
+
 A list defining apt repos that would be common across a major version or distro. Each item in the list represents
 an apt repo to be added to sources.list::
 

--- a/roles/testnode/tasks/yum/repos.yml
+++ b/roles/testnode/tasks/yum/repos.yml
@@ -1,4 +1,14 @@
 ---
+- name: Configure local mirrorlists
+  template:
+    src: 'mirrorlists/{{ ansible_distribution_major_version }}/{{ item }}'
+    dest: '/etc/yum.repos.d/{{ item }}'
+    owner: root
+    group: root
+    mode: 0644
+  with_items: "{{ yum_mirrorlists }}"
+  when: yum_mirrorlists is defined
+
 - name: Configure common additional repos in /etc/yum.repos.d/
   template:
     src: yum_repo.j2

--- a/roles/testnode/templates/mirrorlists/8/CentOS-AppStream-mirrorlist
+++ b/roles/testnode/templates/mirrorlists/8/CentOS-AppStream-mirrorlist
@@ -1,0 +1,7 @@
+# {{ ansible_managed }}
+
+# local yum mirrorlist for CentOS-8 - AppStream repo
+https://download-cc-rdu01.fedoraproject.org/pub/centos/{{ ansible_lsb.release }}/AppStream/x86_64/os/
+http://mirror.linux.duke.edu/pub/centos/{{ ansible_lsb.release }}/AppStream/x86_64/os/
+http://packages.oit.ncsu.edu/centos/{{ ansible_lsb.release }}/AppStream/x86_64/os/
+http://distro.ibiblio.org/centos/{{ ansible_lsb.release }}/AppStream/x86_64/os/

--- a/roles/testnode/templates/mirrorlists/8/CentOS-Base-mirrorlist
+++ b/roles/testnode/templates/mirrorlists/8/CentOS-Base-mirrorlist
@@ -1,0 +1,7 @@
+# {{ ansible_managed }}
+
+# local yum mirrorlist for CentOS-8 - Base repo
+https://download-cc-rdu01.fedoraproject.org/pub/centos/{{ ansible_lsb.release }}/BaseOS/x86_64/os/
+http://mirror.linux.duke.edu/pub/centos/{{ ansible_lsb.release }}/BaseOS/x86_64/os/
+http://packages.oit.ncsu.edu/centos/{{ ansible_lsb.release }}/BaseOS/x86_64/os/
+http://distro.ibiblio.org/centos/{{ ansible_lsb.release }}/BaseOS/x86_64/os/

--- a/roles/testnode/templates/mirrorlists/8/CentOS-Extras-mirrorlist
+++ b/roles/testnode/templates/mirrorlists/8/CentOS-Extras-mirrorlist
@@ -1,0 +1,7 @@
+# {{ ansible_managed }}
+
+# local yum mirrorlist for CentOS-8 - Extras repo
+https://download-cc-rdu01.fedoraproject.org/pub/centos/{{ ansible_lsb.release }}/extras/x86_64/os/
+http://mirror.linux.duke.edu/pub/centos/{{ ansible_lsb.release }}/extras/x86_64/os/
+http://packages.oit.ncsu.edu/centos/{{ ansible_lsb.release }}/extras/x86_64/os/
+http://distro.ibiblio.org/centos/{{ ansible_lsb.release }}/extras/x86_64/os/

--- a/roles/testnode/vars/centos_8.yml
+++ b/roles/testnode/vars/centos_8.yml
@@ -8,6 +8,33 @@ common_yum_repos:
     enabled: 1
     gpgcheck: 0
 
+# These will overwrite the repo files that come with a CentOS installation
+yum_repos:
+  CentOS-AppStream:
+    name: "CentOS-$releasever - AppStream"
+    mirrorlist: file:///etc/yum.repos.d/CentOS-AppStream-mirrorlist
+    gpgcheck: 1
+    enabled: 1
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+  CentOS-Base:
+    name: "CentOS-$releasever - Base"
+    mirrorlist: file:///etc/yum.repos.d/CentOS-Base-mirrorlist
+    gpgcheck: 1
+    enabled: 1
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+  CentOS-Extras:
+    name: "CentOS-$releasever - Extras"
+    mirrorlist: file:///etc/yum.repos.d/CentOS-Extras-mirrorlist
+    gpgcheck: 1
+    enabled: 1
+    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+
+# These are files in roles/testnodes/templates/mirrorlists/8/
+yum_mirrorlists:
+  - CentOS-AppStream-mirrorlist
+  - CentOS-Base-mirrorlist
+  - CentOS-Extras-mirrorlist
+
 copr_repos:
   - ktdreyer/ceph-el8
 


### PR DESCRIPTION
Fixes ``Failed to download metadata for repo 'extras'`` errors.

Signed-off-by: David Galloway <dgallowa@redhat.com>