### PR TITLE
Add cleanup tasks to resolve Grafana apt repository conflict

### DIFF
--- a/roles/grafana_agent/tasks/main.yml
+++ b/roles/grafana_agent/tasks/main.yml
@@ -85,6 +85,21 @@
   when: ansible_pkg_mgr == "apt"
   register: keyrings_exists
 
+- name: Remove conflicting Grafana key file if exists
+  ansible.builtin.file:
+    path: /etc/apt/keyrings/grafana.key
+    state: absent
+  when: ansible_pkg_mgr == "apt"
+
+- name: Remove old Grafana APT repository if exists
+  ansible.builtin.apt_repository:
+    repo: "{{ item }}"
+    state: absent
+  loop:
+    - "deb {{ grafana_apt_repo_url }} stable main"
+    - "deb [signed-by=/etc/apt/keyrings/grafana.key] {{ grafana_apt_repo_url }} stable main"
+  when: ansible_pkg_mgr == "apt"
+
 - name: "Import Grafana GPG key"
   become: true
   ansible.builtin.get_url:


### PR DESCRIPTION
The new tasks remove the conflicting key file and duplicate repository entries before adding the standardized Grafana repository, ensuring a clean APT configuration