### PR TITLE
roles/testnode/vars: add ceph/python3-asyncssh to copr_repos

### DIFF
--- a/roles/testnode/vars/centos_8.yml
+++ b/roles/testnode/vars/centos_8.yml
@@ -42,6 +42,9 @@ yum_mirrorlists:
   - CentOS-Extras-mirrorlist
   - CentOS-PowerTools-mirrorlist
 
+copr_repos:
+  - ceph/python3-asyncssh
+
 packages_to_upgrade:
   - libgcrypt # explicitly tied to qemu build
 

--- a/roles/testnode/vars/redhat_8.yml
+++ b/roles/testnode/vars/redhat_8.yml
@@ -8,6 +8,9 @@ common_yum_repos:
     enabled: 1
     gpgcheck: 0
 
+copr_repos:
+  - ceph/python3-asyncssh
+
 packages:
   # for package-cleanup
   - dnf-utils


### PR DESCRIPTION
python3-asyncssh is not included by EPEL8 yet, but mgr-cephadm requires
it. see also https://tracker.ceph.com/issues/44676

Signed-off-by: Kefu Chai <tchaikov@gmail.com>