### PR TITLE
cobbler: Add CentOS 8.5, fix up obsolete get_url parameter

### DIFF
--- a/cobbler.yml
+++ b/cobbler.yml
@@ -45,6 +45,7 @@
     - { role: cobbler_profile, distro_name: CentOS-8.2-x86_64, tags: ['centos8.2'] }
     - { role: cobbler_profile, distro_name: CentOS-8.3-x86_64, tags: ['centos8.3'] }
     - { role: cobbler_profile, distro_name: CentOS-8.4-x86_64, tags: ['centos8.4'] }
+    - { role: cobbler_profile, distro_name: CentOS-8.5-x86_64, tags: ['centos8.5'] }
     - { role: cobbler_profile, distro_name: CentOS-8.stream-x86_64, tags: ['centos8.stream'] }
     - { role: cobbler_profile, distro_name: CentOS-9.stream-x86_64, tags: ['centos9.stream'] }
     - { role: cobbler_profile, distro_name: Ubuntu-12.04-server-x86_64, tags: ['ubuntu-precise'] }

--- a/roles/cobbler_profile/defaults/main.yml
+++ b/roles/cobbler_profile/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 distros:
-  # Distros with empty iso values will be skipped. These dicts will be 
-  # updated with same-named items in an 'extra_distros' var, which can be 
+  # Distros with empty iso values will be skipped. These dicts will be
+  # updated with same-named items in an 'extra_distros' var, which can be
   # set in the secrets repo.
   "inktank-rescue":
       iso: ""
@@ -134,6 +134,10 @@ distros:
   "CentOS-8.4-x86_64":
       iso: http://packages.oit.ncsu.edu/centos/8.4.2105/isos/x86_64/CentOS-8.4.2105-x86_64-dvd1.iso
       sha256: 0394ecfa994db75efc1413207d2e5ac67af4f6685b3b896e2837c682221fd6b2
+      kickstart: cephlab_rhel.ks
+  "CentOS-8.5-x86_64":
+      iso: https://mirror.cs.pitt.edu/centos-vault/8.5.2111/isos/x86_64/CentOS-8.5.2111-x86_64-dvd1.iso
+      sha256: 3b795863001461d4f670b0dedd02d25296b6d64683faceb8f2b60c53ac5ebb3e
       kickstart: cephlab_rhel.ks
   "Ubuntu-12.04-server-x86_64":
       iso: "http://releases.ubuntu.com/12.04/ubuntu-12.04.5-server-amd64.iso"

--- a/roles/cobbler_profile/tasks/download_iso.yml
+++ b/roles/cobbler_profile/tasks/download_iso.yml
@@ -7,6 +7,6 @@
   get_url:
       url={{ distro.iso }}
       dest={{ iso_path }}
-      sha256sum={{ distro.sha256 }}
+      checksum=sha256:{{ distro.sha256 }}
   when: profile is defined and profile.stdout == ''
   register: download


### PR DESCRIPTION
Discovered while trying to recapture a centos8.stream image