### PR TITLE
roles/testnode/vars/centos_9.yml: add lab-extras and iozone

### DIFF
--- a/roles/testnode/vars/centos_9.yml
+++ b/roles/testnode/vars/centos_9.yml
@@ -1,7 +1,12 @@
 ---
 # vars specific to any centos 9.x version
 
-common_yum_repos: {}
+common_yum_repos:
+  lab-extras:
+    name: "lab-extras"
+    baseurl: "http://{{ mirror_host }}/lab-extras/9/"
+    enabled: 1
+    gpgcheck: 0
 
 yum_repos:
   CentOS-AppStream:
@@ -72,7 +77,7 @@ packages:
   - autoconf
   # for test-crash.sh
   - gdb
-#  - iozone
+  - iozone
 
 epel_packages:
   - dbench


### PR DESCRIPTION
iozone is present in the newly-created lab-extras repo, for the same reasons it's in other CentOS configs