### PR TITLE
Fix nameserver for deb

### DIFF
--- a/roles/nameserver/tasks/config.yml
+++ b/roles/nameserver/tasks/config.yml
@@ -19,7 +19,7 @@
     regexp: '^OPTIONS='
     line: "OPTIONS=\"{{ named_conf_daemon_opts }}\""
     state: present
-    create: True
+    create: false
   notify: restart named
 
 - name: Configure SELinux to allow named to write to master zone files

--- a/roles/nameserver/tasks/config.yml
+++ b/roles/nameserver/tasks/config.yml
@@ -15,7 +15,7 @@
 
 - name: Apply named daemon options
   lineinfile:
-    dest: /etc/sysconfig/named
+    dest: "{{ named_defaults_file }}"
     regexp: '^OPTIONS='
     line: "OPTIONS=\"{{ named_conf_daemon_opts }}\""
     state: present

--- a/roles/nameserver/vars/Debian.yml
+++ b/roles/nameserver/vars/Debian.yml
@@ -18,3 +18,4 @@ bind_group: bind
 
 named_conf_zones_path: /etc/bind/zones
 named_defaults_file: /etc/default/named
+named_conf_file: /etc/bind/named.conf

--- a/roles/nameserver/vars/Debian.yml
+++ b/roles/nameserver/vars/Debian.yml
@@ -17,3 +17,4 @@ bind_user: bind
 bind_group: bind
 
 named_conf_zones_path: /etc/bind/zones
+named_defaults_file: /etc/default/named

--- a/roles/nameserver/vars/Debian.yml
+++ b/roles/nameserver/vars/Debian.yml
@@ -16,6 +16,8 @@ bind_service: bind9
 bind_user: bind
 bind_group: bind
 
+named_conf_dir: /var/cache/bind
+named_conf_data_dir: /var/cache/bind
 named_conf_zones_path: /etc/bind/zones
 named_defaults_file: /etc/default/named
 named_conf_file: /etc/bind/named.conf

--- a/roles/nameserver/vars/RedHat.yml
+++ b/roles/nameserver/vars/RedHat.yml
@@ -23,3 +23,4 @@ bind_user: named
 bind_group: named
 
 named_conf_zones_path: /var/named/zones
+named_defaults_file: /etc/sysconfig/named

--- a/roles/nameserver/vars/Suse.yml
+++ b/roles/nameserver/vars/Suse.yml
@@ -25,3 +25,4 @@ bind_user: named
 bind_group: named
 
 named_conf_zones_path: /var/lib/named
+named_defaults_file: /etc/sysconfig/named


### PR DESCRIPTION
This in combination with https://github.com/ceph/ceph-sepia-secrets/pull/1128 has the role working on both vpn-pub as a master and soko03 as a slave.