### PR TITLE
cobbler: Do not use redhat_register snippet

### DIFF
--- a/roles/cobbler/templates/kickstarts/cephlab_rhel.ks
+++ b/roles/cobbler/templates/kickstarts/cephlab_rhel.ks
@@ -75,7 +75,6 @@ $SNIPPET('post_install_kernel_options')
 $SNIPPET('func_register_if_enabled')
 $SNIPPET('download_config_files')
 $SNIPPET('koan_environment')
-$SNIPPET('redhat_register')
 $SNIPPET('cobbler_register')
 # Enable post-install boot notification
 $SNIPPET('post_anamon')

--- a/roles/cobbler/templates/kickstarts/cephlab_rhel_sdc.ks
+++ b/roles/cobbler/templates/kickstarts/cephlab_rhel_sdc.ks
@@ -89,7 +89,6 @@ $SNIPPET('post_install_kernel_options')
 $SNIPPET('func_register_if_enabled')
 $SNIPPET('download_config_files')
 $SNIPPET('koan_environment')
-$SNIPPET('redhat_register')
 $SNIPPET('cobbler_register')
 # Enable post-install boot notification
 $SNIPPET('post_anamon')

--- a/roles/cobbler/templates/kickstarts/cephlab_rhel_sdi.ks
+++ b/roles/cobbler/templates/kickstarts/cephlab_rhel_sdi.ks
@@ -89,7 +89,6 @@ $SNIPPET('post_install_kernel_options')
 $SNIPPET('func_register_if_enabled')
 $SNIPPET('download_config_files')
 $SNIPPET('koan_environment')
-$SNIPPET('redhat_register')
 $SNIPPET('cobbler_register')
 # Enable post-install boot notification
 $SNIPPET('post_anamon')

--- a/roles/cobbler/templates/kickstarts/cephlab_rhel_sdm.ks
+++ b/roles/cobbler/templates/kickstarts/cephlab_rhel_sdm.ks
@@ -89,7 +89,6 @@ $SNIPPET('post_install_kernel_options')
 $SNIPPET('func_register_if_enabled')
 $SNIPPET('download_config_files')
 $SNIPPET('koan_environment')
-$SNIPPET('redhat_register')
 $SNIPPET('cobbler_register')
 # Enable post-install boot notification
 $SNIPPET('post_anamon')


### PR DESCRIPTION
We already run `subscription-manager` manually in kickstart so we don't need this snippet.

Signed-off-by: David Galloway <dgallowa@redhat.com>