### PR TITLE
Add checkcerts, to use with cron to warn about expiring certs

### DIFF
--- a/tools/checkcerts.py
+++ b/tools/checkcerts.py
@@ -1,0 +1,110 @@
+#!/usr/bin/python3
+
+import argparse
+import socket
+import ssl
+import subprocess
+import sys
+import os
+import tempfile
+import datetime
+import smtplib
+
+DAYS_BEFORE_WARN=7
+
+DEFAULT_DOMAINS = [
+    '1.chacra.ceph.com',
+    '2.chacra.ceph.com',
+    '3.chacra.ceph.com',
+    '4.chacra.ceph.com',
+    'ceph.com',
+    'ceph.io',
+    'chacra.ceph.com',
+    'console-openshift-console.apps.os.sepia.ceph.com',
+    'docs.ceph.com',
+    'download.ceph.com',
+    'git.ceph.com',
+    'grafana.ceph.com',
+    'jenkins.ceph.com',
+    'jenkins.rook.io',
+    'lists.ceph.io',
+    'pad.ceph.com',
+    'pulpito.ceph.com',
+    'quay.ceph.io',
+    'shaman.ceph.com',
+    'status.sepia.ceph.com',
+    'telemetry-public.ceph.com',
+    'tracker.ceph.com',
+    'wiki.sepia.ceph.com',
+    'www.ceph.io',
+    ]
+DEFAULT_EMAIL = [
+    'dmick@redhat.com',
+    'ceph-infra@redhat.com',
+    'akraitman@redhat.com',
+    'aschoen@redhat.com',
+    'zcerza@redhat.com',
+    ]
+
+
+def parse_args():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('-q', '--quiet', action='store_true')
+    ap.add_argument('-e', '--email', nargs='*')
+    ap.add_argument('-d', '--domains', nargs='*', default=DEFAULT_DOMAINS)
+    return ap.parse_args()
+
+def sendmail(emailto, subject, body):
+    FROM = 'gitbuilder@ceph.com'
+    TO = emailto # must be a list
+    SUBJECT = subject
+    TEXT = body
+
+    # Prepare actual message
+
+    message = """\
+From: %s
+To: %s
+Subject: %s
+
+%s
+""" % (FROM, ", ".join(TO), SUBJECT, TEXT)
+
+    # send it 
+    server = smtplib.SMTP('localhost')
+    server.sendmail(FROM, TO, message)
+    server.quit()
+
+def main():
+    context = ssl.create_default_context()
+
+    args = parse_args()
+    domains = args.domains
+
+    for domain in domains:
+        warn = datetime.timedelta(days=DAYS_BEFORE_WARN)
+        try:
+            with socket.create_connection((domain, 443)) as sock:
+                with context.wrap_socket(sock, server_hostname=domain) as ssock:
+                    cert = ssock.getpeercert()
+        except ssl.CertificateError as e:
+            print(f'{domain} cert error: {e}', file=sys.stderr)
+            continue
+        expire = datetime.datetime.strptime(cert['notAfter'], 
+            '%b %d %H:%M:%S %Y %Z')
+        now = datetime.datetime.utcnow()
+        left = expire - now
+
+        if not args.quiet:
+            print(f'{domain}\'s cert has {left} left', file=sys.stderr)
+        if left < warn and args.email:
+            subject = f'{domain}\'s SSL Cert is expiring soon.'
+            body = f'{domain}\'s SSL cert has {left} left until it expires'
+            email = args.email
+            if email == []:
+                email = DEFAULT_EMAIL
+            sendmail(email, subject, body)
+
+if __name__ == '__main__':
+    sys.exit(main())
+


### PR DESCRIPTION
This originally lived on gitbuilder-archive, and I've moved it, revamped it, added some args, added some hosts, modified some emails, ported to Py3, stopped using external programs.  It's quick to run in default mode where it just reports to the terminal; it'll also be quiet and only send email about old certs.

The timezone processing is nonexistent on the reported expiry date; Python timezone handling is a mess.  That could be improved but not without a deep dive.