### PR TITLE
testnode: Move python-dev to distro-specific vars files

### DIFF
--- a/roles/testnode/vars/ubuntu.yml
+++ b/roles/testnode/vars/ubuntu.yml
@@ -4,7 +4,6 @@ common_packages:
   - libfcgi0ldbl
   ###
   # for s3 tests
-  - python-dev
   - libev-dev
   ###
   # for cpan

--- a/roles/testnode/vars/ubuntu_12.04.yml
+++ b/roles/testnode/vars/ubuntu_12.04.yml
@@ -13,6 +13,7 @@ packages:
   # used by workunits
   - mpich2
   - libmpich2-dev
+  - python-dev
 
 non_aarch64_packages:
   - iozone3

--- a/roles/testnode/vars/ubuntu_14.yml
+++ b/roles/testnode/vars/ubuntu_14.yml
@@ -17,6 +17,7 @@ packages:
   # used by workunits
   - mpich2
   - libmpich2-dev
+  - python-dev
 
 non_aarch64_packages:
   - libgoogle-perftools4

--- a/roles/testnode/vars/ubuntu_15.yml
+++ b/roles/testnode/vars/ubuntu_15.yml
@@ -18,6 +18,7 @@ packages:
   # used by workunits
   - mpich2
   - libmpich2-dev
+  - python-dev
 
 non_aarch64_packages:
   - iozone3

--- a/roles/testnode/vars/ubuntu_16.yml
+++ b/roles/testnode/vars/ubuntu_16.yml
@@ -23,6 +23,7 @@ packages:
   ###
   # for building xfstests #18067
   - libtool-bin
+  - python-dev
 
 packages_to_upgrade:
   # http://tracker.ceph.com/issues/13522#note-51

--- a/roles/testnode/vars/ubuntu_18.yml
+++ b/roles/testnode/vars/ubuntu_18.yml
@@ -17,6 +17,7 @@ packages:
   - docker.io
   # qa/workunits/rbd/test_librbd_python.sh
   - python3-nose
+  - python-dev
 
 non_aarch64_packages:
   - libgoogle-perftools4

--- a/roles/testnode/vars/ubuntu_20.yml
+++ b/roles/testnode/vars/ubuntu_20.yml
@@ -18,6 +18,7 @@ packages:
   - python3-numpy
   - python3-matplotlib
   - python3-setuptools
+  - python-dev
 
 non_aarch64_packages:
   - libgoogle-perftools4


### PR DESCRIPTION
Signed-off-by: David Galloway <dgallowa@redhat.com>