### PR TITLE
cobbler_profile: fix two bugs discovered while importing inktank-rescue

### DIFF
--- a/roles/cobbler_profile/tasks/download_image.yml
+++ b/roles/cobbler_profile/tasks/download_image.yml
@@ -11,7 +11,7 @@
   get_url:
       url={{ distro.kernel }}
       dest={{ kernel_path }}
-      sha256sum={{ distro.kernel_sha256 }}
+      checksum=sha256:{{ distro.kernel_sha256 }}
   when: profile is defined and profile.stdout == ''
   register: download_kernel
 
@@ -19,7 +19,7 @@
   get_url:
       url={{ distro.initrd }}
       dest={{ initrd_path }}
-      sha256sum={{ distro.initrd_sha256 }}
+      checksum=sha256:{{ distro.initrd_sha256 }}
   when: profile is defined and profile.stdout == ''
   register: download_initrd
 

--- a/roles/cobbler_profile/tasks/import_distro_image.yml
+++ b/roles/cobbler_profile/tasks/import_distro_image.yml
@@ -35,5 +35,5 @@
 
 - name: Add the profile to cobbler
   command: cobbler profile add --name {{ distro_name }} --distro {{ distro_name }}
-  when: import is defined and import.stdout == ''
+  when: imported is defined and imported.stdout == ''
   register: imported


### PR DESCRIPTION
1) ansible's get_url moves from sha256 to checksum 2) fix 'registered' name (import -> imported) in import_distro_image