### PR TITLE
testnode: Filter ansible_mounts with regex

### DIFF
--- a/roles/testnode/tasks/zap_disks.yml
+++ b/roles/testnode/tasks/zap_disks.yml
@@ -32,15 +32,7 @@
   with_items: "{{ ansible_mounts }}"
   when:
     - item.mount != '/' and
-      item.mount != '/var' and
-      item.mount != '/tmp' and
-      item.mount != '/root' and
-      item.mount != '/home' and
-      '"/boot" not in item.mount' and
-      item.mount != '/.snapshots' and
-      item.mount != '/usr/local' and
-      item.mount != '/srv' and
-      item.mount != '/opt'
+      not item is match("/(boot|home|opt|root|srv|tmp|usr/local|var|.snapshots")
 
 ## http://tracker.ceph.com/issues/20533
 ## Trusty version of wipefs lacks --force option


### PR DESCRIPTION
This fixes an issue Seagate was hitting