### PR TITLE
tools/checkcerts.py: add paddles.front to list of checked hosts

### DIFF
--- a/tools/checkcerts.py
+++ b/tools/checkcerts.py
@@ -29,6 +29,7 @@ DEFAULT_DOMAINS = [
     'jenkins.rook.io',
     'lists.ceph.io',
     'pad.ceph.com',
+    'paddles.front.sepia.ceph.com',
     'pulpito.ceph.com',
     'quay.ceph.io',
     'sentry.ceph.com',


### PR DESCRIPTION
As it says on the tin.  paddles.front now support https.  Add it to the list of checked hosts.