### PR TITLE
testnode: Install libgnutls30 on Ubuntu systems

### DIFF
--- a/roles/testnode/vars/ubuntu.yml
+++ b/roles/testnode/vars/ubuntu.yml
@@ -80,6 +80,8 @@ common_packages:
   - nfs-kernel-server
   # for add-apt-repository
   - software-properties-common
+  # for https://twitter.com/letsencrypt/status/1443621997288767491
+  - libgnutls30
 
 non_aarch64_common_packages:
   - smbios-utils


### PR DESCRIPTION
Fixes: https://twitter.com/letsencrypt/status/1443621997288767491

https://github.com/nodesource/distributions/issues/1266#issuecomment-931481002

Signed-off-by: David Galloway <dgallowa@redhat.com>