### PR TITLE
container-host: Install pip too

### DIFF
--- a/roles/container-host/tasks/container_mirror.yml
+++ b/roles/container-host/tasks/container_mirror.yml
@@ -11,9 +11,11 @@
     content: "{{ container_mirror_cert }}"
   with_items: "{{ container_mirror_cert_paths }}"
 
-- name: Ensure git is installed
+- name: Ensure installation dependencies are installed
   package:
-    name: git
+    name:
+      - git
+      - python-pip
     state: present
   tags:
     - registries-conf-ctl


### PR DESCRIPTION
This was needed on CentOS8 and Ubuntu Focal Jenkins builders.

Signed-off-by: David Galloway <dgallowa@redhat.com>