### PR TITLE
all: Ignore warnings about systemd failing to control init scripts

### DIFF
--- a/roles/common/tasks/nagios.yml
+++ b/roles/common/tasks/nagios.yml
@@ -112,3 +112,5 @@
     name: "{{ nrpe_service_name }}"
     enabled: yes
     state: started
+  # There's an issue with ansible<=2.9 and our custom built kernels (5.8 as of this commit) where the service and systemd modules don't have backwards compatibility with init scripts
+  ignore_errors: "{{ 'ceph' in ansible_kernel }}"

--- a/roles/testnode/tasks/apt_systems.yml
+++ b/roles/testnode/tasks/apt_systems.yml
@@ -74,3 +74,5 @@
   service:
     name: apache2
     state: stopped
+  # There's an issue with ansible<=2.9 and our custom built kernels (5.8 as of this commit) where the service and systemd modules don't have backwards compatibility with init scripts
+  ignore_errors: "{{ 'ceph' in ansible_kernel }}"

--- a/roles/testnode/tasks/ntp.yml
+++ b/roles/testnode/tasks/ntp.yml
@@ -52,3 +52,5 @@
     name: "{{ntp_service_name}}"
     enabled: yes
     state: started
+  # There's an issue with ansible<=2.9 and our custom built kernels (5.8 as of this commit) where the service and systemd modules don't have backwards compatibility with init scripts
+  ignore_errors: "{{ 'ceph' in ansible_kernel }}"


### PR DESCRIPTION
Using the systemd ansible module doesn't help either

https://github.com/ansible/ansible/issues/36585
https://github.com/ansible/ansible/issues/22171

Signed-off-by: David Galloway <dgallowa@redhat.com>