### PR TITLE
smart.sh enhancements for totally failed drives

### DIFF
--- a/roles/common/files/libexec/smart.sh
+++ b/roles/common/files/libexec/smart.sh
@@ -70,8 +70,8 @@ main ()
   # Nagios reads and displays the first line of output on the Services page.
   # All individual messages about failed/failing disk statistics can be viewed
   # on the individual system's SMART detail page in nagios.
-  for msg in "${messages[@]}"
-  do
+  readarray -t sorted < <(for msg in "${messages[@]}"; do echo "$msg"; done | sort)
+  for msg in "${sorted[@]}"; do
     echo "$msg"
   done
   

--- a/roles/common/files/libexec/smart.sh
+++ b/roles/common/files/libexec/smart.sh
@@ -262,6 +262,11 @@ normal_smart ()
         failed=true
         rc=2
         fi
+      # The SSDs in the bruuni just straight up say failed with no additional detail
+      elif sudo smartctl -a /dev/$l | grep -q "FAILED!"; then
+        messages+=("Drive $l has completely failed")
+        failed=true
+        rc=2
       else
         messages+=("No SMART data found for drive $l")
         failed=true

--- a/roles/common/files/libexec/smart.sh
+++ b/roles/common/files/libexec/smart.sh
@@ -264,7 +264,7 @@ normal_smart ()
         fi
       # The SSDs in the bruuni just straight up say failed with no additional detail
       elif sudo smartctl -a /dev/$l | grep -q "FAILED!"; then
-        messages+=("Drive $l has completely failed")
+        messages+=("Drive $l ($(get_serial $l)) has completely failed")
         failed=true
         rc=2
       else
@@ -277,7 +277,7 @@ normal_smart ()
     if echo "$output" | grep -q '^0x05'; then
       reallocated=$(echo "$output" | grep '^0x05' | awk '{print $NF}')
       if [ "$reallocated" != "0" ] && [ $is_ssd = false ]; then
-        messages+=("Drive $l has $reallocated reallocated sectors")
+        messages+=("Drive $l ($(get_serial $l)) has $reallocated reallocated sectors")
         failed=true
         # A small number of reallocated sectors is OK
 	# Don't set rc to WARN if we were already CRIT from previous drive
@@ -293,7 +293,7 @@ normal_smart ()
     if echo "$output" | grep -q '^0xbb'; then
       uncorrect=$(echo "$output" | grep '^0xbb' | awk '{print $NF}')
       if [ "$uncorrect" != "0" ]; then
-        messages+=("Drive $l has $uncorrect reported uncorrect sectors")
+        messages+=("Drive $l ($(get_serial $l)) had $uncorrect reported uncorrect sectors")
         failed=true
         rc=2
       fi
@@ -302,7 +302,7 @@ normal_smart ()
     if echo "$output" | grep -q '^0xc4'; then
       reallocatedevents=$(echo "$output" | grep '^0xc4' | awk '{print $NF}')
       if [ "$reallocatedevents" != "0" ]; then
-        messages+=("Drive $l has $reallocatedevents reallocated events")
+        messages+=("Drive $l ($(get_serial $l)) has $reallocatedevents reallocated events")
         failed=true
         rc=2
       fi
@@ -311,7 +311,7 @@ normal_smart ()
     if echo "$output" | grep -q '^0xc5'; then
       pending=$(echo "$output" | grep '^0xc5' | awk '{print $NF}')
       if [ "$pending" != "0" ]; then
-        messages+=("Drive $l has $pending pending sectors")
+        messages+=("Drive $l ($(get_serial $l)) has $pending pending sectors")
         failed=true
         rc=2
       fi
@@ -320,7 +320,7 @@ normal_smart ()
     if echo "$output" | grep -q '^0xc6'; then
       uncorrect=$(echo "$output" | grep '^0xc6' | awk '{print $NF}')
       if [ "$uncorrect" != "0" ]; then
-        messages+=("Drive $l has $uncorrect uncorrect sectors")
+        messages+=("Drive $l ($(get_serial $l)) has $uncorrect uncorrect sectors")
         failed=true
         rc=2
       fi
@@ -329,7 +329,7 @@ normal_smart ()
     if echo -e "$output" | grep -q '^0xe9'; then
       wearout=$(echo "$output" | grep '^0xe9' | awk '{print $NF}')
       if [ "$wearout" == "1" ]; then
-        messages+=("Drive $l has exhausted its Media_Wearout_Indicator")
+        messages+=("Drive $l ($(get_serial $l)) has exhausted its Media_Wearout_Indicator")
         failed=true
 	# Don't set rc to WARN if we were already CRIT from previous drive
         if [ "$rc" != 2 ]
@@ -418,6 +418,15 @@ nvme_smart ()
       let "failingdrives+=1"
     fi
   done
+}
+
+get_serial() {
+  serial=$(sudo smartctl -i /dev/$1 | grep "Serial Number:" | awk '{ print $3 }')
+  if [ "$serial" == "" ]; then
+    echo "S/N unknown"
+  else
+    echo $serial
+  fi
 }
 
 ## Call main() function


### PR DESCRIPTION
The SSDs in the bruuni don't really provide much useful detail once they've failed beyond a certain point.

```
[root@bruuni002 ~]# sudo smartctl -a /dev/sdb | grep -E "FAILED\!|$"
smartctl 7.1 2020-04-05 r5049 [x86_64-linux-4.18.0-240.1.1.el8_3.x86_64] (local build)
Copyright (C) 2002-19, Bruce Allen, Christian Franke, www.smartmontools.org

=== START OF INFORMATION SECTION ===
Model Family:     Intel S3520 Series SSDs
Device Model:     INTEL SSDSC2BB960G7
Serial Number:    XXXXXXX
LU WWN Device Id: 5 5cd2e4 14e0db4c1
Firmware Version: N2010112
User Capacity:    960,197,124,096 bytes [960 GB]
Sector Sizes:     512 bytes logical, 4096 bytes physical
Rotation Rate:    Solid State Device
Form Factor:      2.5 inches
Device is:        In smartctl database [for details use: -P show]
ATA Version is:   ACS-3 T13/2161-D revision 5
SATA Version is:  SATA 3.1, 6.0 Gb/s
Local Time is:    Wed Nov 25 15:05:49 2020 UTC
SMART support is: Available - device has SMART capability.
SMART support is: Enabled

=== START OF READ SMART DATA SECTION ===
SMART overall-health self-assessment test result: FAILED!
Drive failure expected in less than 24 hours. SAVE ALL DATA.
No failed Attributes found.

General SMART Values:
Offline data collection status:  (0x00)	Offline data collection activity
					was never started.
					Auto Offline Data Collection: Disabled.
Total time to complete Offline 
data collection: 		(    0) seconds.
Offline data collection
capabilities: 			 (0x00) 	Offline data collection not supported.
SMART capabilities:            (0x0000)	Automatic saving of SMART data					is not implemented.
Error logging capability:        (0x00)	Error logging supported.
					General Purpose Logging supported.
SCT capabilities: 	       (0x003d)	SCT Status supported.
					SCT Error Recovery Control supported.
					SCT Feature Control supported.
					SCT Data Table supported.

Read SMART Error Log failed: scsi error badly formed scsi parameters

Read SMART Self-test Log failed: scsi error badly formed scsi parameters

Selective Self-tests/Logging not supported
```