### PR TITLE
roles/grafana_agent: major cleanup and cross-platform fixes

### DIFF
--- a/roles/README.md
+++ b/roles/README.md
@@ -1,0 +1,50 @@
+# Grafana Agent Role
+
+This Ansible role installs, configures, and manages **Grafana Agent** (static mode) for scraping node metrics and forwarding them to a Mimir instance.
+
+It supports both **Debian/Ubuntu** and **RedHat-family** systems (RHEL, Rocky Linux, AlmaLinux, etc.).
+
+## What This Role Does
+
+- Installs `prometheus-node-exporter` (Debian/Ubuntu) or `node_exporter` (RedHat via EPEL)
+- Installs Grafana Agent and adds the official Grafana repository
+- Deploys a configuration that scrapes node metrics from `localhost:9100`
+- Forwards metrics to Mimir with basic authentication and TLS support
+- Creates the WAL directory for Grafana Agent
+- Applies SELinux adjustments on RedHat systems
+- Fails early if Prometheus is listening on port 9090 (to prevent port conflicts)
+
+## Supported Platforms
+
+- Debian / Ubuntu
+- Red Hat Enterprise Linux and derivatives (Rocky Linux, AlmaLinux, CentOS Stream)
+
+## Prerequisites
+
+- Ansible 2.10 or later
+- The `community.general` collection (`ansible-galaxy collection install community.general`)
+- A secrets repository that provides:
+  - `mimir_password.yml` containing `mimir_username` and `mimir_password`
+  - The following variables: `grafana_apt_repo_key_url`, `grafana_apt_repo_url`, `grafana_rpm_repo_url`, `grafana_rpm_repo_key_url`, `agent_mimir_url`, and `scrape_interval_global`
+
+## Role Variables
+
+Sensitive and environment-specific variables should be defined in the secrets repository.
+
+### Required Variables
+
+| Variable                        | Description |
+|--------------------------------|-------------|
+| `secrets_path`                 | Path to the secrets repository |
+| `agent_mimir_url`              | Full `remote_write` URL pointing to your Mimir instance |
+| `mimir_username`               | Username for Mimir basic auth |
+| `mimir_password`               | Password for Mimir basic auth |
+| `grafana_apt_repo_key_url`     | URL to the Grafana APT GPG key |
+| `grafana_apt_repo_url`         | Grafana APT repository base URL |
+| `grafana_rpm_repo_url`         | Grafana RPM repository base URL |
+| `grafana_rpm_repo_key_url`     | URL to the Grafana RPM GPG key |
+| `scrape_interval_global`       | Global scrape interval (defaults to `60s`) |
+
+## Dependencies
+
+This role depends on the `secrets` role, which provides the variable `secrets_path` pointing to the secrets repository.

--- a/roles/grafana_agent/defaults/main.yml
+++ b/roles/grafana_agent/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # Mimir URL and creds
-agent_mimir_url: "http://sepia-grafana.front.sepia.ceph.com:9009/api/v1/push"
+agent_mimir_url: "https://mimir-jenkins-monitoring.apps.pok.os.sepia.ceph.com/api/v1/push"
 agent_mimir_username: "admin"
 grafana_apt_repo_url: "https://apt.grafana.com"
 grafana_apt_repo_key_url: "https://apt.grafana.com/gpg.key"

--- a/roles/grafana_agent/tasks/main.yml
+++ b/roles/grafana_agent/tasks/main.yml
@@ -7,20 +7,73 @@
 
 - name: Gather facts on listening ports
   community.general.listen_ports_facts:
+  tags:
+    - always
 
 # Resolving selinux conflicts
 - import_tasks: useradd-selinux.yml
   when: ansible_os_family == "RedHat"
 
-- name: Check if prometheus is listening on port 9090
-  ansible.builtin.debug:
-    msg: The {{ item.name }} service - pid {{ item.pid }} is running on same port as grafana-agent please set {{ item.name }} to listen on a diffrent port than {{ item.port }}
+
+- name: Fail if prometheus is listening on port 9090 (conflicts with grafana-agent)
+  ansible.builtin.fail:
+    msg: |
+      ERROR: Port conflict detected!
+
+      The '{{ item.name }}' service (PID {{ item.pid }}) is listening on port {{ item.port }}.
+
+      grafana-agent is meant to scrape metrics and forward them to Mimir.
+      Having prometheus listening on 9090 creates a port conflict.
+
+      Please do one of the following:
+        1. Change prometheus to listen on a different port (recommended, e.g. 9091)
+        2. Disable or remove the prometheus service if you want to use grafana-agent instead
+
+      After fixing the conflict, re-run this playbook.
   vars:
-    tcp_listen_violations: "{{ ansible_facts.tcp_listen | selectattr('name', 'in', tcp_whitelist) | list }}"
-    tcp_whitelist:
-      - prometheus
+    tcp_listen_violations: "{{ ansible_facts.tcp_listen | selectattr('port', 'equalto', 9090) | list }}"
   loop: "{{ tcp_listen_violations }}"
