### PR TITLE
common: use ansible_distribution_major_version in epel repos

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -17,13 +17,13 @@ epel_mirror_baseurl: "http://dl.fedoraproject.org/pub/epel"
 epel_repos:
   epel:
     name: "Extra Packages for Enterprise Linux"
-    metalink: "https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever&arch=$basearch&infra=$infra&content=$contentdir"
+    metalink: "https://mirrors.fedoraproject.org/metalink?repo=epel-{{ ansible_distribution_major_version }}&arch=$basearch&infra=$infra&content=$contentdir"
     # ternary requires ansible >= 1.9
     enabled: "{{ enable_epel | ternary(1, 0) }}"
     gpgcheck: 0
   epel-testing:
     name: "Extra Packages for Enterprise Linux - Testing"
-    metalink: "https://mirrors.fedoraproject.org/metalink?repo=testing-epel$releasever&arch=$basearch&infra=$infra&content=$contentdir"
+    metalink: "https://mirrors.fedoraproject.org/metalink?repo=testing-epel{{ ansible_distribution_major_version }}&arch=$basearch&infra=$infra&content=$contentdir"
     enabled: 0
     gpgcheck: 0
 


### PR DESCRIPTION
RHEL systems use `roles/common/tasks/rhel-entitlements.yml`, and this sets Yum's `$releasever` to a specific RHEL minor release (eg. `8.4` or `8.6`). As a result. Fedora's MirrorManager does not return any EPEL repositories for these minor RHEL versions.

We set a static `$releasever` in `rhel-entitlements.yml` so that we pin to old RHEL RPM content in our old RHEL nodes. We probably need to re-think this strategy since our CentOS Stream nodes do not (cannot) do this, and Red Hat does not really support pinning to old versions without an EUS subscription.

Rather than untangling all that and removing our `$releasever` manipulation altogether, this commit simply hard-codes `ansible_distribution_major_version` (`8`, `9`, etc) into the EPEL `.repo` files, ignoring `$releasever` for EPEL.

A longer-term fix would be to stop mangling `$releasever` on RHEL.