### PR TITLE
testnode: remove tgt

### DIFF
--- a/roles/testnode/vars/apt_systems.yml
+++ b/roles/testnode/vars/apt_systems.yml
@@ -6,6 +6,8 @@ nfs_service: nfs-kernel-server
 packages_to_remove:
   # multipath interferes with krbd tests
   - multipath-tools
+  # tgt interferes with ceph-iscsi tests
+  - tgt
 
 ceph_packages_to_remove:
   - ceph

--- a/roles/testnode/vars/yum_systems.yml
+++ b/roles/testnode/vars/yum_systems.yml
@@ -5,6 +5,8 @@ ssh_service_name: sshd
 packages_to_remove:
   # multipath interferes with krbd tests
   - device-mapper-multipath
+  # tgt interferes with ceph-iscsi tests
+  - scsi-target-utils
 
 # ceph packages that we ensure do not exist
 ceph_packages_to_remove:

--- a/roles/testnode/vars/zypper_systems.yml
+++ b/roles/testnode/vars/zypper_systems.yml
@@ -9,6 +9,8 @@ nagios_plugins_directory: /usr/lib64/nagios/plugins
 packages_to_remove:
   # multipath interferes with krbd tests
   - multipath-tools
+  # tgt interferes with ceph-iscsi tests
+  - tgt
 
 # ceph packages that we ensure do not exist
 ceph_packages_to_remove:


### PR DESCRIPTION
As a follow up for commit 67a92953a5a2 ("testnode: don't install tgt"), explicitly remove tgt to cover the case of it already being there.  This also documents that we actively don't want tgt to be there.