### PR TITLE
users: Support defining different branch

### DIFF
--- a/roles/users/defaults/main.yml
+++ b/roles/users/defaults/main.yml
@@ -25,6 +25,8 @@ revoked_users: []
 # A repo containing SSH pubkeys. Will be used for each user that has no key
 # specified.
 keys_repo: "https://github.com/ceph/keys"
+# Branch of above repo to use
+keys_branch: master
 # Where to clone keys_repo on the *local* disk
 keys_repo_path: "~/.cache/src/keys"
 

--- a/roles/users/tasks/update_keys.yml
+++ b/roles/users/tasks/update_keys.yml
@@ -7,7 +7,7 @@
   local_action:
     module: git
     repo: "{{ keys_repo }}"
-    version: master
+    version: "{{ keys_branch }}"
     # http://tracker.ceph.com/issues/16615
     # depth: 1
     force: yes


### PR DESCRIPTION
This will allow one to run the users role prior to a PR being merged.

Signed-off-by: David Galloway <dgallowa@redhat.com>