### PR TITLE
lrc: Have logrotate cronjob optionally run the cephadm-created conf

### DIFF
--- a/roles/long_running_cluster/tasks/logrotate.yml
+++ b/roles/long_running_cluster/tasks/logrotate.yml
@@ -7,12 +7,13 @@
 - name: "Write custom ceph logrotate config"
   template:
     src: ceph-common.logrotate
-    dest: /etc/logrotate.d/ceph-common
+    dest: /etc/logrotate.d/cm-ansible-ceph-common
+  when: lrc_fsid is not defined
 
 - name: "Create cronjob to logrotate every 6 hours"
   cron:
     name: "Logrotate ceph logs every 6 hours"
     minute: "25"
     hour: "0,6,12,18"
-    job: "/usr/sbin/logrotate -f /etc/logrotate.d/ceph-common"
+    job: "/usr/sbin/logrotate -f /etc/logrotate.d/{{ lrc_fsid|default('cm-ansible-ceph-common') }}"
     user: root


### PR DESCRIPTION
cephadm manages a different logrotate file.  That file's name is the cluster FSID.

So I'll defined lrc_fsid in the secrets repo and this task will change the cronjob to run that logrotate file instead of the ceph-common one (that wasn't doing anything useful anyway).

Signed-off-by: David Galloway <dgallowa@redhat.com>