### PR TITLE
testnode: move removing openmpi-common to apt_systems.yml

### DIFF
--- a/roles/testnode/vars/apt_systems.yml
+++ b/roles/testnode/vars/apt_systems.yml
@@ -6,6 +6,8 @@ nfs_service: nfs-kernel-server
 packages_to_remove:
   # multipath interferes with krbd tests
   - multipath-tools
+  # openmpi-common conflicts with mpich stuff
+  - openmpi-common
   # tgt interferes with ceph-iscsi tests
   - tgt
 

--- a/roles/testnode/vars/ubuntu.yml
+++ b/roles/testnode/vars/ubuntu.yml
@@ -92,7 +92,3 @@ non_aarch64_packages_to_upgrade:
 
 no_recommended_packages:
   - collectl
-
-packages_to_remove:
-   # openmpi-common conflicts with mpitch stuff
-  - openmpi-common


### PR DESCRIPTION
Otherwise, because it's placed in ubuntu.yml, it resets packages_to_remove list defined in apt_systems.yml to just openmpi-common and commit 701d3594d220 ("testnode: remove tgt") doesn't take effect.

While at it, fix a typo in the comment -- it's mpich.