### PR TITLE
cobbler: Run yum update during CentOS Stream install

### DIFF
--- a/roles/cobbler/templates/kickstarts/cephlab_rhel.ks
+++ b/roles/cobbler/templates/kickstarts/cephlab_rhel.ks
@@ -86,8 +86,13 @@ $SNIPPET('cephlab_user')
 #if $distro == 'RHEL'
 $SNIPPET('cephlab_rhel_rhsm')
 #end if
+#if distro_ver_minor == 'stream'
+# We want the latest packages because it's Stream
+yum -y update
+#else
 # Update to latest kernel before rebooting
 yum -y update kernel
+#end if
 $SNIPPET('cephlab_rc_local')
 $SNIPPET('kickstart_done')
 # End final steps

--- a/roles/cobbler/templates/kickstarts/cephlab_rhel_sdi.ks
+++ b/roles/cobbler/templates/kickstarts/cephlab_rhel_sdi.ks
@@ -100,8 +100,13 @@ $SNIPPET('cephlab_user')
 #if $distro == 'RHEL'
 $SNIPPET('cephlab_rhel_rhsm')
 #end if
+#if distro_ver_minor == 'stream'
+# We want the latest packages because it's Stream
+yum -y update
+#else
 # Update to latest kernel before rebooting
 yum -y update kernel
+#end if
 $SNIPPET('cephlab_rc_local')
 $SNIPPET('kickstart_done')
 # End final steps

--- a/roles/cobbler/templates/kickstarts/cephlab_rhel_sdm.ks
+++ b/roles/cobbler/templates/kickstarts/cephlab_rhel_sdm.ks
@@ -100,8 +100,13 @@ $SNIPPET('cephlab_user')
 #if $distro == 'RHEL'
 $SNIPPET('cephlab_rhel_rhsm')
 #end if
+#if distro_ver_minor == 'stream'
+# We want the latest packages because it's Stream
+yum -y update
+#else
 # Update to latest kernel before rebooting
 yum -y update kernel
+#end if
 $SNIPPET('cephlab_rc_local')
 $SNIPPET('kickstart_done')
 # End final steps


### PR DESCRIPTION
It occurred to me that the CentOS 8 Stream ISO is probably always going to be outdated so we can just run 'yum update' during kickstart.  We *don't* want to do this for non-Stream distro because it'll update a RHEL8.4 image to RHEL8.5, for example.

Signed-off-by: David Galloway <dgallowa@redhat.com>