### PR TITLE
roles/cobbler/templates/snippets/cephlab_packages_rhel: add dbus pkgs

### DIFF
--- a/roles/cobbler/templates/snippets/cephlab_packages_rhel
+++ b/roles/cobbler/templates/snippets/cephlab_packages_rhel
@@ -19,6 +19,8 @@ perl
 #if $distro == 'RHEL'
 # Needed in RHEL9 but not CentOS9
 NetworkManager-initscripts-updown
+dbus-tools
+dbus-daemon
 #end if
 #if $distro == 'CentOS'
 # CentOS 9 Stream only packages


### PR DESCRIPTION
FOG capture requires dbus-uuidgen (in dbus-tools) and the presence of /var/lib/dbus (from dbus-daemon) to do the bug-avoidance dance for Satellite.  It's not clear that bug-avoidance dance is still necessary, but this is the minimal-investigation minimal-touch change to make the capture process work.