### PR TITLE
OpenVPN logrotate configuration to keep the logs for a year.

### DIFF
--- a/roles/gateway/files/openvpn.logrotate
+++ b/roles/gateway/files/openvpn.logrotate
@@ -1,9 +1,11 @@
 /var/log/openvpn/*.log {
 	daily
-	rotate 90
+	rotate 7
 	compress
 	missingok
 	copytruncate
 	notifempty
-	create 644 nobody nobody
+	dateext
+	dateformat -%Y-%m-%d-daily
 }
+

--- a/roles/gateway/files/openvpn_weekly_rotation
+++ b/roles/gateway/files/openvpn_weekly_rotation
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+LOG_DIR="/var/log/openvpn"
+LOG_FILE="openvpn.log"
+ARCHIVE_DIR="/var/log/openvpn/weekly-logs"
+WEEKLY_ARCHIVE_NAME="openvpn-$(date +\%Y-\%m-\%d)_weekly_logs.tar.gz"
+RETENTION_DAYS=365  # Keep weekly archives for a year
+
+# Create archive directory if it doesn't exist
+mkdir -p "$ARCHIVE_DIR"
+
+# Temporary folder for decompressed logs
+TEMP_DIR=$(mktemp -d)
+
+# Decompress all rotated daily logs (mylogfile.log.1.gz, mylogfile.log.2.gz, etc.)
+for file in $(find "$LOG_DIR" -name "$LOG_FILE-*");
+	do gzip -d -c $file > "$TEMP_DIR/$(basename $file .gz)";
+done
+
+# Create a compressed archive with all daily logs from the past week
+tar -czf "$ARCHIVE_DIR/$WEEKLY_ARCHIVE_NAME" -C "$TEMP_DIR" .
+
+# Cleanup temporary files
+rm -rf "$TEMP_DIR"
+
+# Delete archives older than a year
+find "$ARCHIVE_DIR" -name "*.tar.gz" -mtime +$RETENTION_DAYS -delete

--- a/roles/gateway/files/openvpn_weekly_rotation
+++ b/roles/gateway/files/openvpn_weekly_rotation
@@ -5,12 +5,13 @@ LOG_FILE="openvpn.log"
 ARCHIVE_DIR="/var/log/openvpn/weekly-logs"
 WEEKLY_ARCHIVE_NAME="openvpn-$(date +\%Y-\%m-\%d)_weekly_logs.tar.gz"
 RETENTION_DAYS=365  # Keep weekly archives for a year
+TEMP_DIR=$(mktemp -d)  # Temporary folder for decompressed logs
+
+# Clean the temporary folder in case of failure
+trap 'rm -rf "$TEMP_DIR"' ERR
 
 # Create archive directory if it doesn't exist
 mkdir -p "$ARCHIVE_DIR"
-
-# Temporary folder for decompressed logs
-TEMP_DIR=$(mktemp -d)
 
 # Decompress all rotated daily logs (mylogfile.log.1.gz, mylogfile.log.2.gz, etc.)
 for file in $(find "$LOG_DIR" -name "$LOG_FILE-*");

--- a/roles/gateway/tasks/logging.yml
+++ b/roles/gateway/tasks/logging.yml
@@ -13,7 +13,7 @@
     dest: /etc/logrotate.d/openvpn
   notify: restart rsyslog
 
-- name: Write weekly rotation script on anacron
+- name: Create weekly log rotation script
   copy:
     src: files/openvpn_weekly_rotation
     dest: /etc/cron.weekly/openvpn_weekly_rotation

--- a/roles/gateway/tasks/logging.yml
+++ b/roles/gateway/tasks/logging.yml
@@ -13,6 +13,14 @@
     dest: /etc/logrotate.d/openvpn
   notify: restart rsyslog
 
+- name: Write weekly rotation script on anacron
+  copy:
+    src: files/openvpn_weekly_rotation
+    dest: /etc/cron.weekly/openvpn_weekly_rotation
+    mode: '0755'
+    owner: root
+    group: root
+
 - name: Write rsyslog conf file
   copy:
     src: files/openvpn.rsyslog


### PR DESCRIPTION
The daily rotation was configured to keep daily logs for a week. A new script to manage weekly rotation and keep those logs for a year was generated to be put into /etc/cron.weekly

Fixes: https://ibm.monday.com/boards/5591222586/pulses/8354436354