### PR TITLE
set-bmc-static: skip some tasks when certain vars|bool

### DIFF
--- a/tools/set-bmc-static.yml
+++ b/tools/set-bmc-static.yml
@@ -53,6 +53,7 @@
     register: power_status_factory
     when:
       - setup_user
+      - not only_lan_access|bool
     tags: test_user
     ignore_errors: true
 
@@ -62,6 +63,7 @@
     register: power_status_power
     when:
       - setup_user
+      - not only_lan_access|bool
     tags: test_user
     ignore_errors: true
 
@@ -80,6 +82,8 @@
     fail:
     when:
       - (power_status_factory.rc != 0) and (power_status_power.rc != 0)
+    tags:
+      - test_user
 
   - name: Check if we have SSH access
     shell: "timeout 3s ssh {{ inventory_hostname }} true"
@@ -99,6 +103,7 @@
     shell: "ipmitool -I lanplus -U {{ initial_user }} -P {{ initial_pass }} -H {{ inventory_hostname_short }}.{{ ipmi_domain }} user set name {{ power_uid }} {{ power_user }}"
     register: set_username_locally
     delegate_to: localhost
+    become: false
     when:
       - setup_user
       - have_ssh_access.rc != 0
@@ -108,6 +113,7 @@
     shell: "ipmitool -I lanplus -U {{ initial_user }} -P {{ initial_pass }} -H {{ inventory_hostname_short }}.{{ ipmi_domain }} channel setaccess {{ ipmi_channel_id }} {{ power_uid }} privilege=4 callin=on ipmi=on"
     register: set_permissions_locally
     delegate_to: localhost
+    become: false
     when:
       - setup_user
       - have_ssh_access.rc != 0
@@ -117,6 +123,7 @@
     shell: "ipmitool -I lanplus -U {{ initial_user }} -P {{ initial_pass }} -H {{ inventory_hostname_short }}.{{ ipmi_domain }} user set password {{ power_uid }} {{ power_pass }}"
     register: set_password_locally
     delegate_to: localhost
+    become: false
     when:
       - setup_user
       - have_ssh_access.rc != 0
@@ -125,6 +132,7 @@
   - name: Enable user
     shell: "ipmitool -I lanplus -U {{ initial_user }} -P {{ initial_pass }} -H {{ inventory_hostname_short }}.{{ ipmi_domain }} user enable {{ power_uid }}"
     delegate_to: localhost
+    become: false
     when:
       - setup_user
       - have_ssh_access.rc != 0
@@ -137,6 +145,7 @@
     shell: "ipmitool -I lanplus -U {{ power_user }} -P {{ power_pass }} -H {{ inventory_hostname_short }}.{{ ipmi_domain }} lan print 1 | grep -q DHCP"
     register: dhcp_already_enabled
     delegate_to: localhost
+    become: false
     when: use_dhcp
     failed_when: dhcp_already_enabled.stderr != ''
     changed_when: false
@@ -145,6 +154,7 @@
     shell: "ipmitool -I lanplus -U {{ power_user }} -P {{ power_pass }} -H {{ inventory_hostname_short }}.{{ ipmi_domain }} lan set {{ ipmi_channel_id }} ipsrc dhcp"
     register: set_to_dhcp_locally
     delegate_to: localhost
+    become: false
     when:
       - use_dhcp
       - (dhcp_already_enabled is defined and dhcp_already_enabled.rc != 0)


### PR DESCRIPTION
Made this work:

```
ansible-playbook tools/set-bmc-static.yml --limit 'trial001*' -e only_lan_access=true --skip-tags test_user
```

Otherwise:

