### PR TITLE
Feat: Add s390x rhel support

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -33,7 +33,9 @@
 - name: Set the hardware clock
   command: hwclock --systohc
   # unless system clock is using kvm-clock
-  when: current_clocksource.stdout.find('kvm-clock') == -1
+  when: 
+    - current_clocksource.stdout.find('kvm-clock') == -1
+    - ansible_facts.architecture != "s390x"
   tags:
     - timezone
 

--- a/roles/common/tasks/rhel-entitlements.yml
+++ b/roles/common/tasks/rhel-entitlements.yml
@@ -18,6 +18,10 @@
   set_fact:
     have_entitlements: "{{ subscription_manager_org != '' and subscription_manager_activationkey != ''}}"
 
+- name: 'Set rhsm_repos based on the architecture'
+  set_fact:
+    rhsm_repos: "rhsm_repos_{{ ansible_facts.architecture }}"
+
 - name: Find existing CA Cert RPMs
   command: rpm -qa katello-ca-consumer*
   register: existing_satellite_cert
@@ -161,7 +165,7 @@
 
 - name: Set replace_repos true if rhsm_repos differs from repo_list
   set_fact:
-    replace_repos: "{{ repo_list|sort != rhsm_repos|sort }}"
+    replace_repos: "{{ repo_list|sort != vars[rhsm_repos]|sort }}"
   when: repo_list is defined
 
 - name: Set replace_repos true if newly-subscribed
@@ -178,7 +182,7 @@
   no_log: true
 
 - name: Enable necessary rhsm repos
-  command: subscription-manager repos {% for repo in rhsm_repos|list %}--enable={{ repo }} {% endfor %}
+  command: subscription-manager repos {% for repo in vars[rhsm_repos]|list %}--enable={{ repo }} {% endfor %}
   when: rhsm_registered == true and
         replace_repos|bool == true
   retries: 5

--- a/roles/common/vars/redhat_9.yml
+++ b/roles/common/vars/redhat_9.yml
@@ -9,6 +9,11 @@ rhsm_repos_x86_64:
   - rhel-9-for-x86_64-appstream-rpms
   - codeready-builder-for-rhel-9-x86_64-rpms
 
+rhsm_repos_arm64:
+  - rhel-9-for-aarch64-baseos-rpms
+  - rhel-9-for-aarch64-appstream-rpms
+  - codeready-builder-for-rhel-9-aarch64-rpms
+
 nrpe_selinux_packages:
   - python3-libsemanage
   - python3-policycoreutils

--- a/roles/common/vars/redhat_9.yml
+++ b/roles/common/vars/redhat_9.yml
@@ -1,5 +1,10 @@
 ---
-rhsm_repos:
+rhsm_repos_s390x:
+  - rhel-9-for-s390x-baseos-e4s-rpms
+  - rhel-9-for-s390x-appstream-eus-rpms
+  - codeready-builder-for-rhel-9-s390x-rpms
+
+rhsm_repos_x86_64:
   - rhel-9-for-x86_64-baseos-rpms
   - rhel-9-for-x86_64-appstream-rpms
   - codeready-builder-for-rhel-9-x86_64-rpms

--- a/roles/testnode/defaults/main.yml
+++ b/roles/testnode/defaults/main.yml
@@ -79,6 +79,3 @@ configure_cachefilesd: false
 
 # Is this a containerized testnode?
 containerized_node: false
-
-# Set to false if disk should not cleaned - simple runs for nodes with one disk only.
-wipefs_disk: true

--- a/roles/testnode/defaults/main.yml
+++ b/roles/testnode/defaults/main.yml
@@ -79,3 +79,6 @@ configure_cachefilesd: false
 
 # Is this a containerized testnode?
 containerized_node: false
+
+# Set to false if disk should not cleaned - simple runs for nodes with one disk only.
+wipefs_disk: true

--- a/roles/testnode/tasks/setup-ubuntu-non-aarch64.yml
+++ b/roles/testnode/tasks/setup-ubuntu-non-aarch64.yml
@@ -16,6 +16,7 @@
     owner: root
     group: root
     mode: 0755
+  when: ansible_facts.architecture != "s390x"
 
 - name: Enable kernel modules to load at boot time.
   template:

--- a/tools/prep-fog-capture.yml
+++ b/tools/prep-fog-capture.yml
@@ -179,3 +179,4 @@
 
   - name: Sync the hardware clock
     command: "hwclock --systohc"
+    when: ansible_facts.architecture != "s390x"


### PR DESCRIPTION
This is the fix for ticket:
https://github.com/ceph/ceph-cm-ansible/issues/790

Problem:
Using ceph-cm-ansible is causing issues with RHEL especially on s390x hypervisors like zVM.
Different packages needed for s390x architecture.

Fix:
Use ansible_facts.architecture as an architecture flag to load the correct software.
Disable hwclock and /etc/grub.d/02_force_timeout.

Packages names are adapted to fit into rhel on s390x.

    rhel-9-for-s390x-baseos-e4s-rpms
    rhel-9-for-s390x-appstream-eus-rpms
    codeready-builder-for-rhel-9-s390x-rpms

Test:

The fix was tested on s390x (zVM) using RHEL
cat /etc/os-release to
NAME="Red Hat Enterprise Linux"
VERSION="9.6 (Plow)"
ID="rhel"

ansible-playbook /home/teuthology/ceph-cm-ansible/cephlab.yml -vvv --extra-vars '{"ansible_ssh_user": "ubuntu"}' -i /tmp/testnode_inventory

PLAY RECAP ***********************************************************************************************************************************************************************************************************************
a3e11001.lnxero1.boe       : ok=124  changed=36   unreachable=0    failed=0    skipped=247  rescued=0    ignored=3   
a3e11008.lnxero1.boe       : ok=124  changed=36   unreachable=0    failed=0    skipped=247  rescued=0    ignored=3   

