### PR TITLE
roles/testnode/vars/ubuntu_20: add python3-venv to packages

### DIFF
--- a/roles/testnode/vars/ubuntu_20.yml
+++ b/roles/testnode/vars/ubuntu_20.yml
@@ -11,6 +11,7 @@ packages:
   # qa/workunits/rbd/test_librbd_python.sh
   - python3-nose
   # python3 version of deps
+  - python3-venv
   - python3-virtualenv
   - python3-configobj
   - python3-gevent


### PR DESCRIPTION
since we are going to replace virtualenv with "python3 -m venv",
let's add python3-venv.

keep python3-virtualenv around for a while just in case.

Signed-off-by: Kefu Chai <tchaikov@gmail.com>