### PR TITLE
cobbler: Support CentOS Stream

### DIFF
--- a/cobbler.yml
+++ b/cobbler.yml
@@ -40,6 +40,7 @@
     - { role: cobbler_profile, distro_name: CentOS-8.1-aarch64, tags: ['centos8.1-aarch64'] }
     - { role: cobbler_profile, distro_name: CentOS-8.2-x86_64, tags: ['centos8.2'] }
     - { role: cobbler_profile, distro_name: CentOS-8.3-x86_64, tags: ['centos8.3'] }
+    - { role: cobbler_profile, distro_name: CentOS-8.stream-x86_64, tags: ['centos8.stream'] }
     - { role: cobbler_profile, distro_name: Ubuntu-12.04-server-x86_64, tags: ['ubuntu-precise'] }
     - { role: cobbler_profile, distro_name: Ubuntu-14.04-server-x86_64, tags: ['ubuntu-trusty'] }
     - { role: cobbler_profile, distro_name: Ubuntu-15.04-server-x86_64, tags: ['ubuntu-vivid'] }

--- a/roles/cobbler/templates/triggers/install/post/cephlab_ansible.sh
+++ b/roles/cobbler/templates/triggers/install/post/cephlab_ansible.sh
@@ -37,6 +37,9 @@ ansible-playbook testnodes.yml -v --limit $name* --tags user,pubkeys,zap 2>&1 > 
 if [[ $profile == *"-stock" ]]
 then
     exit 0
+elif [[ $profile == *"8.stream"* ]]
+then
+    ansible-playbook tools/convert-to-centos-stream.yml -v --limit $name* 2>&1 >> /var/log/ansible/$name.log
 fi
 ansible-playbook testnodes.yml -v --limit $name* --skip-tags user,pubkeys,zap 2>&1 >> /var/log/ansible/$name.log &
 popd

--- a/roles/cobbler_profile/defaults/main.yml
+++ b/roles/cobbler_profile/defaults/main.yml
@@ -42,6 +42,8 @@ distros:
       iso: ""
   "RHEL-8.3-Server-x86_64":
       iso: ""
+  "CentOS-8.stream-x86_64":
+      iso: ""
   "Fedora-22-Server-x86_64":
       iso: http://ftp.linux.ncsu.edu/mirror/ftp.redhat.com/pub/fedora/linux/releases/22/Server/x86_64/iso/Fedora-Server-DVD-x86_64-22.iso
       sha256: b2acfa7c7c6b5d2f51d3337600c2e52eeaa1a1084991181c28ca30343e52e0df

--- a/roles/cobbler_profile/tasks/import_distro.yml
+++ b/roles/cobbler_profile/tasks/import_distro.yml
@@ -42,10 +42,13 @@
   changed_when: false
 
 - import_tasks: import_distro_iso.yml
-  when: profile_type|default('') == 'iso'
+  when: profile_type|default('') == 'iso' and not '"stream" in distro_name'
 
 - import_tasks: import_distro_image.yml
   when: profile_type|default('') == 'image'
+
+- import_tasks: import_stream_profile.yml
+  when: '"stream" in distro_name'
 
 # If either the profile already existed or we successfully imported the
 # distro, we might want to update other options in the profile. i.e. kickstarts

