### PR TITLE
testnode: Basic filesystem and mountpoint support

### DIFF
--- a/roles/testnode/README.rst
+++ b/roles/testnode/README.rst
@@ -235,6 +235,18 @@ A dictionary of drives/devices you want to partition.  ``scratch_devs`` is not r
         scratch_devs:
           - 2
 
+An optional dictionary of filesystems you want created and where to mount them.  (You must use a ``drives_to_partition`` or ``logical_volumes`` dictionary to carve up drives first.)  Example::
+
+    filesystems:
+      varfoo:
+        device: "/dev/nvme0n1p5"
+        fstype: ext4
+        mountpoint: "/var/lib/foo"
+      fscache:
+        device: "/dev/nvme0n1p6"
+        fstype: xfs
+        mountpoint: "/var/cache/fscache"
+
 A dictionary of volume groups you want created.  ``pvs`` should be a comma-delimited list.  Example::
 
     volume_groups:
@@ -283,6 +295,9 @@ Available tags are listed below:
 
 cpan
     Install and configure cpan and Amazon::S3.
+
+filesystems
+    Create and mount filesystems.
 
 gpg-keys
     Install gpg keys on Fedora.    

--- a/roles/testnode/tasks/filesystems.yml
+++ b/roles/testnode/tasks/filesystems.yml
@@ -1,0 +1,14 @@
+---
+- name: Create filesystems
+  filesystem:
+    dev: "{{ item.value.device }}"
+    fstype: "{{ item.value.fstype }}"
+  with_dict: "{{ filesystems }}"
+
+- name: Mount filesystems
+  mount:
+    path: "{{ item.value.mountpoint }}"
+    src: "{{ item.value.device }}"
+    fstype: "{{ item.value.fstype }}"
+    state: mounted
+  with_dict: "{{ filesystems }}"

--- a/roles/testnode/tasks/main.yml
+++ b/roles/testnode/tasks/main.yml
@@ -89,6 +89,12 @@
   tags:
     - lvm
 
+- name: set up filesystems
+  import_tasks: filesystems.yml
+  tags:
+    - filesystems
+  when: filesystems is defined
+
 - name: mount /var/lib/ceph to specified partition
   import_tasks: var_lib.yml
   when: var_lib_partition is defined


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/6373

This will really only be useful is `drives_to_partition` or `logical_volumes` gets overridden in ansible.cephlab overrides in teuthology yaml.  e.g.,

```
overrides:
  ansible.cephlab:
    vars:
      drives_to_partition:
        nvme0n1:
          device: "/dev/nvme0n1"
          unit: "GB"
          sizes:
            - "0 80"
            - "80 160"
            - "160 240"
            - "240 320"
            - "320 340"
            - "340 400"
          scratch_devs:
            - p1
            - p2
            - p3
            - p4
      filesystems:
        nvme0n1p6:
          device: "/dev/nvme0n1p6"
          fstype: xfs
          mountpoint: "/var/cache/fscache"
```

Signed-off-by: David Galloway <dgallowa@redhat.com>