### PR TITLE
container-host: Install python dependencies

### DIFF
--- a/roles/container-host/tasks/container_mirror.yml
+++ b/roles/container-host/tasks/container_mirror.yml
@@ -22,6 +22,7 @@
   pip:
     name: git+https://github.com/sebastian-philipp/registries-conf-ctl
     state: latest
+    executable: "{{ pip_executable|default('pip3') }}"
   tags:
     - registries-conf-ctl
 

--- a/roles/container-host/vars/apt_systems.yml
+++ b/roles/container-host/vars/apt_systems.yml
@@ -1,3 +1,5 @@
 ---
 container_packages:
   - docker.io
+  - python3-setuptools
+  - python3-pip

--- a/roles/container-host/vars/centos_7.yml
+++ b/roles/container-host/vars/centos_7.yml
@@ -1,0 +1,6 @@
+---
+container_packages:
+  - podman
+  - podman-docker
+
+pip_executable: pip

--- a/roles/container-host/vars/ubuntu_18.yml
+++ b/roles/container-host/vars/ubuntu_18.yml
@@ -1,0 +1,7 @@
+---
+container_packages:
+  - docker.io
+  - python-setuptools
+  - python-pip
+
+pip_executable: pip


### PR DESCRIPTION
I need this role for Jenkins builders.  They don't get setuptools or pip installed during the common role.

Signed-off-by: David Galloway <dgallowa@redhat.com>