### PR TITLE
cobbler_systems: Only update systems if mac and ip are defined

### DIFF
--- a/roles/cobbler_systems/tasks/populate_systems.yml
+++ b/roles/cobbler_systems/tasks/populate_systems.yml
@@ -28,3 +28,6 @@
 - name: Update existing systems in cobbler
   command: cobbler system edit --name={{ item.split('.')[0] }} --mac={{ hostvars[item].mac }} --ip-address={{ hostvars[item].ip }} --interface={{ hostvars[item].interface|default(interface) }} --hostname={{ item.split('.')[0] }}.{{ lab_domain }} --kopts="{{ hostvars[item].kernel_options|default(kernel_options) }}" --kopts-post="{{ hostvars[item].kernel_options_post|default(kernel_options_post) }}" --ksmeta="{{ hostvars[item].kickstart_metadata|default(kickstart_metadata) }}" --power-type={{ hostvars[item].power_type|default(power_type) }} --power-address={{ item.split('.')[0] }}.{{ ipmi_domain }} --power-user={{ hostvars[item].power_user|default(power_user) }} --power-pass={{ hostvars[item].power_pass|default(power_pass) }}
   with_items: "{{ cobbler_systems_update }}"
+  when:
+    - hostvars[item].mac is defined
+    - hostvars[item].ip is defined


### PR DESCRIPTION
We must have some systems that snuck into cobbler without having a MAC or IP so when this second "update" task runs, it fails

Signed-off-by: David Galloway <dgallowa@redhat.com>