### PR TITLE
testnode: Install collectl without recommended packages

### DIFF
--- a/roles/testnode/README.rst
+++ b/roles/testnode/README.rst
@@ -167,6 +167,10 @@ A list of packages to upgrade. These lists are defined in the vars files in ``va
 
     packages_to_upgrade: []
 
+A list of packages to install via ``apt install --no-install-recommends``::
+
+    no_recommended_packages: []
+
 A list of packages to install via pip. These lists are defined in the vars files in ``vars/``::
 
     pip_packages_to_install: []

--- a/roles/testnode/tasks/apt/packages.yml
+++ b/roles/testnode/tasks/apt/packages.yml
@@ -37,3 +37,10 @@
     state: present
     force: yes
   when: ansible_architecture != "aarch64"
+
+- name: Install packages with --no-install-recommends
+  apt:
+    name: "{{ no_recommended_packages|list }}"
+    state: present
+    install_recommends: no
+  when: no_recommended_packages|length > 0

--- a/roles/testnode/vars/ubuntu.yml
+++ b/roles/testnode/vars/ubuntu.yml
@@ -53,7 +53,6 @@ common_packages:
   ###
   - vim
   - pdsh
-  - collectl
   # for blktrace and seekwatcher
   - blktrace
   ###
@@ -93,6 +92,9 @@ packages_to_upgrade:
 
 non_aarch64_packages_to_upgrade:
   - libapache2-mod-fastcgi
+
+no_recommended_packages:
+  - collectl
 
 packages_to_remove:
    # openmpi-common conflicts with mpitch stuff


### PR DESCRIPTION
collectl has a bunch of Gnome Desktop Environment packages that are recommended.  So on Ubuntu 20.04 at least, a desktop environment was getting installed and would eventually go to sleep.

Signed-off-by: David Galloway <dgallowa@redhat.com>