### PR TITLE
common: Ignore /snap mountpoints when checking disk usage

### DIFF
--- a/roles/common/files/libexec/diskusage.pl
+++ b/roles/common/files/libexec/diskusage.pl
@@ -56,7 +56,7 @@ my $crit = 0;
 my @parts;
 my $hostname = `hostname`;
 chomp $hostname;
-@parts = `mount | grep -vi fuse`;
+@parts = `mount | grep -vi fuse\|/snap`;
 
 #if ( $hostname eq 'zartan' ) {
 #	@parts = `mount`;


### PR DESCRIPTION
Signed-off-by: David Galloway <dgallowa@redhat.com>