### PR TITLE
common: RHSM register w/ full hostname

### DIFF
--- a/roles/common/tasks/rhel-entitlements.yml
+++ b/roles/common/tasks/rhel-entitlements.yml
@@ -53,6 +53,7 @@
   command: subscription-manager register
            --activationkey={{ subscription_manager_activationkey }}
            --org={{ subscription_manager_org }}
+           --name={{ ansible_fqdn }}
            {% if set_rhsm_release|default(false)|bool == true %}--release={{ ansible_distribution_version }}{% endif %}
            --force
   no_log: true


### PR DESCRIPTION
For some reason, sometimes hosts try to register with their short hostname.  Sometimes with the FQDN.

As of Satellite 6.5, the service won't let you register two different hostnames with the same UUID (https://access.redhat.com/solutions/4207781).

This change makes sure all hosts register with the FQDN so there's no more conflicts.

Signed-off-by: David Galloway <dgallowa@redhat.com>