### PR TITLE
container-host: Ignore service restart error on new kernel

### DIFF
--- a/roles/container-host/tasks/container_mirror.yml
+++ b/roles/container-host/tasks/container_mirror.yml
@@ -42,3 +42,5 @@
     name: docker
     state: restarted
   when: "'docker.io' in container_packages"
+  # There's an issue with ansible<=2.9 and our custom built kernels (5.8 as of this commit) where the service and systemd modules don't have backwards compatibility with init scripts
+  ignore_errors: "{{ 'ceph' in ansible_kernel }}"


### PR DESCRIPTION
Signed-off-by: David Galloway <dgallowa@redhat.com>