### PR TITLE
github: add syntax and lint checks

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,26 @@
+---
+skip_list:
+  - command-instead-of-module
+  - command-instead-of-shell
+  - deprecated-command-syntax
+  - deprecated-local-action
+  - empty-string-compare
+  - experimental
+  - fqcn[action-core]
+  - fqcn[action]
+  - git-latest
+  - jinja
+  - literal-compare
+  - load-failure
+  - meta-no-info
+  - name[casing]
+  - no-changed-when
+  - no-handler
+  - no-jinja-when
+  - no-relative-paths
+  - no-tabs
+  - package-latest
+  - risky-file-permissions
+  - risky-shell-pipe
+  - role-name
+  - unnamed-task

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -18,7 +18,6 @@ skip_list:
   - no-handler
   - no-jinja-when
   - no-relative-paths
-  - no-tabs
   - package-latest
   - risky-file-permissions
   - risky-shell-pipe

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,38 @@
+name: tests
+
+on: [push, pull_request]
+
+jobs:
+  syntax-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install ansible
+      run: |
+        sudo apt-get update
+        sudo apt-get purge ansible
+        sudo apt-get install python3-setuptools
+        pip3 install ansible --user
+    - name: ansible-playbook syntax check
+      run: |
+        export PATH=$PATH:$HOME/.local/bin
+        sed -i /^vault_password_file/d ansible.cfg
+        ansible-playbook -i localhost, cephlab.yml --syntax-check
+  ansible-lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install ansible-lint
+      run: |
+        sudo apt-get update
+        sudo apt-get purge ansible
+        sudo apt-get install python3-setuptools
+        # This pinned ansible version should match teuthology's
+        # requirements.txt.
+        # And we choose an ansible-lint version to be compatible with this
+        # Ansible version.
+        pip3 install ansible==2.10.7 ansible-lint[core]==5.4.0 --user
+    - name: Run ansible-lint
+      run: |
+        export PATH=$PATH:$HOME/.local/bin
+        ansible-lint -v roles/*

--- a/roles/cobbler/tasks/settings.yml
+++ b/roles/cobbler/tasks/settings.yml
@@ -28,5 +28,5 @@
   when: users_digest is changed or dynamic_settings is changed or server_value is changed
 
 - name: Update settings
-  command: cobbler setting edit --name={{ item.name }} --value={{ item.value}}
+  command: cobbler setting edit --name={{ item.name }} --value={{ item.value }}
   with_items: "{{ settings }}"

--- a/roles/firmware/tasks/areca/main.yml
+++ b/roles/firmware/tasks/areca/main.yml
@@ -30,5 +30,5 @@
         (current_areca_version.stdout != latest_{{ areca_model_pretty }}_version)
 
 - name: Run Areca firmware update playbook
-  import_tasks: roles/firmware/tasks/areca/areca-update.yml
+  import_tasks: areca/areca-update.yml
   when: need_areca_update is defined and need_areca_update == true

--- a/roles/firmware/tasks/mira/bios.yml
+++ b/roles/firmware/tasks/mira/bios.yml
@@ -10,5 +10,5 @@
   when: current_bios_version.stdout != latest_bios_version
 
 - name: Include BIOS update logic
-  import_tasks: roles/firmware/tasks/mira/bios-update.yml
+  import_tasks: mira/bios-update.yml
   when: need_bios_update is defined and need_bios_update == true

--- a/roles/firmware/tasks/mira/bmc.yml
+++ b/roles/firmware/tasks/mira/bmc.yml
@@ -23,5 +23,5 @@
   when: current_bmc_version.stdout != latest_bmc_version
 
 - name: Include BMC update logic
-  import_tasks: roles/firmware/tasks/mira/bmc-update.yml
+  import_tasks: mira/bmc-update.yml
   when: need_bmc_update is defined and need_bmc_update == true

--- a/roles/firmware/tasks/smithi/bmc.yml
+++ b/roles/firmware/tasks/smithi/bmc.yml
@@ -23,5 +23,5 @@
   when: current_bmc_version.stdout != latest_bmc_version
 
 - name: Include BMC update logic
-  import_tasks: roles/firmware/tasks/smithi/bmc-update.yml
+  import_tasks: smithi/bmc-update.yml
   when: need_bmc_update is defined and need_bmc_update == true

--- a/roles/fog-server/tasks/main.yml
+++ b/roles/fog-server/tasks/main.yml
@@ -9,7 +9,7 @@
 
 - name: Ensure a path for FOG
   file:
-    path: "/home/{{ fog_user}}/fog"
+    path: "/home/{{ fog_user }}/fog"
     owner: "{{ fog_user }}"
     state: directory
 

--- a/roles/public_facing/tasks/letsencrypt_nginx.yml
+++ b/roles/public_facing/tasks/letsencrypt_nginx.yml
@@ -16,7 +16,7 @@
     state: present
 
 # 'letsencrypt renew' fails because it can't reach the letsencrypt authority server using IPv6
-- name: Create cron entry to force IPv4 connectivity to letsencrypt authority server
+- name: Create cron entry to force IPv4 connectivity to letsencrypt authority server  # noqa no-tabs
   cron:
     name: "Forces letsencrypt to use IPv4 when accessing acme-v01.api.letsencrypt.org"
     hour: "0"

--- a/roles/rook/tasks/rook-recovery.yml
+++ b/roles/rook/tasks/rook-recovery.yml
@@ -7,7 +7,6 @@
     group: "{{ security_group }}"
     instance_type: "{{ controller_instance_type }}"
     image: "{{ image }}"
-    wait: true
     region: "{{ region }}"
     vpc_subnet_id: "{{ vpc_subnet_id }}"
     assign_public_ip: yes

--- a/roles/testnode/tasks/cpan.yml
+++ b/roles/testnode/tasks/cpan.yml
@@ -34,7 +34,7 @@
     mode: 0755
 
 - name: Ensure perl-doc and cpanminus is installed on apt systems.
-  apt: name={{item}} state=present
+  apt: name={{ item }} state=present
   with_items:
     - cpanminus
     - perl-doc

--- a/roles/testnode/tasks/ntp.yml
+++ b/roles/testnode/tasks/ntp.yml
@@ -49,7 +49,7 @@
 
 - name: Make sure ntpd is running.
   service:
-    name: "{{ntp_service_name}}"
+    name: "{{ ntp_service_name }}"
     enabled: yes
     state: started
   # There's an issue with ansible<=2.9 and our custom built kernels (5.8 as of this commit) where the service and systemd modules don't have backwards compatibility with init scripts

--- a/roles/users/tasks/filter_users.yml
+++ b/roles/users/tasks/filter_users.yml
@@ -18,7 +18,7 @@
     # in managed_admin_users
     managed_users:
       "[{% for lab_user in managed_users -%}
-      {% if not managed_admin_users|selectattr('name', 'equalto', lab_user.name)|list|length %}{{ lab_user}},{% endif %}
+      {% if not managed_admin_users|selectattr('name', 'equalto', lab_user.name)|list|length %}{{ lab_user }},{% endif %}
       {%- endfor %}]"
   when: extra_admin_users is defined and extra_admin_users|length > 0
 


### PR DESCRIPTION
Run Ansible's `--syntax-check` and `ansible-lint` on every PR and Git push.
    
Ignore some common `ansible-lint` errors so we can get to green quickly. We can re-evaluate this list later and perhaps fix some of them down the road.
