### PR TITLE
cobbler_systems: Set default_profile to a newer distro

### DIFF
--- a/roles/cobbler_systems/defaults/main.yml
+++ b/roles/cobbler_systems/defaults/main.yml
@@ -2,4 +2,4 @@
 interface: eth0
 kernel_options: ''
 kernel_options_post: ''
-default_profile: "Ubuntu-14.04-server-x86_64"
+default_profile: "RHEL-8.6-Server-x86_64"


### PR DESCRIPTION
I just chose RHEL8.6 because it's available in both Sepia and Octo labs.  Ubuntu and CentOS aren't.

Signed-off-by: David Galloway <dgallowa@redhat.com>