### PR TITLE
teuthology nginx: add gzip_ variables to allow compressed responses

### DIFF
--- a/roles/teuthology/templates/nginx.conf
+++ b/roles/teuthology/templates/nginx.conf
@@ -1,5 +1,11 @@
 # {{ ansible_managed }}
 server {
+        gzip on;
+        gzip_types *;
+        gzip_comp_level 9;
+        gzip_proxied any;
+        gzip_vary on;
+        gzip_static on;
         allow all;
         autoindex on;
         server_name {{ inventory_hostname }};


### PR DESCRIPTION
in particular, gzip_static on allows the server to return file.gz
(if compression is allowable) for files that are requested as "file".
This handles the teuthology.log.gz files that are still referred to as
teuthology.log from pulpito pages.

Signed-off-by: Dan Mick <dmick@redhat.com>