### PR TITLE
testnode: Make sure PowerTools repo is enabled on CentOS

### DIFF
--- a/roles/testnode/tasks/yum/repos.yml
+++ b/roles/testnode/tasks/yum/repos.yml
@@ -38,6 +38,11 @@
     - (ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 8)
     - copr_repos|length > 0
 
+- name: Enable PowerTools on CentOS
+  command: "dnf -y config-manager --set-enabled powertools"
+  when:
+    - ansible_distribution == 'CentOS'
+
 - import_tasks: gpg_keys.yml
   when: ansible_distribution == "Fedora"
   tags:


### PR DESCRIPTION
https://github.com/ceph/ceph-cm-ansible/pull/731 removed the custom-made repo files that added mirrorlists; however, it also removed the side-effect of enabling the Power Tools repo (which is not enabled by default).  This adds a call to dnf config-manager to enable the repo, whatever its repo file name, on CentOS testnodes.

Fixes: https://tracker.ceph.com/issues/59678