### PR TITLE
testnode: Replace apt_key module

### DIFF
--- a/roles/testnode/README.rst
+++ b/roles/testnode/README.rst
@@ -133,16 +133,19 @@ A list of repo files to remove from /etc/yum.repos.d::
 
 
 A list defining apt repos that would be common across a major version or distro. Each item in the list represents
-an apt repo to be added to sources.list::
+an apt repo to be added to sources.list. Each entry **must** include a ``signed-by=`` option pointing to the
+corresponding key installed under ``/etc/apt/keyrings/`` (see ``key_host`` above)::
 
     common_apt_repos: []
 
     # An Example:
     common_apt_repos:
       # mod_fastcgi for radosgw
-      - "deb https://gitbuilder.ceph.com/libapache-mod-fastcgi-deb-{{ansible_distribution_release}}-x86_64-basic/ref/master/ {{ansible_distribution_release}} main"
+      - "deb [signed-by=/etc/apt/keyrings/autobuild.asc] https://gitbuilder.ceph.com/libapache-mod-fastcgi-deb-{{ansible_distribution_release}}-x86_64-basic/ref/master/ {{ansible_distribution_release}} main"
 
-A list defining version-specific apt repos. Each item in the list represents an apt repo to be added to sources.list::
+
+A list defining version-specific apt repos. Each item in the list represents an apt repo to be added to sources.list.
+Each entry **must** include a ``signed-by=`` option pointing to the corresponding key installed under ``/etc/apt/keyrings/``::
 
     apt_repos: []
 

--- a/roles/testnode/tasks/apt/repos.yml
+++ b/roles/testnode/tasks/apt/repos.yml
@@ -8,14 +8,33 @@
     mode: 0644
   register: apt_prefs
 
+- name: Ensure keyrings directory exists
+  file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+    owner: root
+    group: root
+
+# The following task used to use the apt_key ansible module.
+# apt_key is deprecated because it adds keys to the global keyring, meaning
+# any key could be used to authenticate any repo. Instead, we store each key
+# under /etc/apt/keyrings/ and require each repo entry to reference its key
+# explicitly via signed-by= (enforced by the assert task below).
+
 - name: Install apt keys
-  apt_key:
-    url: "{{ item }}"
-    state: present
-  with_items:
-    - "http://{{ key_host }}/keys/autobuild.asc"
-    - "http://{{ key_host }}/keys/release.asc"
+  get_url:
+    url: "{{ item.url }}"
+    dest: "/etc/apt/keyrings/{{ item.name }}"
+    mode: '0644'
+    owner: root
+    group: root
+  loop:
+    - { url: "http://{{ key_host }}/keys/autobuild.asc", name: "autobuild.asc" }
+    - { url: "http://{{ key_host }}/keys/release.asc",   name: "release.asc" }
   # try for 2 minutes before failing
+  register: key_download
+  until: key_download is succeeded
   retries: 24
   delay: 5
 
@@ -25,11 +44,22 @@
     name: "{{ python_apt_package_name|default('python-apt') }}"
     state: present
 
+- name: Verify apt repo strings include signed-by
+  assert:
+    that:
+      - "'signed-by=' in item"
+    fail_msg: >-
+      apt repo entry is missing a signed-by= option: "{{ item }}"
+      Entries must reference a key under /etc/apt/keyrings/, e.g.
+      [signed-by=/etc/apt/keyrings/release.asc]
+  loop: "{{ apt_repos|list + common_apt_repos|list }}"
+  when: (apt_repos|list + common_apt_repos|list) | length > 0
+
 - name: Add local apt repos.
   apt_repository:
     repo: "{{ item }}"
     state: present
-    update_cache: no 
+    update_cache: no
     mode: 0644
   with_items: "{{ apt_repos|list + common_apt_repos|list }}"
   register: local_apt_repos


### PR DESCRIPTION
As of this writing, apt_repos and common_apt_repos are actually unused/empty but the functionality is still useful.

When a chacra repo is added during a teuthology job, `[trusted=yes]` is added to the repo file so no worries there.

```
curl -s https://2.chacra.ceph.com/repos/ceph/tentacle/64721f2bfd1c725c9d5f65983a99bac4d01e22d4/ubuntu/jammy/flavors/default/repo
deb [trusted=yes] https://2.chacra.ceph.com/r/ceph/tentacle/64721f2bfd1c725c9d5f65983a99bac4d01e22d4/ubuntu/jammy/flavors/default/ jammy main
```

Fixes: https://tracker.ceph.com/issues/63567