### PR TITLE
testnode: Fix CentOS repo mirrorlists

### DIFF
--- a/roles/testnode/templates/mirrorlists/8/CentOS-AppStream-mirrorlist
+++ b/roles/testnode/templates/mirrorlists/8/CentOS-AppStream-mirrorlist
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 
 # local yum mirrorlist for CentOS-8 - AppStream repo
-https://download-cc-rdu01.fedoraproject.org/pub/centos/{{ ansible_lsb.release }}/AppStream/x86_64/os/
-http://mirror.linux.duke.edu/pub/centos/{{ ansible_lsb.release }}/AppStream/x86_64/os/
-http://packages.oit.ncsu.edu/centos/{{ ansible_lsb.release }}/AppStream/x86_64/os/
-http://distro.ibiblio.org/centos/{{ ansible_lsb.release }}/AppStream/x86_64/os/
+https://download-cc-rdu01.fedoraproject.org/pub/centos/{{ ansible_distribution_major_version }}/AppStream/x86_64/os/
+http://mirror.linux.duke.edu/pub/centos/{{ ansible_distribution_major_version }}/AppStream/x86_64/os/
+http://packages.oit.ncsu.edu/centos/{{ ansible_distribution_major_version }}/AppStream/x86_64/os/
+http://distro.ibiblio.org/centos/{{ ansible_distribution_major_version }}/AppStream/x86_64/os/

--- a/roles/testnode/templates/mirrorlists/8/CentOS-Base-mirrorlist
+++ b/roles/testnode/templates/mirrorlists/8/CentOS-Base-mirrorlist
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 
 # local yum mirrorlist for CentOS-8 - Base repo
-https://download-cc-rdu01.fedoraproject.org/pub/centos/{{ ansible_lsb.release }}/BaseOS/x86_64/os/
-http://mirror.linux.duke.edu/pub/centos/{{ ansible_lsb.release }}/BaseOS/x86_64/os/
-http://packages.oit.ncsu.edu/centos/{{ ansible_lsb.release }}/BaseOS/x86_64/os/
-http://distro.ibiblio.org/centos/{{ ansible_lsb.release }}/BaseOS/x86_64/os/
+https://download-cc-rdu01.fedoraproject.org/pub/centos/{{ ansible_distribution_major_version }}/BaseOS/x86_64/os/
+http://mirror.linux.duke.edu/pub/centos/{{ ansible_distribution_major_version }}/BaseOS/x86_64/os/
+http://packages.oit.ncsu.edu/centos/{{ ansible_distribution_major_version }}/BaseOS/x86_64/os/
+http://distro.ibiblio.org/centos/{{ ansible_distribution_major_version }}/BaseOS/x86_64/os/

--- a/roles/testnode/templates/mirrorlists/8/CentOS-Extras-mirrorlist
+++ b/roles/testnode/templates/mirrorlists/8/CentOS-Extras-mirrorlist
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 
 # local yum mirrorlist for CentOS-8 - Extras repo
-https://download-cc-rdu01.fedoraproject.org/pub/centos/{{ ansible_lsb.release }}/extras/x86_64/os/
-http://mirror.linux.duke.edu/pub/centos/{{ ansible_lsb.release }}/extras/x86_64/os/
-http://packages.oit.ncsu.edu/centos/{{ ansible_lsb.release }}/extras/x86_64/os/
-http://distro.ibiblio.org/centos/{{ ansible_lsb.release }}/extras/x86_64/os/
+https://download-cc-rdu01.fedoraproject.org/pub/centos/{{ ansible_distribution_major_version }}/extras/x86_64/os/
+http://mirror.linux.duke.edu/pub/centos/{{ ansible_distribution_major_version }}/extras/x86_64/os/
+http://packages.oit.ncsu.edu/centos/{{ ansible_distribution_major_version }}/extras/x86_64/os/
+http://distro.ibiblio.org/centos/{{ ansible_distribution_major_version }}/extras/x86_64/os/


### PR DESCRIPTION
I think there used to be individual directories with the ansible_lsb.release in the path but now there only seems to be "8" and "8.1.1911" so we'll just use 8.

Signed-off-by: David Galloway <dgallowa@redhat.com>