### PR TITLE
cobbler_profile: s/import/imported

### DIFF
--- a/roles/cobbler_profile/tasks/import_distro.yml
+++ b/roles/cobbler_profile/tasks/import_distro.yml
@@ -53,7 +53,7 @@
   set_fact:
     profile_found:
         ((profile is defined and profile.stdout == distro_name) or
-         (import is defined and import.rc == 0))
+         (imported is defined and imported.rc == 0))
 
 - import_tasks: update_kickstart.yml
   when: distro.kickstart is defined and

--- a/roles/cobbler_profile/tasks/import_distro_image.yml
+++ b/roles/cobbler_profile/tasks/import_distro_image.yml
@@ -31,9 +31,9 @@
   command: cobbler distro add --kernel {{ kernel_path }} --initrd {{ initrd_path }} --name {{ distro_name }}
   when: download is changed or (files_exist and
         profile is defined and profile.stdout == '')
-  register: import
+  register: imported
 
 - name: Add the profile to cobbler
   command: cobbler profile add --name {{ distro_name }} --distro {{ distro_name }}
   when: import is defined and import.stdout == ''
-  register: import
+  register: imported

--- a/roles/cobbler_profile/tasks/import_distro_iso.yml
+++ b/roles/cobbler_profile/tasks/import_distro_iso.yml
@@ -39,7 +39,7 @@
 
 - name: Import the distro (also creates the profile)
   command: cobbler import --path={{ iso_mount }} --name={{ distro_name }} --arch={{ arch }}
-  register: import
+  register: imported
   when: mount is defined and mount is changed
 
 # In the next two step we need to


### PR DESCRIPTION
I guess something changed in ansible so that it doesn't like 'import' as the variable name.

Signed-off-by: David Galloway <dgallowa@redhat.com>