### PR TITLE
testnode: Install make on el8

### DIFF
--- a/roles/testnode/vars/redhat_8.yml
+++ b/roles/testnode/vars/redhat_8.yml
@@ -42,6 +42,7 @@ packages:
   # for workunits,
   - gcc
   - git
+  - make
   # qa/workunits/rados/test_python.sh
   - python3-nose
   # for cram tests


### PR DESCRIPTION
This package isn't included in the cloud image that the Octo PSI nodes use.

Fixes: https://tracker.ceph.com/issues/48751

Signed-off-by: David Galloway <dgallowa@redhat.com>