### PR TITLE
common: failovermethod is deprecated

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -18,14 +18,12 @@ epel_repos:
   epel:
     name: "Extra Packages for Enterprise Linux"
     mirrorlist: file:///etc/yum.repos.d/epel-mirrorlist
-    failovermethod: priority
     # ternary requires ansible >= 1.9
     enabled: "{{ enable_epel | ternary(1, 0) }}"
     gpgcheck: 0
   epel-testing:
     name: "Extra Packages for Enterprise Linux - Testing"
     mirrorlist: file:///etc/yum.repos.d/epel-testing-mirrorlist
-    failovermethod: priority
     enabled: 0
     gpgcheck: 0
 


### PR DESCRIPTION
Signed-off-by: David Galloway <dgallowa@redhat.com>