### PR TITLE
Fix "Unsupported parameters for (stat) module: get_md5" 

### DIFF
--- a/roles/cobbler_profile/tasks/download_image.yml
+++ b/roles/cobbler_profile/tasks/download_image.yml
@@ -1,10 +1,10 @@
 ---
 - name: Check to see if the kernel exists
-  stat: path={{ kernel_path }} get_checksum=no get_md5=no
+  stat: path={{ kernel_path }} get_checksum=no
   register: kernel_stat
 
 - name: Check to see if the initrd exists
-  stat: path={{ initrd_path }} get_checksum=no get_md5=no
+  stat: path={{ initrd_path }} get_checksum=no
   register: initrd_stat
 
 - name: Download kernel

--- a/roles/cobbler_profile/tasks/download_iso.yml
+++ b/roles/cobbler_profile/tasks/download_iso.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check to see if the ISO exists
-  stat: path={{ iso_path }} get_checksum=no get_md5=no
+  stat: path={{ iso_path }} get_checksum=no
   register: iso_stat
 
 - name: Download ISO

--- a/roles/pulpito/tasks/main.yml
+++ b/roles/pulpito/tasks/main.yml
@@ -43,7 +43,6 @@
   stat:
     path: "{{ supervisor_conf_path }}"
     get_checksum: no
-    get_md5: no
   register: supervisor_conf
 
 - name: Copy supervisord config

--- a/roles/pulpito/tasks/setup_pulpito.yml
+++ b/roles/pulpito/tasks/setup_pulpito.yml
@@ -28,7 +28,6 @@
   stat: 
     path: "{{ pulpito_repo_path }}/virtualenv"
     get_checksum: no
-    get_md5: no
   register: virtualenv
 
 - name: Create the virtualenv
@@ -56,7 +55,6 @@
   stat:
     path: "{{ pulpito_repo_path }}/prod.py"
     get_checksum: no
-    get_md5: no
   register: pulpito_config
 
 - name: Copy pulpito config

--- a/roles/testnode/tasks/resolvconf.yml
+++ b/roles/testnode/tasks/resolvconf.yml
@@ -14,7 +14,6 @@
   stat:
     path: /etc/network/interfaces
     get_checksum: no
-    get_md5: no
   register: etc_network_interfaces
 
 - name: Rewrite /etc/network/interfaces to use dhcp


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/66106

get_md5 was removed in ansible 2.9: https://docs.ansible.com/ansible/2.8/modules/stat_module.html
Release notes for ansible 9 (or ansible-core 2.16): https://github.com/ansible-community/ansible-build-data/blob/0dee49ac8a7674153606ddc6432d4029eb20172d/9/CHANGELOG-v9.rst#L5195

Result: https://pulpito.ceph.com/vallariag-2024-05-20_05:57:34-rbd:nvmeof-main-distro-default-smithi/


