### PR TITLE
container-host: distro-specific secrets file

### DIFF
--- a/roles/container-host/tasks/main.yml
+++ b/roles/container-host/tasks/main.yml
@@ -10,7 +10,7 @@
 - name: Including distro specific variables
   include_vars: "{{ item }}"
   with_first_found:
-    - "{{ secrets_path }}/container-host.yml"
+    - "{{ secrets_path }}/container-host/{{ ansible_distribution | lower }}_{{ ansible_distribution_major_version }}.yml"
     - "{{ ansible_distribution | lower }}_{{ ansible_distribution_major_version }}.yml"
     - "{{ package_manager }}_systems.yml"
     - empty.yml


### PR DESCRIPTION
`container_packages` was getting set to `podman` for all downstream distros.  That won't work for Ubuntu so we'll use distro-specific secrets overrides.

Signed-off-by: David Galloway <dgallowa@redhat.com>