### PR TITLE
testnode: Alternate method of detecting Stream (for Openstack instances)

### DIFF
--- a/roles/testnode/tasks/yum/stream.yml
+++ b/roles/testnode/tasks/yum/stream.yml
@@ -4,16 +4,6 @@
 # We just don't want to rely on CentOS' infra to provide our mirror lists.  It has bitten us in the past.
 - name: Clean up Stream distro-provided repos
   shell: "rm -rvf /etc/yum.repos.d/*-Stream-*"
-  when:
-    - ansible_lsb.description is defined
-    - '"Stream" in ansible_lsb.description'
-
-# Setting this var will add "-stream" to the mirrorlist/baseurl URLs in .repo files
-- set_fact:
-    dash_stream: "-stream"
-  when:
-    - ansible_lsb.description is defined
-    - '"Stream" in ansible_lsb.description'
 
 - name: Include CentOS Stream specific variables
   include_vars: "{{ item }}"

--- a/roles/testnode/tasks/yum_systems.yml
+++ b/roles/testnode/tasks/yum_systems.yml
@@ -54,11 +54,24 @@
   command:
     rpm --rebuilddb
 
+- name: Check /etc/os-release to see if this is CentOS Stream
+  shell: "grep 'CentOS Stream' /etc/os-release || true"
+  register: stream_in_osrelease
+  tags:
+    - repos
+
+# Setting this var will add "-stream" to the mirrorlist/baseurl URLs in .repo files
+- set_fact:
+    dash_stream: "-stream"
+    is_stream: true
+  when: (ansible_lsb.description is defined and "Stream" in ansible_lsb.description) or
+        stream_in_osrelease.stdout is search("CentOS Stream")
+  tags:
+    - repos
+
 - name: Perform CentOS Stream related tasks
   import_tasks: yum/stream.yml
-  when:
-    - ansible_lsb.description is defined
-    - '"Stream" in ansible_lsb.description'
+  when: is_stream|default('false')|bool
   tags:
     - repos
 

--- a/roles/testnode/vars/centos_8_stream.yml
+++ b/roles/testnode/vars/centos_8_stream.yml
@@ -3,3 +3,6 @@
 
 packages_to_upgrade:
   - systemd
+
+packages:
+  - lvm2

--- a/roles/testnode/vars/yum_systems.yml
+++ b/roles/testnode/vars/yum_systems.yml
@@ -44,6 +44,6 @@ ceph_dependency_packages_to_remove:
 pip_packages_to_install:
   - remoto>=0.0.35
 
-# This gets defined to "-stream" in roles/testnode/tasks/yum/repos.yml when CentOS Stream is the OS.
+# This gets defined to "-stream" in roles/testnode/tasks/yum_systems.yml when CentOS Stream is the OS.
 # It adds "-stream" to yum repo mirrorlist URLs.
 dash_stream: ""


### PR DESCRIPTION
Apparently the CentOS Stream Openstack images work despite the PXE images not working.

These changes are needed in order to run the testnode role against CentOS 8 Stream instances in Openstack.

Signed-off-by: David Galloway <dgallowa@redhat.com>