### PR TITLE
testnode: Remove needless tasks

### DIFF
--- a/roles/testnode/tasks/apt/repos.yml
+++ b/roles/testnode/tasks/apt/repos.yml
@@ -1,17 +1,4 @@
 ---
-# Check for and remove custom repos.
-# http://tracker.ceph.com/issues/12794
-- name: Check for custom repos
-  shell: "ls -1 /etc/apt/sources.list.d/"
-  register: custom_repos
-  changed_when: false
-
-- name: Remove custom repos
-  file: path=/etc/apt/sources.list.d/{{ item }} state=absent
-  with_items: "{{ custom_repos.stdout_lines|default([]) }}"
-  # Ignore changes here because we will be removing repos that we end up re-adding later
-  changed_when: false
-
 - name: Set apt preferences
   template:
     dest: "/etc/apt/preferences.d/ceph.pref"
@@ -20,19 +7,6 @@
     group: root
     mode: 0644
   register: apt_prefs
-
-# Starting with ubuntu 15.04 we no longer maintain our own package mirrors.
-# For anything ubuntu < 15.04 or debian <=7 we still do.
-- name: Add sources list
-  template:
-    dest: /etc/apt/sources.list
-    src: "apt/sources.list.{{ ansible_distribution_release | lower }}"
-    owner: root
-    group: root
-    mode: 0644
-  register: sources
-  when: ansible_architecture != "aarch64" and
-        ansible_distribution_major_version|int < 15
 
 - name: Install apt keys
   apt_key:


### PR DESCRIPTION
The linked tracker above the custom repo removal task is from long before we had golden OS images (pre-FOG).