--- a/roles/cobbler_profile/tasks/import_stream_profile.yml
+++ b/roles/cobbler_profile/tasks/import_stream_profile.yml
@@ -1,0 +1,26 @@
+---
+- name: "Extract distro name and major version from {{ distro_name }}"
+  set_fact:
+    distro_and_version: "{{ distro_name.split('.')[0] }}"
+
+- name: "Extract distro name from {{ distro_name }}"
+  set_fact:
+    stream_distro_name: "{{ distro_name.split('-')[0] }}"
+
+- name: "Extract the major version number from {{ distro_and_version }}"
+  set_fact:
+    stream_distro_version: "{{ distro_and_version.split('-')[1] }}"
+
+- name: "Get the latest non-Stream profile that matches this {{ stream_distro_name }} Stream distro version (e.g., CentOS-8.3-x86_64)"
+  shell: "cobbler profile list | grep {{ distro_and_version }} | grep -v 'stream\\|arm\\|aarch\\|stock' | sort -V | tail -n 1 | xargs"
+  register: latest_non_stream_profile
+
+# See commit message for why we do it this way
+- name: "Add {{ distro_name }} to Cobbler as a sub-profile of {{ latest_non_stream_profile.stdout }}"
+  command: "cobbler profile add --name {{ distro_name }} --parent {{ latest_non_stream_profile.stdout }} --clobber"
+  register: imported
+  when: latest_non_stream_profile.stdout_lines|length != 0
+
+# Try importing as an ISO instead if we can't create a sub-profile
+- import_tasks: import_distro_iso.yml
+  when: latest_non_stream_profile.stdout_lines|length == 0

--- a/roles/testnode/tasks/yum/repos.yml
+++ b/roles/testnode/tasks/yum/repos.yml
@@ -1,4 +1,19 @@
 ---
+# In non-Stream CentOS versions, ceph-cm-ansible takes care of overwriting the Distro/ISO-provided repo files.
+# Since we convert from CentOS 8.X to CentOS Stream, we have to delete the Stream repo files that the process creates.
+# We just don't want to rely on CentOS' infra to provide our mirror lists.  It has bitten us in the past.
+- name: Clean up Stream distro-provided repos
+  shell: "rm -rvf /etc/yum.repos.d/*Stream*"
+  when:
+    - ansible_lsb.description is defined
+    - '"Stream" in ansible_lsb.description'
+
+- set_fact:
+    dash_stream: "-stream"
+  when:
+    - ansible_lsb.description is defined
+    - '"Stream" in ansible_lsb.description'
+
 - name: Configure local mirrorlists
   template:
     src: 'mirrorlists/{{ ansible_distribution_major_version }}/{{ item }}'

--- a/roles/testnode/templates/mirrorlists/8/CentOS-AppStream-mirrorlist
+++ b/roles/testnode/templates/mirrorlists/8/CentOS-AppStream-mirrorlist
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 
 # local yum mirrorlist for CentOS-8 - AppStream repo
-https://download-cc-rdu01.fedoraproject.org/pub/centos/{{ ansible_distribution_major_version }}/AppStream/x86_64/os/
-http://mirror.linux.duke.edu/pub/centos/{{ ansible_distribution_major_version }}/AppStream/x86_64/os/
-http://packages.oit.ncsu.edu/centos/{{ ansible_distribution_major_version }}/AppStream/x86_64/os/
-http://distro.ibiblio.org/centos/{{ ansible_distribution_major_version }}/AppStream/x86_64/os/
+https://download-cc-rdu01.fedoraproject.org/pub/centos/{{ ansible_distribution_major_version }}{{ dash_stream }}/AppStream/x86_64/os/
+http://mirror.linux.duke.edu/pub/centos/{{ ansible_distribution_major_version }}{{ dash_stream }}/AppStream/x86_64/os/
+http://packages.oit.ncsu.edu/centos/{{ ansible_distribution_major_version }}{{ dash_stream }}/AppStream/x86_64/os/
+http://distro.ibiblio.org/centos/{{ ansible_distribution_major_version }}{{ dash_stream }}/AppStream/x86_64/os/

--- a/roles/testnode/templates/mirrorlists/8/CentOS-Base-mirrorlist
+++ b/roles/testnode/templates/mirrorlists/8/CentOS-Base-mirrorlist
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 
 # local yum mirrorlist for CentOS-8 - Base repo
