### PR TITLE
common: use EPEL metalink

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -17,13 +17,13 @@ epel_mirror_baseurl: "http://dl.fedoraproject.org/pub/epel"
 epel_repos:
   epel:
     name: "Extra Packages for Enterprise Linux"
-    mirrorlist: file:///etc/yum.repos.d/epel-mirrorlist
+    metalink: "https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever&arch=$basearch&infra=$infra&content=$contentdir"
     # ternary requires ansible >= 1.9
     enabled: "{{ enable_epel | ternary(1, 0) }}"
     gpgcheck: 0
   epel-testing:
     name: "Extra Packages for Enterprise Linux - Testing"
-    mirrorlist: file:///etc/yum.repos.d/epel-testing-mirrorlist
+    metalink: "https://mirrors.fedoraproject.org/metalink?repo=testing-epel$releasever&arch=$basearch&infra=$infra&content=$contentdir"
     enabled: 0
     gpgcheck: 0
 

--- a/roles/common/tasks/epel.yml
+++ b/roles/common/tasks/epel.yml
@@ -16,17 +16,6 @@
   register: epel_repo
   with_dict: "{{ epel_repos }}"
 
-- name: Configure local epel mirrorlists
-  template:
-    src: '{{ item }}'
-    dest: '/etc/yum.repos.d/{{ item }}'
-    owner: root
-    group: root
-    mode: 0644
-  with_items:
-    - epel-mirrorlist
-    - epel-testing-mirrorlist
-
 - name: Clean yum cache
   shell: yum clean all
   when: epel_repo is defined and epel_repo is changed

--- a/roles/common/templates/epel-mirrorlist
+++ b/roles/common/templates/epel-mirrorlist
@@ -1,9 +1,0 @@
-# {{ ansible_managed }}
-
-# local yum mirrorlist for epel-{{ ansible_distribution_major_version }}
-http://download-ib01.fedoraproject.org/pub/epel/{{ ansible_distribution_major_version }}/{% if ansible_distribution_major_version|int >= 8 %}Everything/{% endif %}$basearch
-http://download-cc-rdu01.fedoraproject.org/pub/epel/{{ ansible_distribution_major_version }}/{% if ansible_distribution_major_version|int >= 8 %}Everything/{% endif %}$basearch
-http://mirrors.cat.pdx.edu/epel/{{ ansible_distribution_major_version }}/{% if ansible_distribution_major_version|int >= 8 %}Everything/{% endif %}$basearch
-http://mirror.pnl.gov/epel/{{ ansible_distribution_major_version }}/{% if ansible_distribution_major_version|int >= 8 %}Everything/{% endif %}$basearch
-http://ftp.linux.ncsu.edu/pub/epel/{{ ansible_distribution_major_version }}/{% if ansible_distribution_major_version|int >= 8 %}Everything/{% endif %}$basearch
-http://mirror.oss.ou.edu/epel/{{ ansible_distribution_major_version }}/{% if ansible_distribution_major_version|int >= 8 %}Everything/{% endif %}$basearch

--- a/roles/common/templates/epel-testing-mirrorlist
+++ b/roles/common/templates/epel-testing-mirrorlist
@@ -1,9 +1,0 @@
-# {{ ansible_managed }}
-
-# local yum mirrorlist for epel-testing-{{ ansible_distribution_major_version }}
-http://download-ib01.fedoraproject.org/pub/epel/testing/{{ ansible_distribution_major_version }}/{% if ansible_distribution_major_version|int >= 8 %}Everything/{% endif %}$basearch
-http://download-cc-rdu01.fedoraproject.org/pub/epel/testing/{{ ansible_distribution_major_version }}/{% if ansible_distribution_major_version|int >= 8 %}Everything/{% endif %}$basearch
-http://mirrors.cat.pdx.edu/epel/testing/{{ ansible_distribution_major_version }}/{% if ansible_distribution_major_version|int >= 8 %}Everything/{% endif %}$basearch
-http://mirror.pnl.gov/epel/testing/{{ ansible_distribution_major_version }}/{% if ansible_distribution_major_version|int >= 8 %}Everything/{% endif %}$basearch
-http://fedora-epel.mirror.lstn.net/testing/{{ ansible_distribution_major_version }}/{% if ansible_distribution_major_version|int >= 8 %}Everything/{% endif %}$basearch
-http://mirror.oss.ou.edu/epel/testing/{{ ansible_distribution_major_version }}/{% if ansible_distribution_major_version|int >= 8 %}Everything/{% endif %}$basearch


### PR DESCRIPTION
Some mirrors are stale (https://pagure.io/fedora-infrastructure/issue/11233)

Use MirrorManager's metalink application so we always get up-to-date mirrors.

MirrorManager will also return the list of mirror that carry each architecture (x86_64, aarch64, etc) so we will not need to manage that information ourselves here.