### PR TITLE
testnode: don't install tgt

### DIFF
--- a/roles/testnode/vars/debian_7.yml
+++ b/roles/testnode/vars/debian_7.yml
@@ -89,10 +89,6 @@ packages:
   ###
   # DistCC for arm
   - distcc
-  ###
-  # tgt
-  - tgt
-  - open-iscsi
   
 packages_to_upgrade:
   - apt

--- a/roles/testnode/vars/debian_8.yml
+++ b/roles/testnode/vars/debian_8.yml
@@ -83,10 +83,6 @@ packages:
   ###
   # DistCC for arm
   - distcc
-  ###
-  # tgt
-  - tgt
-  - open-iscsi
 
 #NOTE: these packages were not found for debian 8, but are present for debian 7
 #- mencoder

--- a/roles/testnode/vars/ubuntu.yml
+++ b/roles/testnode/vars/ubuntu.yml
@@ -66,10 +66,6 @@ common_packages:
   - default-jdk
   - junit4
   ###
-  # tgt
-  - tgt
-  - open-iscsi
-  ###
   # for samba testing
   - cifs-utils
   # for Static IP


### PR DESCRIPTION
We haven't done anything with tgt for over 10 years and tgt can interfere with setting up ceph-iscsi targets, resulting in "Could not create NetworkPortal in configFS" errors.