### PR TITLE
testnode: install iozone package from sepia lab repo

### DIFF
--- a/roles/testnode/vars/centos_8.yml
+++ b/roles/testnode/vars/centos_8.yml
@@ -89,6 +89,7 @@ packages:
   - autoconf
   # for test-crash.sh
   - gdb
+  - iozone
 
 epel_packages: []
 

--- a/roles/testnode/vars/redhat_8.yml
+++ b/roles/testnode/vars/redhat_8.yml
@@ -62,6 +62,7 @@ packages:
   - autoconf
   # for test-crash.sh
   - gdb
+  - iozone
 
 epel_packages:
   - dbench

--- a/roles/testnode/vars/yum_systems.yml
+++ b/roles/testnode/vars/yum_systems.yml
@@ -23,7 +23,6 @@ ceph_packages_to_remove:
   - librbd1
   - librados2
   - mod_fastcgi
-  - iozone
 
 ceph_dependency_packages_to_remove:
   - boost-random


### PR DESCRIPTION
The iozone package is remove from centos/rhel 8 dues to the license
issue, and this will install the package from the spia lab repo.

Fixes: https://tracker.ceph.com/issues/43600
Signed-off-by: Xiubo Li <xiubli@redhat.com>