### PR TITLE
common/tasks/rhel-entitlements.yml: regenerate machine-id

### DIFF
--- a/roles/common/tasks/rhel-entitlements.yml
+++ b/roles/common/tasks/rhel-entitlements.yml
@@ -50,6 +50,12 @@
   register: new_uuid
   when: use_satellite == true
 
+- name: Run dbus-uuidgen to create /var/lib/dbus/machine-id
+  shell: dbus-uuidgen --ensure
+
+- name: Run systemd-machine-id-setup to set /etc/machine-id
+  shell: systemd-machine-id-setup
+
 - name: Add new UUID to dmi_system_uuid.facts
   ansible.builtin.lineinfile:
     path: /etc/rhsm/facts/dmi_system_uuid.facts
@@ -177,6 +183,15 @@
         replace_repos|bool == true
   retries: 5
   delay: 10
+
+# recreate the removed machine-id files to avoid breaking
+# other parts of the system, /bin/install-kernel for instance
+
+- name: Run dbus-uuidgen to create /var/lib/dbus/machine-id
+  shell: dbus-uuidgen --ensure
+
+- name: Run systemd-machine-id-setup to set /etc/machine-id
+  shell: systemd-machine-id-setup
 
 - name: Remove old apt-mirror repository definition.
   file:


### PR DESCRIPTION
We can't leave /etc/machine-id blank; it breaks things, one of which is the kernel install, which runs a postinstall script to update /boot/loader/entries, which does nothing (silently) if there's nothing in /etc/machine-id.  Since it can come from the dbus id, and does by default, and there's a command to generate the dbus id, generate both, dbus first.  This fixes the kernel postinstall. I don't know if there should be any correlation between machine-id and the subscription-manager/katello IDs.