### PR TITLE
Creating a selinux module to resolve selinux conflicts with grafana agent

### DIFF
--- a/roles/grafana_agent/defaults/main.yml
+++ b/roles/grafana_agent/defaults/main.yml
@@ -9,3 +9,8 @@ grafana_rpm_repo_key_url: "https://rpm.grafana.com/gpg.key"
 
 scrape_interval_global: "60s"
 scrape_interval_node: "30s"
+
+# Selinux packages
+useradd_selinux_packages:
+  - policycoreutils
+  - checkpolicy

--- a/roles/grafana_agent/files/grafana/customuseradd.te
+++ b/roles/grafana_agent/files/grafana/customuseradd.te
@@ -1,0 +1,12 @@
+module customuseradd 1.0;
+
+require {
+	type useradd_t;
+  type var_lib_t;
+	class file { execute read create write getattr setattr
+open };
+}
+
+#============= useradd_t ==============
+
+allow useradd_t var_lib_t:file { write create open setattr getattr };

--- a/roles/grafana_agent/tasks/main.yml
+++ b/roles/grafana_agent/tasks/main.yml
@@ -8,6 +8,10 @@
 - name: Gather facts on listening ports
   community.general.listen_ports_facts:
 
+# Resolving selinux conflicts
+- import_tasks: useradd-selinux.yml
+  when: ansible_os_family == "RedHat"
+
 - name: Check if prometheus is listening on port 9090
   ansible.builtin.debug:
     msg: The {{ item.name }} service - pid {{ item.pid }} is running on same port as grafana-agent please set {{ item.name }} to listen on a diffrent port than {{ item.port }}

--- a/roles/grafana_agent/tasks/useradd-selinux.yml
+++ b/roles/grafana_agent/tasks/useradd-selinux.yml
@@ -1,0 +1,38 @@
+---
+- name: useradd - Install SELinux dependencies
+  package:
+    name: "{{ useradd_selinux_packages|list }}"
+    state: present
+
+# ignore_errors in case we don't have any repos
+- name: useradd - Ensure SELinux policy is up to date
+  package:
+    name: selinux-policy-targeted
+    state: latest
+  ignore_errors: true
+
+- name: useradd - Copy SELinux type enforcement file
+  copy:
+    src: grafana/customuseradd.te
+    dest: /tmp/customuseradd.te
+
+- name: useradd - Compile SELinux module file
+  command: checkmodule -M -m -o /tmp/customuseradd.mod /tmp/customuseradd.te
+
+- name: useradd - Build SELinux policy package
+  command: semodule_package -o /tmp/customuseradd.pp -m /tmp/customuseradd.mod
+
+- name: useradd - Load SELinux policy package
+  command: semodule -i /tmp/customuseradd.pp
+
+- name: useradd - Remove temporary files
+  file:
+    path: /tmp/customuseradd.*
+    state: absent
+
+- name: Verify SELinux module is installed
+  command: semodule -l
+  register: semodule_list
+  changed_when: false
+  failed_when: "'customuseradd' not in semodule_list.stdout"
+

--- a/testnodes.yml
+++ b/testnodes.yml
@@ -4,4 +4,5 @@
   roles:
     - common
     - testnode
+    - grafana_agent
   become: true


### PR DESCRIPTION
This code creates a new ansible task in the grafana_agent role that configures a SELinux module on CentOS and RedHat systems which allows useradd command to access var_lib_t context files, that way we can avoid SELinux denials after the grafana installation on the teuthology-suite's executions.

Fixes: https://ibm.monday.com/boards/5591222586/pulses/8269716052

I have run a test with teuthology-suite command like this in order to verify if the module was working or not.
teuthology-suite -s smoke --ceph-repo ceph -c squid --suite-repo ceph -m smithi --subset 1/5 -p 50 -l 8 --force-priority --newest 10 --sha1 a8eeed19eb9ce9bdce3a02ea18f12005000c9146 /home/falcocer/ansible-branch.yml

Result before the module:
https://pulpito.ceph.com/falcocer-2025-02-17_21:50:23-smoke-squid-distro-default-smithi/

Result after the module:
https://pulpito.ceph.com/falcocer-2025-02-24_18:34:53-smoke-squid-distro-default-smithi/