### PR TITLE
users: Change home dir path for teuthology host

### DIFF
--- a/roles/users/tasks/create_users.yml
+++ b/roles/users/tasks/create_users.yml
@@ -14,6 +14,7 @@
     shell: /bin/bash
     state: present
     append: yes
+    home: "{{ ('teuthology' in group_names) | ternary('/tank/home', '/home') }}/{{ item.name }}"
   with_items: "{{ managed_admin_users }}"
 
 - name: Create all users without sudo access.
@@ -21,4 +22,5 @@
     name: "{{ item.name }}"
     shell: /bin/bash
     state: present
+    home: "{{ ('teuthology' in group_names) | ternary('/tank/home', '/home') }}/{{ item.name }}"
   with_items: "{{ managed_users }}"


### PR DESCRIPTION
The home dirs live at the /tank/home mountpoint.  This change will default to /home unless the host we're running the role against is in the teuthology ansible group.

Fixes: https://tracker.ceph.com/issues/63562