### PR TITLE
ansible-lint: Fixing broken tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,11 +24,13 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get purge -y ansible
-        sudo apt-get install -y python3-setuptools python3-pip
+        sudo apt-get install -y python3-setuptools python3-pip python3-venv
+        sudo python3 -m venv lintenv
+        source lintenv/bin/activate && echo "Virtual environment activated"
         # This pinned ansible version should match teuthology's
         # requirements.txt.
         # And we choose an ansible-lint version to be compatible with this
         # Ansible version.
-        sudo pip3 install --break-system-packages ansible==2.10.7 ansible-lint[core]==5.4.0
+        sudo pip3 install --break-system-packages ansible-core==2.18.2 ansible-lint[core]==6.19.0
     - name: Run ansible-lint
       run: ansible-lint -v roles/*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,14 +10,12 @@ jobs:
     - name: Install ansible
       run: |
         sudo apt-get update
-        sudo apt-get purge ansible
-        sudo apt-get install python3-setuptools
-        pip3 install ansible --user
+        sudo apt-get purge -y ansible
+        sudo apt-get install -y python3-setuptools python3-pip
+        sudo pip3 install --break-system-packages ansible==2.10.7
     - name: ansible-playbook syntax check
-      run: |
-        export PATH=$PATH:$HOME/.local/bin
-        sed -i /^vault_password_file/d ansible.cfg
-        ansible-playbook -i localhost, cephlab.yml --syntax-check
+      run: ANSIBLE_VAULT_PASSWORD_FILE=/dev/null ansible-playbook -i localhost, cephlab.yml --syntax-check
+
   ansible-lint:
     runs-on: ubuntu-latest
     steps:
@@ -25,14 +23,12 @@ jobs:
     - name: Install ansible-lint
       run: |
         sudo apt-get update
-        sudo apt-get purge ansible
-        sudo apt-get install python3-setuptools
+        sudo apt-get purge -y ansible
+        sudo apt-get install -y python3-setuptools python3-pip
         # This pinned ansible version should match teuthology's
         # requirements.txt.
         # And we choose an ansible-lint version to be compatible with this
         # Ansible version.
-        pip3 install ansible==2.10.7 ansible-lint[core]==5.4.0 --user
+        sudo pip3 install --break-system-packages ansible==2.10.7 ansible-lint[core]==5.4.0
     - name: Run ansible-lint
-      run: |
-        export PATH=$PATH:$HOME/.local/bin
-        ansible-lint -v roles/*
+      run: ansible-lint -v roles/*


### PR DESCRIPTION
Before:
```
2025-02-24T20:32:22.8480111Z WARNING: PATH altered to include /usr/bin
2025-02-24T20:32:22.9998767Z Unable to find a working copy of ansible executable. CompletedProcess(args=['ansible', '--version'], returncode=1, stdout='', stderr='Traceback (most recent call last):\n  File "/home/runner/.local/bin/ansible", line 62, in <module>\n    import ansible.constants as C\n  File "/home/runner/.local/lib/python3.12/site-packages/ansible/constants.py", line 15, in <module>\n    from ansible.config.manager import ConfigManager, ensure_type, get_ini_config_value\n  File "/home/runner/.local/lib/python3.12/site-packages/ansible/config/manager.py", line 29, in <module>\n    from ansible.module_utils.six.moves import configparser\nModuleNotFoundError: No module named \'ansible.module_utils.six.moves\'\n')
2025-02-24T20:32:23.0288372Z ##[error]Process completed with exit code 4.
```

Fixes:
  - Specify vault password file as /dev/null. Avoids modifying ansible.cfg
  - --break-system-packages because these are ephemeral containers we don't care about
  - Remove PATH since we're installing ansible globally via pip