### PR TITLE
prep-fog-capture.yml: mount -> ansible.posix.mount

### DIFF
--- a/tools/prep-fog-capture.yml
+++ b/tools/prep-fog-capture.yml
@@ -57,7 +57,7 @@
     shell: sed -i '/\/var\/lib\/ceph/d' /etc/fstab
 
   - name: Unmount /var/lib/ceph
-    mount:
+    ansible.posix.mount:
       path: /var/lib/ceph
       state: unmounted
 


### PR DESCRIPTION
The mount module has moved; give it a full path.  Requires https://github.com/ceph/ceph-build/pull/2275 to allow the module to be found.  Tested manually.