### PR TITLE
container-host: Install mirror cert in both podman and docker paths

### DIFF
--- a/roles/container-host/README.rst
+++ b/roles/container-host/README.rst
@@ -11,7 +11,7 @@ Variables
 
 ``container_packages: []`` is the list of container packages to install.  We default to podman on RedHat based distros and docker.io on Debian-based distros.
 
-The following variables are used to optionally configure a docker.io mirror CA certificate. The role will use ``/etc/containers/certs.d`` if ``podman`` is installed and ``/etc/docker/certs.d`` if ``docker`` is installed.::
+The following variables are used to optionally configure a docker.io mirror CA certificate. The role will install the certificate in both ``/etc/containers/certs.d`` (for podman) and ``/etc/docker/certs.d`` (for docker).::
 
     # Defined in all.yml in secrets repo
     container_mirror: docker-mirror.front.sepia.ceph.com:5000
@@ -21,9 +21,6 @@ The following variables are used to optionally configure a docker.io mirror CA c
       -----BEGIN CERTIFICATE-----
       ...
       -----END CERTIFICATE-----
-
-    # Automatically determined in roles/container-host/tasks/main.yml
-    container_mirror_cert_path: "/etc/docker/certs.d/{{ container_mirror }}"
 
 Tags
 ++++

--- a/roles/container-host/tasks/container_mirror.yml
+++ b/roles/container-host/tasks/container_mirror.yml
@@ -1,13 +1,15 @@
 ---
-- name: "Create {{ container_mirror_cert_path }}"
+- name: "Create container_mirror_cert_paths"
   file:
-    path: "{{ container_mirror_cert_path }}"
+    path: "{{ item }}"
     state: directory
+  with_items: "{{ container_mirror_cert_paths }}"
 
 - name: "Copy {{ container_mirror }} self-signed cert"
   copy:
-    dest: "{{ container_mirror_cert_path }}/docker-mirror.crt"
+    dest: "{{ item }}/docker-mirror.crt"
     content: "{{ container_mirror_cert }}"
+  with_items: "{{ container_mirror_cert_paths }}"
 
 - name: Install registries-conf-ctl 
   pip:

--- a/roles/container-host/tasks/main.yml
+++ b/roles/container-host/tasks/main.yml
@@ -21,7 +21,6 @@
   when: container_packages|length > 0
 
 - set_fact:
-    container_mirror_cert_path: "/etc/containers/certs.d/{{ container_mirror }}"
     container_service_conf: "/etc/containers/registries.conf"
   when:
     - "'podman' in container_packages"
@@ -29,7 +28,6 @@
     - container-mirror
 
 - set_fact:
-    container_mirror_cert_path: "/etc/docker/certs.d/{{ container_mirror }}"
     container_service_conf: "/etc/docker/daemon.json"
   when:
     - "'docker.io' in container_packages"
@@ -41,6 +39,5 @@
   when:
     - container_mirror is defined
     - container_mirror_cert is defined
-    - container_mirror_cert_path is defined
   tags:
     - container-mirror

--- a/roles/container-host/vars/main.yml
+++ b/roles/container-host/vars/main.yml
@@ -1,0 +1,4 @@
+---
+container_mirror_cert_paths:
+  - "/etc/docker/certs.d/{{ container_mirror }}"
+  - "/etc/containers/certs.d/{{ container_mirror }}"


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/48715

Signed-off-by: David Galloway <dgallowa@redhat.com>