-https://download-cc-rdu01.fedoraproject.org/pub/centos/{{ ansible_distribution_major_version }}/BaseOS/x86_64/os/
-http://mirror.linux.duke.edu/pub/centos/{{ ansible_distribution_major_version }}/BaseOS/x86_64/os/
-http://packages.oit.ncsu.edu/centos/{{ ansible_distribution_major_version }}/BaseOS/x86_64/os/
-http://distro.ibiblio.org/centos/{{ ansible_distribution_major_version }}/BaseOS/x86_64/os/
+https://download-cc-rdu01.fedoraproject.org/pub/centos/{{ ansible_distribution_major_version }}{{ dash_stream }}/BaseOS/x86_64/os/
+http://mirror.linux.duke.edu/pub/centos/{{ ansible_distribution_major_version }}{{ dash_stream }}/BaseOS/x86_64/os/
+http://packages.oit.ncsu.edu/centos/{{ ansible_distribution_major_version }}{{ dash_stream }}/BaseOS/x86_64/os/
+http://distro.ibiblio.org/centos/{{ ansible_distribution_major_version }}{{ dash_stream }}/BaseOS/x86_64/os/

--- a/roles/testnode/templates/mirrorlists/8/CentOS-Extras-mirrorlist
+++ b/roles/testnode/templates/mirrorlists/8/CentOS-Extras-mirrorlist
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 
 # local yum mirrorlist for CentOS-8 - Extras repo
-https://download-cc-rdu01.fedoraproject.org/pub/centos/{{ ansible_distribution_major_version }}/extras/x86_64/os/
-http://mirror.linux.duke.edu/pub/centos/{{ ansible_distribution_major_version }}/extras/x86_64/os/
-http://packages.oit.ncsu.edu/centos/{{ ansible_distribution_major_version }}/extras/x86_64/os/
-http://distro.ibiblio.org/centos/{{ ansible_distribution_major_version }}/extras/x86_64/os/
+https://download-cc-rdu01.fedoraproject.org/pub/centos/{{ ansible_distribution_major_version }}{{ dash_stream }}/extras/x86_64/os/
+http://mirror.linux.duke.edu/pub/centos/{{ ansible_distribution_major_version }}{{ dash_stream }}/extras/x86_64/os/
+http://packages.oit.ncsu.edu/centos/{{ ansible_distribution_major_version }}{{ dash_stream }}/extras/x86_64/os/
+http://distro.ibiblio.org/centos/{{ ansible_distribution_major_version }}{{ dash_stream }}/extras/x86_64/os/

--- a/roles/testnode/vars/yum_systems.yml
+++ b/roles/testnode/vars/yum_systems.yml
@@ -43,3 +43,7 @@ ceph_dependency_packages_to_remove:
 
 pip_packages_to_install:
   - remoto>=0.0.35
+
+# This gets defined to "-stream" in roles/testnode/tasks/yum/repos.yml when CentOS Stream is the OS.
+# It adds "-stream" to yum repo mirrorlist URLs.
+dash_stream: ""

--- a/tools/convert-to-centos-stream.yml
+++ b/tools/convert-to-centos-stream.yml
@@ -1,0 +1,17 @@
+---
+### This playbook simply converts a CentOS host to CentOS Stream.
+### It is primarily intended to be run during Cobbler's cephlab_ansible.sh post-install trigger.
+
+- hosts:
+    - all
+  become: true
+  gather_facts: true
+  tasks:
+
+  - name: Swap to Stream Repos
+    command: dnf -y swap centos-linux-repos centos-stream-repos
+    when: ansible_distribution == 'CentOS'
+
+  - name: Sync Stream Repos
+    command: dnf -y distro-sync
+    when: ansible_distribution == 'CentOS'


### PR DESCRIPTION
We have to do it this way for a number of reasons

1. The vmlinuz and initrd in the CentOS Stream ISO aren't compatible. https://bugs.centos.org/view.php?id=18188
2. The version of Cobbler we're running does not recognize CentOS Stream ISO without hacking the distro_signatures file
3. Probably most importantly, when using the CentOS Stream ISO, after the installation is finished, we bizarrely end up with CentOS 8.3...  Not Stream.

Signed-off-by: David Galloway <dgallowa@redhat.com>