### PR TITLE
container-host: restart docker service

### DIFF
--- a/roles/container-host/tasks/container_mirror.yml
+++ b/roles/container-host/tasks/container_mirror.yml
@@ -35,3 +35,9 @@
   command: registries-conf-ctl add-mirror docker.io "{{ container_mirror }}"
   environment:
     PATH: /usr/local/bin:/usr/bin
+
+# not very elegant but it's a workaround for now
+- name: Restart docker service
+  service: docker
+    state: restarted
+  when: "'docker.io' in container_packages"


### PR DESCRIPTION
Once the mirror has been added in `/etc/docker/daemon.json`
we need to restart the daemon.

This is not very elegant but it's a workaround for now.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>