### PR TITLE
main.yml: set teuthology_default_machine_type

### DIFF
--- a/roles/teuthology/defaults/main.yml
+++ b/roles/teuthology/defaults/main.yml
@@ -12,6 +12,7 @@ teuthology_repo: https://github.com/ceph/teuthology.git
 teuthology_branch: "master"
 teuthology_yaml_extra: ""
 teuthology_ceph_git_base_url: "git://git.ceph.com/"
+teuthology_default_machine_type: "smithi"
 archive_base: "/home/{{ teuthology_execution_user }}/archive"
 
 remote_crontab_url: "https://raw.githubusercontent.com/ceph/ceph/master/qa/crontab/teuthology-cronjobs"


### PR DESCRIPTION
set teuthology_default_machine_type to smithi.
see: https://github.com/ceph/teuthology/pull/1625

Signed-off-by: Deepika Upadhyay <dupadhya@redhat.com>