### PR TITLE
cephlab_ansible.sh: use scl rh-python38 on CentOS 7

### DIFF
--- a/roles/cobbler/templates/triggers/install/post/cephlab_ansible.sh
+++ b/roles/cobbler/templates/triggers/install/post/cephlab_ansible.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 ## {{ ansible_managed }}
 set -ex
+
+# Cobbler on CentOS 7 in May 2023 needed a later python than the default 3.6
+# check for SCL 3.8 and enable if so.  scl enable starts a child shell; the undocumented
+# scl_source sets the environment variables (PATH, LD_LIBRARY_PATH, MANPATH, PKG_CONFIG_PATH,
+# and XDG_DATA_DIRS) in the current shell.
+
+if scl -l | grep -s rh-python38 >/dev/null 2>&1 ; then source scl_source enable rh-python38; fi
+
 name=$2
 profile=$(cobbler system dumpvars --name $2 | grep profile_name | cut -d ':' -f2)
 export USER=root


### PR DESCRIPTION
cephlab_ansible.sh runs at the very end of the installation process during a cobbler install for fog image capture, on first reboot of the freshly-cobblered system.

Cobbler runs on a CentOS 7 installation today, but its python is too old to support modern ansible.  The SCL for python 3.8 is installed on cobbler.  Add code here to, if installed, enable the SCL (by setting some paths in the trigger script that is executed on the cobbler server after the installed host reboots; a curl fetch is placed at the end of /etc/rc.local, and this script runs to finish up all the configuration of the host for teuthology use.