### PR TITLE
testnode: Don't attempt to install base or core

### DIFF
--- a/roles/testnode/tasks/yum/packages.yml
+++ b/roles/testnode/tasks/yum/packages.yml
@@ -44,13 +44,6 @@
   tags:
     - remove-ceph-dependency
 
-# https://bugzilla.redhat.com/show_bug.cgi?id=1782899
-- name: Base group workaround for BZ1782899
-  shell: "dnf -y groupinstall base --nobest && dnf -y group upgrade base"
-  when:
-    - ansible_os_family == "RedHat"
-    - ansible_distribution_major_version|int > 7
-
 - name: Install packages
   package:
     name: "{{ packages|list }}"

--- a/roles/testnode/vars/centos_8.yml
+++ b/roles/testnode/vars/centos_8.yml
@@ -39,8 +39,6 @@ copr_repos:
   - ktdreyer/ceph-el8
 
 packages:
-  - '@core'
-  - '@base'
   # for package-cleanup
   - dnf-utils
   - sysstat

--- a/roles/testnode/vars/redhat_8.yml
+++ b/roles/testnode/vars/redhat_8.yml
@@ -12,8 +12,6 @@ copr_repos:
   - ktdreyer/ceph-el8
 
 packages:
-  - '@core'
-  - '@base'
   # for package-cleanup
   - dnf-utils
   - git-all


### PR DESCRIPTION
These groups are already taken care of during Cobbler installation.  We're hitting https://bugzilla.redhat.com/show_bug.cgi?id=1782899 in RHEL8 so let's not bother trying to reinstall during ceph-cm-ansible.

Signed-off-by: David Galloway <dgallowa@redhat.com>