### PR TITLE
testnode: replace 'powertools' with 'crb' for centos 9+

### DIFF
--- a/roles/testnode/tasks/yum/repos.yml
+++ b/roles/testnode/tasks/yum/repos.yml
@@ -42,6 +42,13 @@
   command: "dnf -y config-manager --set-enabled powertools"
   when:
     - ansible_distribution == 'CentOS'
+    - ansible_distribution_major_version | int < 9
+
+- name: Enable CodeReady Linux Builder on CentOS 9
+  command: "dnf -y config-manager --set-enabled crb"
+  when:
+    - ansible_distribution == 'CentOS'
+    - ansible_distribution_major_version | int >= 9
 
 - import_tasks: gpg_keys.yml
   when: ansible_distribution == "Fedora"


### PR DESCRIPTION
a candidate fix for https://tracker.ceph.com/issues/61648

i verified that the `dnf -y config-manager --set-enabled crb` command works against a fresh centos stream 9 install, but haven't tested the ansible changes themselves