### PR TITLE
centos8, centos9: install dbench package from epel instead of lab-extras

### DIFF
--- a/roles/testnode/vars/centos_8.yml
+++ b/roles/testnode/vars/centos_8.yml
@@ -61,13 +61,13 @@ packages:
   # for pjd tests
   - libacl-devel
   # for fs tests,
-  - dbench
   - autoconf
   # for test-crash.sh
   - gdb
   - iozone
 
-epel_packages: []
+epel_packages:
+  - dbench
 
 nfs_service: nfs-server
 

--- a/roles/testnode/vars/centos_9.yml
+++ b/roles/testnode/vars/centos_9.yml
@@ -69,13 +69,13 @@ packages:
   # for pjd tests
   - libacl-devel
   # for fs tests,
-#  - dbench
   - autoconf
   # for test-crash.sh
   - gdb
 #  - iozone
 
-epel_packages: []
+epel_packages:
+  - dbench
 
 nfs_service: nfs-server
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/62227