### PR TITLE
Revert "testnode: Add Apache Arrow repo"

### DIFF
--- a/roles/testnode/tasks/yum/gpg_keys.yml
+++ b/roles/testnode/tasks/yum/gpg_keys.yml
@@ -15,5 +15,4 @@
   with_items:
     - 'https://{{ key_host }}/keys/release.asc'
     - 'https://{{ key_host }}/keys/autobuild.asc'
-    - 'https://dist.apache.org/repos/dist/dev/arrow/KEYS'
   register: gpg_keys

--- a/roles/testnode/tasks/yum/repos.yml
+++ b/roles/testnode/tasks/yum/repos.yml
@@ -39,6 +39,7 @@
     - copr_repos|length > 0
 
 - import_tasks: gpg_keys.yml
+  when: ansible_distribution == "Fedora"
   tags:
     - gpg-keys
 

--- a/roles/testnode/vars/centos_7.yml
+++ b/roles/testnode/vars/centos_7.yml
@@ -12,11 +12,6 @@ yum_repos:
     baseurl: "http://{{ mirror_host }}/lab-extras/centos7/"
     enabled: 1
     gpgcheck: 0
-  apache-arrow:
-    name: "Apache Arrow"
-    baseurl: "https://apache.jfrog.io/artifactory/arrow/centos/7/$basearch"
-    enabled: 1
-    gpgcheck: 1
 
 packages:
   - '@core'

--- a/roles/testnode/vars/centos_8.yml
+++ b/roles/testnode/vars/centos_8.yml
@@ -7,11 +7,6 @@ common_yum_repos:
     baseurl: "http://{{ mirror_host }}/lab-extras/8/"
     enabled: 1
     gpgcheck: 0
-  apache-arrow:
-    name: "Apache Arrow"
-    baseurl: "https://apache.jfrog.io/artifactory/arrow/centos/8/$basearch"
-    enabled: 1
-    gpgcheck: 1
 
 # These will overwrite the repo files that come with a CentOS installation
 yum_repos:

--- a/roles/testnode/vars/redhat_7.yml
+++ b/roles/testnode/vars/redhat_7.yml
@@ -12,11 +12,6 @@ common_yum_repos:
     baseurl: "http://{{ mirror_host }}/lab-extras/rhel7/"
     enabled: 1
     gpgcheck: 0
-  apache-arrow:
-    name: "Apache Arrow"
-    baseurl: "https://apache.jfrog.io/artifactory/arrow/centos/7/$basearch"
-    enabled: 1
-    gpgcheck: 1
 
 packages:
   - '@core'

--- a/roles/testnode/vars/redhat_8.yml
+++ b/roles/testnode/vars/redhat_8.yml
@@ -7,11 +7,6 @@ common_yum_repos:
     baseurl: "http://{{ mirror_host }}/lab-extras/8/"
     enabled: 1
     gpgcheck: 0
-  apache-arrow:
-    name: "Apache Arrow"
-    baseurl: "https://apache.jfrog.io/artifactory/arrow/centos/8/$basearch"
-    enabled: 1
-    gpgcheck: 1
 
 copr_repos:
   - ceph/python3-asyncssh


### PR DESCRIPTION
This reverts commit 3f960fe1b6957bdfb551bd4e53ad275d0d446855.

the new plan is to submodule the things we needed from this repo, so it's no longer necessary. and since centos 8 eol, it looks like apache may have removed the `/centos/8/` repos so this is now causing teuthology failures