### PR TITLE
testnode: No pkg tasks before repos are set up

### DIFF
--- a/roles/testnode/tasks/zap_disks.yml
+++ b/roles/testnode/tasks/zap_disks.yml
@@ -13,7 +13,8 @@
   package:
     name: ['gdisk', 'device-mapper']
     state: present
-  when: ansible_os_family == "RedHat"
+  when: (ansible_distribution == "RedHat" and rhsm_registered is defined and rhsm_registered == true) or
+        (ansible_os_family == "RedHat" and ansible_distribution != "RedHat")
 
 - name: Set root disk
   set_fact:


### PR DESCRIPTION
Newer versions of RHEL8 don't like having yum called if they don't have repos setup.

When a RHEL8 machine gets provisioned via Cobbler, we zap the disks before we register the server to Satellite (or CDN).

We don't really need to check if gdisk and device-mapper are installed during a Cobbler install because we know they're installed in https://github.com/ceph/ceph-cm-ansible/blob/main/roles/cobbler/templates/snippets/cephlab_packages_rhel

Signed-off-by: David Galloway <dgallowa@redhat.com>