### PR TITLE
Using the cpanm ansible module

### DIFF
--- a/roles/testnode/tasks/cpan.yml
+++ b/roles/testnode/tasks/cpan.yml
@@ -46,6 +46,7 @@
   changed_when: false
 
 - name: "Install Amazon::S3."
-  command: "cpan  Amazon::S3"
+  cpanm:
+    name: "Amazon::S3"
   when: cpan_check is defined and
         cpan_check.rc != 0


### PR DESCRIPTION
Using the cpanm ansible module instead of using the "command" module since we are seeing "Proceed nonetheless? [no] no', 'Aborted." during host re-imaging which can be solved using this module that does a clean installation in this case
http://pulpito.front.sepia.ceph.com/yuvalif-2022-12-20_21:29:08-rgw-wip-yuval-fix-58167-distro-default-smithi/7122795/
Signed-off-by: Adam Kraitman <akraitma@redhat.com>