### PR TITLE
nameserver: Disable minimal-responses

### DIFF
--- a/roles/nameserver/templates/named.conf.j2
+++ b/roles/nameserver/templates/named.conf.j2
@@ -24,6 +24,8 @@ options {
 
 	listen-on-v6 { none; };
 
+	minimal-responses	no;
+
 {% if named_conf_dnssec_validation is defined %}
 	dnssec-validation {{ named_conf_dnssec_validation }};
 {% endif %}


### PR DESCRIPTION
Just upgraded vpn-pub to el9.

BIND 9.16 (EL9) changed the default behavior for minimal-responses, causing authority and additional (glue) sections to be omitted from responses. Set minimal-responses no explicitly to restore consistent behavior across all nameservers regardless of BIND version.