### PR TITLE
testnode: Install lvm2 on RHEL8 machines

### DIFF
--- a/roles/testnode/vars/redhat_8.yml
+++ b/roles/testnode/vars/redhat_8.yml
@@ -58,6 +58,8 @@ packages:
   # for test-crash.sh
   - gdb
   - iozone
+  # cephadm
+  - lvm2
 
 epel_packages:
   - dbench


### PR DESCRIPTION
The PSI nodes downstream don't have lvm2 pre-installed like the baremetal ISO image.

Signed-off-by: David Galloway <dgallowa@redhat.com>