### PR TITLE
roles/testnode/templates/ssh: disable GSSAPIAuthentication for RHEL8 and Centos8

### DIFF
--- a/roles/testnode/templates/ssh/sshd_config_centos_8
+++ b/roles/testnode/templates/ssh/sshd_config_centos_8
@@ -18,8 +18,8 @@ PasswordAuthentication yes
 ChallengeResponseAuthentication no
 
 # GSSAPI options
-GSSAPIAuthentication yes
-GSSAPICleanupCredentials yes
+GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
 
 UsePAM yes
 

--- a/roles/testnode/templates/ssh/sshd_config_redhat_8
+++ b/roles/testnode/templates/ssh/sshd_config_redhat_8
@@ -18,8 +18,8 @@ PasswordAuthentication yes
 ChallengeResponseAuthentication no
 
 # GSSAPI options
-GSSAPIAuthentication yes
-GSSAPICleanupCredentials yes
+GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
 
 UsePAM yes
 


### PR DESCRIPTION
Disable GSSAPIAuthentication on the RHEL8 and Centos8 testnodes for this PR: https://github.com/ceph/ceph/pull/42051

Fixes: https://tracker.ceph.com/issues/44676
Signed-off-by: Melissa Li <li.melissa.kun@gmail.com>