### PR TITLE
testnode: update openjdk version to 1.8.0

### DIFF
--- a/roles/testnode/vars/centos_7.yml
+++ b/roles/testnode/vars/centos_7.yml
@@ -83,7 +83,7 @@ packages:
   # for pretty-printing xml
   - perl-XML-Twig
   # for java bindings, hadoop, etc.
-  - java-1.6.0-openjdk-devel
+  - java-1.8.0-openjdk-devel
   - junit4
   # for nfs
   - nfs-utils

--- a/roles/testnode/vars/redhat_7.6.yml
+++ b/roles/testnode/vars/redhat_7.6.yml
@@ -62,7 +62,7 @@ packages:
   - mod_ssl
   - mod_fastcgi-2.4.7-1.ceph.el7
   - perl-XML-Twig
-  - java-1.6.0-openjdk-devel
+  - java-1.8.0-openjdk-devel
   - junit4
   - nfs-utils
   # for xfstests

--- a/roles/testnode/vars/redhat_7.8.yml
+++ b/roles/testnode/vars/redhat_7.8.yml
@@ -64,7 +64,7 @@ packages:
   - mod_ssl
   - mod_fastcgi-2.4.7-1.ceph.el7
   - perl-XML-Twig
-  - java-1.6.0-openjdk-devel
+  - java-1.8.0-openjdk-devel
   - junit4
   - nfs-utils
   # for xfstests

--- a/roles/testnode/vars/redhat_7.yml
+++ b/roles/testnode/vars/redhat_7.yml
@@ -65,7 +65,7 @@ packages:
   - mod_fastcgi-2.4.7-1.ceph.el7
   - libev-devel
   - perl-XML-Twig
-  - java-1.6.0-openjdk-devel
+  - java-1.8.0-openjdk-devel
   - junit4
   - nfs-utils
   # for xfstests


### PR DESCRIPTION
the aarch64 architecture is supported for OpenJDK 8

	modified:   roles/testnode/vars/centos_7.yml
	modified:   roles/testnode/vars/redhat_7.6.yml
	modified:   roles/testnode/vars/redhat_7.8.yml
	modified:   roles/testnode/vars/redhat_7.yml

Signed-off-by: Dai Zhiwei <daizhiwei3@huawei.com>