### PR TITLE
tools/checkcerts.py: fix deprecated datetime.datetime.utcnow()

### DIFF
--- a/tools/checkcerts.py
+++ b/tools/checkcerts.py
@@ -9,6 +9,7 @@ import os
 import tempfile
 import datetime
 import smtplib
+import zoneinfo
 
 DAYS_BEFORE_WARN=7
 
@@ -100,9 +101,15 @@ def main():
             errstr = f'{domain} cert error: {e}'
 
         if not certerr:
-            expire = datetime.datetime.strptime(cert['notAfter'],
-                '%b %d %H:%M:%S %Y %Z')
-            now = datetime.datetime.utcnow()
+            exp=cert['notAfter'].split()
+            tzname=exp[-1]
+            exp = ' '.join(exp[:-1])
+
+            expire = datetime.datetime.strptime(exp,
+                '%b %d %H:%M:%S %Y')
+            tzinfo=zoneinfo.ZoneInfo(tzname)
+            expire = expire.replace(tzinfo=tzinfo)
+            now = datetime.datetime.now(datetime.UTC)
             left = expire - now
 
             errstr = f'{domain:30s} cert: {str(left).rsplit(".",1)[0]} left until it expires'


### PR DESCRIPTION
    The replacement, datetime.datetime.now(datetime.UTC), returns a
    tz-aware item, so the expiry time must also be timezone-aware.
    datetime.strptime() does not handle that time format sanely.
    I don't know why.

    Luckily zoneinfo exists and can parse likely timezones into valid
    datetime.tzinfo instances, as far as I can tell.  Why isn't this part
    of datetime?  I don't know.  But this code seems be somewhat reliable
    (assuming the timezone name is the last item in the date string,
    delimited by spaces).
