### PR TITLE
testnode: Always ifup the secondary NIC

### DIFF
--- a/roles/testnode/tasks/secondary_nic.yml
+++ b/roles/testnode/tasks/secondary_nic.yml
@@ -74,7 +74,7 @@
     - ansible_os_family == 'RedHat'
 
 - name: "Bounce {{ nic_to_configure }}"
-  shell: "ifdown {{ nic_to_configure }} && ifup {{ nic_to_configure }}"
+  shell: "ifdown {{ nic_to_configure }}; ifup {{ nic_to_configure }}"
   when:
     - wrote_network_config is changed
     - ansible_os_family == 'RedHat'


### PR DESCRIPTION
If the NIC was already down, `ifdown` causes the playbook to fail.  We want to always (at least attempt to) take the NIC down, then bring it back up.

Signed-off-by: David Galloway <dgallowa@redhat.com>