### PR TITLE
Add an extra module to disable SHA1 MACs on ssh config

### DIFF
--- a/roles/public_facing/tasks/main.yml
+++ b/roles/public_facing/tasks/main.yml
@@ -20,6 +20,17 @@
     line: "PasswordAuthentication no"
     state: present
   notify: restart sshd
+  tags: ssh_config
+
+- name: Remove SHA1 MACs from ssh config
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: "^MACs"
+    line: "MACs hmac-sha2-512,hmac-sha2-256"
+    insertafter: EOF
+    state: present
+  notify: restart sshd 
+  tags: ssh_config 
 
 ## Individual host tasks
 


### PR DESCRIPTION
This is to mitigate a vulnerability found on the public_facing hosts.