### PR TITLE
roles/testnode/templates/ssh: temporarily set RHEL8 sshd loglevel to debug

### DIFF
--- a/roles/testnode/templates/ssh/sshd_config_redhat_8
+++ b/roles/testnode/templates/ssh/sshd_config_redhat_8
@@ -36,3 +36,5 @@ AcceptEnv XMODIFIERS
 Subsystem	sftp	/usr/libexec/openssh/sftp-server
 
 MaxSessions 1000
+
+LogLevel DEBUG3


### PR DESCRIPTION
Temporarily increase RHEL8 sshd loglevel to DEBUG3 for debugging this PR: https://github.com/ceph/ceph/pull/42051

Signed-off-by: Melissa Li <li.melissa.kun@gmail.com>