### PR TITLE
nameserver: Support forwarders

### DIFF
--- a/roles/nameserver/README.rst
+++ b/roles/nameserver/README.rst
@@ -71,6 +71,13 @@ Most variables are defined in ``roles/nameserver/defaults/main.yml`` and values 
 |                                                        |                                                                                                                           |
 |                                                        |**NOTE:** Setting to "yes" will add ``allow-recursion { any; }``. See To-Do.                                               |
 +--------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------+
+|::                                                      |A list of nameservers BIND should forward external DNS queries to.  This is not required but should be defined in          |
+|                                                        |``ansible/inventory/group_vars/nameserver.yml`` if desired.                                                                |
+|  named_forwarders:                                     |                                                                                                                           |
+|    - 8.8.8.8                                           |                                                                                                                           |
+|    - 1.1.1.1                                           |                                                                                                                           |
+|                                                        |                                                                                                                           |
++--------------------------------------------------------+---------------------------------------------------------------------------------------------------------------------------+
 |``named_conf_slave: true``                              |Will configure the server as a DNS slave if true.  This variable is not required but should be set to true in the hostvars |
 |                                                        |if desired.                                                                                                                |
 |                                                        |                                                                                                                           |

--- a/roles/nameserver/templates/named.conf.j2
+++ b/roles/nameserver/templates/named.conf.j2
@@ -15,6 +15,9 @@ options {
 {% if named_conf_recursion == "yes" %}
 	allow-recursion		{ any; };
 {% endif %}
+{% if named_forwarders is defined %}
+	forwarders { {% for forwarder in named_forwarders -%}{{ forwarder }}; {% endfor -%} };
+{% endif %}
 {% if named_conf_allow_axfr is defined %}
 	allow-transfer		{ {% for ip in named_conf_allow_axfr -%}{{ ip }}; {% endfor -%} };
 {% endif %}


### PR DESCRIPTION
When setting up this nameserver role in Octo, recursive lookups were failing.  I suspect maybe BIND is doing an `NS` lookup when it doesn't know about a domain it is asked about.  Red Hat blocks all external DNS queries so I've defined an internal DNS server for the Octo BIND server to forward to.  Now external lookups work.

Signed-off-by: David Galloway <dgallowa@redhat.com>