### PR TITLE
testnode: Write sentinel file after container-host role

### DIFF
--- a/cephlab.yml
+++ b/cephlab.yml
@@ -7,6 +7,11 @@
 # if this node is in the teuthology group, configure it
 - import_playbook: teuthology.yml
 
+- hosts: testnodes
+  tasks:
+    - set_fact:
+        ran_from_cephlab_playbook: true
+
 # if this node is in the testnode group, configure it
 - import_playbook: testnodes.yml
 
@@ -24,3 +29,14 @@
 
 # if this node is in the pulpito group, configure it
 - import_playbook: pulpito.yml
+
+# Touch a file to indicate we are done. This is something chef did;
+# teuthology.task.internal.vm_setup() expects it.
+- hosts: testnodes
+  become: true
+  tasks:
+    - name: Touch /ceph-qa-ready
+      file:
+          path: /ceph-qa-ready
+          state: touch
+      when: ran_from_cephlab_playbook|bool

--- a/roles/testnode/tasks/main.yml
+++ b/roles/testnode/tasks/main.yml
@@ -161,3 +161,4 @@
   file:
       path: /ceph-qa-ready
       state: touch
+  when: (ran_from_cephlab_playbook is undefined or not ran_from_cephlab_playbook|bool)


### PR DESCRIPTION
Now that we're running the entire cephlab.yml playbook during Cobbler kickstart, the sentinel file is getting touched while the container-host playbook is still running.

This change will still write the /ceph-qa-ready sentinel file during the testnodes role if the testnodes role got called directly

Signed-off-by: David Galloway <dgallowa@redhat.com>