### PR TITLE
Remove unnecessary duplicate repo definitions for centos9

### DIFF
--- a/roles/testnode/vars/centos_9.yml
+++ b/roles/testnode/vars/centos_9.yml
@@ -8,19 +8,6 @@ common_yum_repos:
     enabled: 1
     gpgcheck: 0
 
-yum_repos:
-  CentOS-AppStream:
-    name: "CentOS-$releasever - AppStream"
-    baseurl: https://composes.stream.centos.org/test/latest-CentOS-Stream/compose/AppStream/x86_64/os/
-    gpgcheck: 0
-    enabled: 1
-    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
-  CentOS-BaseOS:
-    name: "CentOS-$releasever - BaseOS"
-    baseurl: https://composes.stream.centos.org/test/latest-CentOS-Stream/compose/BaseOS/x86_64/os/
-    gpgcheck: 0
-    enabled: 1
-    gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 
 # When mirrors become available, these will be filenames in roles/testnodes/templates/mirrorlists/9/
 yum_mirrorlists: []


### PR DESCRIPTION
CentOS 8 had different .repo files for each major section (BaseOS, AppStream, etc.).  CentOS 9 has apparently moved to a single file, centos.repo.  This change 1) removes the management of separate repo files for BaseOS and AppStream, since those repos are included in centos.repo, and 2) stops using the perhaps-questionable single baseurl in favor of the default metalink/mirrors setup

There are errors occurring for teuthology tests on centos9 that may be related to this, with the errors of the form "<pkg> from <repo> does not belong to a distupgrade repository".  As near as I can tell, a "distupgrade repository" is one used only for upgrade, and I can't find information on how exactly it's indicated, so I don't know if this change will resolve the error or not.