### PR TITLE
testnode: Run grafana_agent role optionally

### DIFF
--- a/roles/testnode/README.rst
+++ b/roles/testnode/README.rst
@@ -303,6 +303,11 @@ Configure ``cachefilesd``.  See https://tracker.ceph.com/issues/6373.  Defaults 
     cachefilesd_fstop
     cachefilesd_secctx
 
+Include the grafana_agent role to report testnode resource statistics to Grafana.  Defaults to ``false``::
+
+    run_grafana_agent_role: true
+
+
 Tags
 ++++
 

--- a/roles/testnode/meta/main.yml
+++ b/roles/testnode/meta/main.yml
@@ -1,3 +1,5 @@
 ---
 dependencies:
   - role: secrets
+  - role: grafana_agent
+    when: run_grafana_agent_role is defined and run_grafana_agent_role

--- a/testnodes.yml
+++ b/testnodes.yml
@@ -4,5 +4,4 @@
   roles:
     - common
     - testnode
-    - grafana_agent
   become: true


### PR DESCRIPTION
Snippet from ansible.log
```
TASK [grafana_agent : Gather facts on listening ports] *************************
skipping: [smithi116.front.sepia.ceph.com] => {"changed": false, "false_condition": "run_grafana_agent_role is defined and run_grafana_agent_role", "skip_reason": "Conditional result was False"}
```

https://pulpito.ceph.com/dgalloway-2025-03-03_22:29:15-smoke-squid-distro-default-smithi/

We'll define this at the machine type level in the secrets repos.