### PR TITLE
dhcp-server: Only create host declaration if its IP is in subnet we'r…

### DIFF
--- a/roles/dhcp-server/templates/dhcpd.subnet.conf.j2
+++ b/roles/dhcp-server/templates/dhcpd.subnet.conf.j2
@@ -55,6 +55,7 @@ subnet {{ subnet_item.cidr | ipaddr('network') }} netmask {{ subnet_item.cidr | 
 
   {% for host in groups['all'] | sort | unique -%}
   {% if hostvars[host][subnet_item.macvar] is defined -%}
+  {% if hostvars[host][subnet_item.ipvar] | ipaddr(subnet_item.cidr) | ipaddr('bool') -%}
   host {{ host.split('.')[0] }}-{{ subnet }} {
     {% if hostvars[host]['dhcp_next_server'] is defined -%}
     next-server {{ hostvars[host]['dhcp_next_server'] }};
@@ -66,6 +67,7 @@ subnet {{ subnet_item.cidr | ipaddr('network') }} netmask {{ subnet_item.cidr | 
     hardware ethernet {{ hostvars[host][subnet_item.macvar] }};
     fixed-address {{ hostvars[host][subnet_item.ipvar] }};
   }
+  {% endif -%}
   {% endif -%}
   {% endfor -%}
 } # end subnet


### PR DESCRIPTION
Only create host declaration if its IP is in subnet we're writing

In the Octo lab, we have multiple subnets with the same domain and VLAN.  This is problematic because in the `dhcp_subnets` dict, we only anticipate there being one cidr.

This change will let you have multiple "subnets" in `dhcp_subnets` without fiddling with the ansible inventory ipvars or macvars.

Signed-off-by: David Galloway <dgallowa@redhat.com>