-  failed_when: true
+  when:
+    - ansible_facts.tcp_listen is defined
+    - tcp_listen_violations | length > 0
+  tags:
+    - always
+
+# Install node_exporter
+- name: Install prometheus-node-exporter (Debian/Ubuntu)
+  become: true
+  ansible.builtin.package:
+    name: prometheus-node-exporter
+    state: present
+  when: ansible_os_family == "Debian"
+
+- name: Install EPEL repository (RedHat)
+  become: true
+  ansible.builtin.dnf:
+    name: epel-release
+    state: present
+  when: ansible_os_family == "RedHat"
+
+- name: Install node_exporter (RedHat family)
+  become: true
+  ansible.builtin.package:
+    name: node_exporter
+    state: present
+  when: ansible_os_family == "RedHat"
+
+# Determine correct service name
+- name: Determine node_exporter service name
+  ansible.builtin.set_fact:
+    node_exporter_service_name: "{{ 'prometheus-node-exporter' if ansible_pkg_mgr == 'apt' else 'node_exporter' }}"
+
+# Enable and start node_exporter
+- name: Enable and start node_exporter
+  become: true
+  ansible.builtin.systemd:
+    name: "{{ node_exporter_service_name }}"
+    enabled: true
+    state: started
+    daemon_reload: true
 
 - name: "Ensure that path /etc/apt/keyrings exists"
   become: true
@@ -68,6 +121,15 @@
   ansible.builtin.package:
     name: "grafana-agent"
     state: "present"
+
+- name: Ensure Grafana Agent WAL directory exists
+  become: true
+  ansible.builtin.file:
+    path: /var/lib/grafana-agent/wal
+    state: directory
+    owner: grafana-agent
+    group: grafana-agent
+    mode: '0750'
 
 - name: "Enable grafana-agent"
   become: true

--- a/roles/grafana_agent/templates/grafana-agent.yaml.j2
+++ b/roles/grafana_agent/templates/grafana-agent.yaml.j2
@@ -1,33 +1,26 @@
-server:
-  log_level: info
-
 metrics:
+  wal_directory: /var/lib/grafana-agent/wal
   global:
-    remote_write:
-      - url: {{ agent_mimir_url }}
-        basic_auth:
-          username: {{ agent_mimir_username }}
-          password: {{ agent_mimir_password }}
-        queue_config:
-          max_backoff: 5m
-    external_labels:
-      nodetype: unknown_nodetype
-      ingest_instance: {{ inventory_hostname }}
-    scrape_interval: {{ scrape_interval_global }}
-  configs:
-    - name: {{ inventory_hostname }}
-      scrape_configs:
-        - job_name: 'grafana-agent-exporter'
-          relabel_configs:
-            - source_labels: [__address__]
-              target_label: instance
-              replacement: {{ inventory_hostname }}
+    scrape_interval: {{ scrape_interval_global | default('60s') }}
 
-integrations:
-  node_exporter:
-    enabled: true
-    scrape_interval: {{ scrape_interval_node }}
-    instance: {{ inventory_hostname }}
-    rootfs_path: /
-    sysfs_path: /sys
-    procfs_path: /proc
+  configs:
+    - name: default
+      scrape_configs:
+        - job_name: node
+          static_configs:
+            - targets: ['localhost:9100']
+          relabel_configs:
+            - target_label: instance
+              replacement: "{{ ansible_fqdn }}:9100"
+            - target_label: nodename
+              replacement: "{{ ansible_fqdn }}"
+
+      remote_write:
+        - url: "{{ agent_mimir_url }}"
+          tls_config:
+            insecure_skip_verify: true
+{% if mimir_username is defined and mimir_password is defined %}
+          basic_auth:
+            username: "{{ mimir_username }}"
+            password: "{{ mimir_password }}"
+{% endif %}

--- a/roles/maas/tasks/add_users.yml
+++ b/roles/maas/tasks/add_users.yml
@@ -12,7 +12,7 @@
         existing_usernames: "{{ existing_users.stdout | from_json | map(attribute='username') | list }}"
     
     - name: Create all admin users.
-      command: "maas {{ maas_admin_username }} users create username={{ item.name }} email={{ item.email }} password={{ item.name}}temp is_superuser=1"
+      command: "maas {{ maas_admin_username }} users create username={{ item.name }} email={{ item.email }} password={{ item.name }}temp is_superuser=1"
       with_items: "{{ admin_users }}"
       when: item.name not in existing_usernames
 

--- a/roles/maas/tasks/install_maasdb.yml
+++ b/roles/maas/tasks/install_maasdb.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install PostgreSQL
   apt:
-    name: postgresql-{{ postgres_version}}
+    name: postgresql-{{ postgres_version }}
     state: present
   when: inventory_hostname in groups['maas_db_server']
   tags: 


### PR DESCRIPTION
- Update default Mimir endpoint
- Improve port 9090 conflict detection (now fails clearly on all distros)
- Fix node_exporter installation on RedHat (EPEL + correct package)
- Refactor grafana-agent.yaml.j2 to use clean static scrape config + basic_auth
- Add WAL directory management
- Add comprehensive README.md