### PR TITLE
testnode: Install redhat-lsb-core

### DIFF
--- a/roles/testnode/vars/centos_8.yml
+++ b/roles/testnode/vars/centos_8.yml
@@ -39,6 +39,7 @@ packages_to_upgrade:
   - libgcrypt # explicitly tied to qemu build
 
 packages:
+  - redhat-lsb-core
   # for package-cleanup
   - dnf-utils
   - sysstat


### PR DESCRIPTION
This usually gets installed via Cobbler during FOG image capturing.  That doesn't do us any good when FOG isn't being used.

Signed-off-by: David Galloway <dgallowa@redhat.com>