### PR TITLE
testnode: don't zap 'sr' devices

### DIFF
--- a/roles/testnode/tasks/zap_disks.yml
+++ b/roles/testnode/tasks/zap_disks.yml
@@ -57,6 +57,7 @@
     - item.key not in root_disk
     - '"loop" not in item.key'
     - '"ram" not in item.key'
+    - '"sr" not in item.key'
 
 ## See https://tracker.ceph.com/issues/22354 and
 ## https://github.com/ceph/ceph/pull/20400
@@ -67,6 +68,7 @@
     - item.key not in root_disk
     - '"loop" not in item.key'
     - '"ram" not in item.key'
+    - '"sr" not in item.key'
 
 - name: Remove all LVM data
   shell: "dmsetup remove_all --force"


### PR DESCRIPTION
We don't need zapping of libvirt dvd devices

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>