### PR TITLE
fix AnsibleFailedError: hwclock: Cannot access the Hardware Clock via…

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -31,11 +31,17 @@
   register: current_clocksource
 
 - name: Set the hardware clock
-  command: hwclock --systohc
+  command: hwclock --systohc --verbose
+  become: true
+  become_method: sudo
+  become_user: root
+  environment:
+    PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
   # unless system clock is using kvm-clock
   when: current_clocksource.stdout.find('kvm-clock') == -1
   tags:
     - timezone
+  ignore_errors: true
 
 # configure Kerberos
 - import_tasks: kerberos.yml

--- a/tools/prep-fog-capture.yml
+++ b/tools/prep-fog-capture.yml
@@ -143,4 +143,10 @@
     when: '"chrony" in ntp_service'
 
   - name: Sync the hardware clock
-    command: "hwclock --systohc"
+    command: "hwclock --systohc --verbose"
+    become: true
+    become_method: sudo
+    become_user: root
+    environment:
+      PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    ignore_errors: true


### PR DESCRIPTION
In virtual machines or containers, running the `smoke` test case can easily lead to failure due to errors like "['hwclock: Cannot access the Hardware Clock via any known method.', 'hwclock: Use the --verbose option to see the details of our search for an access method.']". This is because virtual machines or containers typically lack the necessary permissions to directly execute the `hwclock` command, and such errors are not usually serious and should not cause test case failures. In containers or virtual machines, `hwclock` errors should be ignored to allow the test case to continue execution.

fix https://tracker.ceph.com/issues/69280