### PR TITLE
generate-fog-csv: Only print a line if the MAC is defined

### DIFF
--- a/tools/generate-fog-csv.yml
+++ b/tools/generate-fog-csv.yml
@@ -7,3 +7,4 @@
   roles:
     - generate-fog-csv
   become: false
+  gather_facts: false

--- a/tools/roles/generate-fog-csv/templates/csv.j2
+++ b/tools/roles/generate-fog-csv/templates/csv.j2
@@ -1,3 +1,5 @@
 {% for host in groups['cobbler_managed'] %}
+{% if hostvars[host]['mac'] is defined %}
 "{{ hostvars[host]['mac'] }}","{{ hostvars[host]['inventory_hostname_short'] }}","","","1","0","","","fog","","","","","","","","","{{ hostvars[host]['kernel_options'] }}","","{{ hostvars[host]['fog_install_drive']|default('/dev/sda') }}","","","","","0000-00-00 00:00:00","110","","",""
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
There's some hosts that are "cobbler_managed" but don't have a MAC and don't need a MAC.  Ansible doesn't help us out any here and print WHICH host doesn't have a MAC.  Just throws an error.

Also, there's no need to gather facts on localhost so I set that to `false`

Signed-off-by: David Galloway <dgallowa@redhat.com>