### PR TITLE
common: Register local docker.io registry mirror

### DIFF
--- a/roles/common/tasks/container_mirror.yml
+++ b/roles/common/tasks/container_mirror.yml
@@ -23,3 +23,10 @@
   copy:
     dest: "{{ container_mirror_cert_path }}/docker-mirror.crt"
     content: "{{ container_mirror_cert }}"
+
+- name: Install registries-conf-ctl 
+  pip:
+    name: git+https://github.com/sebastian-philipp/registries-conf-ctl 
+
+- name: Add local docker.io registry mirror
+  command: registries-conf-ctl add-mirror docker.io docker-mirror.front.sepia.ceph.com


### PR DESCRIPTION
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

Note that I'm not super familiar with ansible nor ceph-cm-ansible. 

Take this as an idea or suggestion, instead of an actual PR. 