### PR TITLE
paddles: Updates required for migration to new host

### DIFF
--- a/roles/paddles/tasks/setup_db.yml
+++ b/roles/paddles/tasks/setup_db.yml
@@ -1,4 +1,17 @@
 ---
+- name: Listen on all interfaces
+  postgresql_set:
+    name: listen_addresses
+    value: "*"
+  become_user: postgres
+  register: pg_listen
+
+- name: Restart postgres to listen on all interfaces
+  service:
+    name: postgresql
+    state: restarted
+  when: pg_listen is changed
+
 - name: Create the postgresql database
   postgresql_db:
     name: paddles

--- a/roles/paddles/tasks/setup_docker.yml
+++ b/roles/paddles/tasks/setup_docker.yml
@@ -32,6 +32,22 @@
     source: pull
   register: image_pull
 
+- name: Get postgres hba conf file location
+  postgresql_info:
+    db: paddles
+    filter: settings
+  become_user: postgres
+  register: pg_info
+
+- name: Tell postgres to trust the Docker network
+  postgresql_pg_hba:
+    dest: "{{ pg_info.settings.hba_file.setting }}"
+    contype: host
+    users: all
+    databases: all
+    method: md5
+    source: "{{ ansible_docker_gwbridge.ipv4.address }}/{{ ansible_docker_gwbridge.ipv4.prefix }}"
+
 - name: Create docker swarm service
   become_user: "{{ paddles_user }}"
   docker_swarm_service:

--- a/roles/paddles/vars/apt_systems.yml
+++ b/roles/paddles/vars/apt_systems.yml
@@ -18,9 +18,7 @@ paddles_extra_packages:
 
 paddles_docker_packages:
   - docker.io
-  # docker swarm needs the requests module
-  - python-requests
-  - python-docker
+  - python3-docker
 
 # We need this so we can disable apache2 to get out of the way of nginx
 apache_service: 'apache2'


### PR DESCRIPTION
python-docker doesn't exist on 20.04; python3-docker does, and also on 18.04, and requires python3-requests.