### PR TITLE
testnode: libgcrypt needs to be updated to match QEMU build

### DIFF
--- a/roles/testnode/vars/centos_8.yml
+++ b/roles/testnode/vars/centos_8.yml
@@ -35,6 +35,9 @@ yum_mirrorlists:
   - CentOS-Base-mirrorlist
   - CentOS-Extras-mirrorlist
 
+packages_to_upgrade:
+  - libgcrypt # explicitly tied to qemu build
+
 packages:
   # for package-cleanup
   - dnf-utils


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1828681

Signed-off-by: Jason Dillaman <dillaman@redhat.com>