```
ansible-playbook tools/set-bmc-static.yml --limit 'trial001*' -e only_lan_access=true

PLAY [all] *********************************************************************************************************************************************************************************************

TASK [include_vars] ************************************************************************************************************************************************************************************
ok: [trial001.front.sepia.ceph.com]

TASK [include_vars] ************************************************************************************************************************************************************************************
ok: [trial001.front.sepia.ceph.com]

TASK [Make sure we have power_user and power_pass] *****************************************************************************************************************************************************
skipping: [trial001.front.sepia.ceph.com]

TASK [test factory ipmi creds] *************************************************************************************************************************************************************************
fatal: [trial001.front.sepia.ceph.com -> localhost]: FAILED! => {"changed": false, "module_stderr": "sudo: a password is required\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
...ignoring

TASK [test power_user/power_pass creds] ****************************************************************************************************************************************************************
fatal: [trial001.front.sepia.ceph.com -> localhost]: FAILED! => {"changed": false, "module_stderr": "sudo: a password is required\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
...ignoring

TASK [debug] *******************************************************************************************************************************************************************************************
ok: [trial001.front.sepia.ceph.com] => {
    "msg": "factory False power_user False"
}

TASK [if both fail, halt now] **************************************************************************************************************************************************************************
fatal: [trial001.front.sepia.ceph.com]: FAILED! => {"changed": false, "msg": "Failed as requested from task"}

PLAY RECAP *********************************************************************************************************************************************************************************************
trial001.front.sepia.ceph.com : ok=5    changed=0    unreachable=0    failed=1    skipped=1    rescued=0    ignored=2

vim tools/set-bmc-static.yml
%
ansible-playbook tools/set-bmc-static.yml --limit 'trial001*' -e only_lan_access=true

PLAY [all] *********************************************************************************************************************************************************************************************

TASK [include_vars] ************************************************************************************************************************************************************************************
ok: [trial001.front.sepia.ceph.com]

TASK [include_vars] ************************************************************************************************************************************************************************************
ok: [trial001.front.sepia.ceph.com]

TASK [Make sure we have power_user and power_pass] *****************************************************************************************************************************************************
skipping: [trial001.front.sepia.ceph.com]

TASK [test factory ipmi creds] *************************************************************************************************************************************************************************
skipping: [trial001.front.sepia.ceph.com]

TASK [test power_user/power_pass creds] ****************************************************************************************************************************************************************
skipping: [trial001.front.sepia.ceph.com]

TASK [debug] *******************************************************************************************************************************************************************************************
fatal: [trial001.front.sepia.ceph.com]: FAILED! => {"msg": "The conditional check '(power_status_factory.rc != 0) or (power_status_power.rc != 0)' failed. The error was: error while evaluating conditional ((power_status_factory.rc != 0) or (power_status_power.rc != 0)): 'dict object' has no attribute 'rc'. 'dict object' has no attribute 'rc'\n\nThe error appears to be in '/Users/david/src/ceph-cm-ansible/tools/set-bmc-static.yml': line 70, column 5, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n  - debug:\n    ^ here\n"}

PLAY RECAP *********************************************************************************************************************************************************************************************
trial001.front.sepia.ceph.com : ok=2    changed=0    unreachable=0    failed=1    skipped=3    rescued=0    ignored=0

---

ansible-playbook tools/set-bmc-static.yml --limit 'trial001*' -e only_lan_access=true --skip-tags test_user

PLAY [all] *********************************************************************************************************************************************************************************************

TASK [include_vars] ************************************************************************************************************************************************************************************
ok: [trial001.front.sepia.ceph.com]

TASK [include_vars] ************************************************************************************************************************************************************************************
ok: [trial001.front.sepia.ceph.com]

TASK [Make sure we have power_user and power_pass] *****************************************************************************************************************************************************
skipping: [trial001.front.sepia.ceph.com]

TASK [if both fail, halt now] **************************************************************************************************************************************************************************
fatal: [trial001.front.sepia.ceph.com]: FAILED! => {"msg": "The conditional check '(power_status_factory.rc != 0) and (power_status_power.rc != 0)' failed. The error was: error while evaluating conditional ((power_status_factory.rc != 0) and (power_status_power.rc != 0)): 'power_status_factory' is undefined. 'power_status_factory' is undefined\n\nThe error appears to be in '/Users/david/src/ceph-cm-ansible/tools/set-bmc-static.yml': line 81, column 5, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n  - name: if both fail, halt now\n    ^ here\n"}

PLAY RECAP *********************************************************************************************************************************************************************************************
trial001.front.sepia.ceph.com : ok=2    changed=0    unreachable=0    failed=1    skipped=1    rescued=0    ignored=0

---

ansible-playbook tools/set-bmc-static.yml --limit 'trial001*' -e only_lan_access=true --skip-tags test_user

PLAY [all] *********************************************************************************************************************************************************************************************

TASK [include_vars] ************************************************************************************************************************************************************************************
ok: [trial001.front.sepia.ceph.com]

TASK [include_vars] ************************************************************************************************************************************************************************************
ok: [trial001.front.sepia.ceph.com]

TASK [Make sure we have power_user and power_pass] *****************************************************************************************************************************************************
skipping: [trial001.front.sepia.ceph.com]

TASK [Check if we have SSH access] *********************************************************************************************************************************************************************
skipping: [trial001.front.sepia.ceph.com]

TASK [Fake SSH failure if not desired] *****************************************************************************************************************************************************************
ok: [trial001.front.sepia.ceph.com]

TASK [Initial setup of username from localhost] ********************************************************************************************************************************************************
fatal: [trial001.front.sepia.ceph.com -> localhost]: FAILED! => {"changed": false, "module_stderr": "sudo: a password is required\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
...ignoring

TASK [Initial setup of permissions from localhost] *****************************************************************************************************************************************************
fatal: [trial001.front.sepia.ceph.com -> localhost]: FAILED! => {"changed": false, "module_stderr": "sudo: a password is required\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
...ignoring

TASK [Initial setup of password from localhost] ********************************************************************************************************************************************************
fatal: [trial001.front.sepia.ceph.com -> localhost]: FAILED! => {"changed": false, "module_stderr": "sudo: a password is required\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
...ignoring

TASK [Enable user] *************************************************************************************************************************************************************************************
fatal: [trial001.front.sepia.ceph.com -> localhost]: FAILED! => {"changed": false, "module_stderr": "sudo: a password is required\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
...ignoring

TASK [meta] ********************************************************************************************************************************************************************************************

PLAY RECAP *********************************************************************************************************************************************************************************************
trial001.front.sepia.ceph.com : ok=7    changed=0    unreachable=0    failed=0    skipped=2    rescued=0    ignored=4
```