### PR TITLE
maas: Add relay_vlan support to networking reconciliation

### DIFF
--- a/roles/maas/README.md
+++ b/roles/maas/README.md
@@ -135,6 +135,11 @@ maas_networking:
         description: "..."           # Optional, stored on the VLAN
         mtu: 1500                    # Optional, applied during VLAN update
         dhcp_on: false               # Optional. If true, MAAS DHCP is enabled for the VLAN
+        relay_vlan: 1338             # Optional. VID (same fabric) that DHCP/PXE traffic for this
+                                     # VLAN is relayed through. Tells MAAS not to move this VLAN's
+                                     # subnets to the VLAN the boot traffic was observed on.
+                                     # Mutually exclusive with dhcp_on. Set to '' to clear a relay;
+                                     # omit to leave MAAS untouched.
         primary_rack_controller: ""  # Optional per-VLAN override of the global primary rack controller
         subnets:
           - cidr: 10.20.192.0/20     # Required
@@ -162,13 +167,13 @@ maas_overwrite_ipranges: Optional, defaults to `false`. When `true`, overlapping
 
 What `tasks/networking.yml` does, in order:
 
-1. Validates the inventory before making any API calls. It fails fast if any DHCP-enabled VLAN is missing a `dynamic` ip_range, if any VLAN name violates the `^[a-z0-9-]+$` rule, or if `maas_global_primary_rack_controller` is unset and any VLAN omits `primary_rack_controller`.
+1. Validates the inventory before making any API calls. It fails fast if any DHCP-enabled VLAN is missing a `dynamic` ip_range, if any VLAN name violates the `^[a-z0-9-]+$` rule, if any `relay_vlan` setting is invalid (combined with `dhcp_on`, pointing at itself, or pointing at a VLAN that is itself relayed), or if `maas_global_primary_rack_controller` is unset and any VLAN omits `primary_rack_controller`.
 2. Reads the existing MAAS Domains and creates any new domains found in `maas_networking[*].vlans[*].subnets[*].domain` (`networking/domain_create.yml`).
 3. Reads the existing MAAS Spaces and creates any new spaces found in the subnet definitions (`networking/space_create.yml`).
 4. Reads the existing Fabrics and creates any missing fabrics named in `maas_networking[*].fabric` (`networking/fabric_create.yml`).
 5. Reads each fabric's VLANs (`networking/fabric_vlans_read_from_maas.yml`) and builds a `_vlan_index` keyed by fabric and VID (`networking/vlan_build_index.yml`). Missing VLANs are created with their `vid`, `name`, `description`, `mtu`, and `space`, but not yet with `dhcp_on` (`networking/vlan_create.yml`). The index is then rebuilt to pick up newly-created VLANs.
 6. For every (fabric, vlan, subnet) triple, applies the subnet (`networking/subnet_apply.yml`): creates it if missing or updates it in place, sets `gateway_ip` and `managed`, applies DNS servers (subnet-level first, then `maas_global_dns_servers`), and reconciles its IP ranges (`networking/subnet_range_create.yml`). The range task skips exact matches, refuses to create a `dynamic` range on an unmanaged subnet, and either fails on overlaps or replaces them depending on `maas_overwrite_ipranges`.
-7. Finally, updates each VLAN's mutable properties — `name`, `mtu`, `space`, `primary_rack`, and `dhcp_on` — only after IP ranges exist, since MAAS will reject `dhcp_on=true` on a VLAN with no dynamic range (`networking/vlan_update.yml`).
+7. Finally, updates each VLAN's mutable properties — `name`, `mtu`, `space`, `primary_rack`, `dhcp_on`, and `relay_vlan` — only after IP ranges exist, since MAAS will reject `dhcp_on=true` on a VLAN with no dynamic range (`networking/vlan_update.yml`). A `relay_vlan` VID is resolved to the target VLAN's MAAS database id via the `_vlan_index`, and the task asserts the target exists on the fabric before issuing the PUT.
 
 Machines variables include:
 

--- a/roles/maas/tasks/networking.yml
+++ b/roles/maas/tasks/networking.yml
@@ -86,6 +86,44 @@
       DHCP is enabled but no dynamic range is defined on these VLANs:
       {{ (_dhcp_missing_dynamic | default([])) | to_nice_json }}
 
+# --- Check relay_vlan settings -------------------------------------------------
+
+# MAAS rejects dhcp_on=true together with relay_vlan, self-relays, and relays
+# whose target is itself relayed (no chaining). Catch what we can before any
+# API call; existence of the target VLAN in MAAS is asserted per-VLAN later in
+# networking/vlan_update.yml once the index has been built.
+- name: Build list of invalid relay_vlan settings
+  set_fact:
+    _relay_vlan_violations: |
+      {% set bad = [] %}
+      {% for pair in (maas_networking | subelements('vlans', skip_missing=True)) %}
+      {%   set fab = pair[0] %}
+      {%   set v   = pair[1] %}
+      {%   set rvid = v.relay_vlan | default('', true) | string | trim %}
+      {%   if rvid | length > 0 %}
+      {%     if v.dhcp_on | default(false) | bool %}
+      {%       set _ = bad.append(fab.fabric ~ ":VID " ~ (v.vid | string) ~ " sets both dhcp_on and relay_vlan (mutually exclusive in MAAS)") %}
+      {%     endif %}
+      {%     if rvid == (v.vid | string) %}
+      {%       set _ = bad.append(fab.fabric ~ ":VID " ~ (v.vid | string) ~ " relays to itself") %}
+      {%     endif %}
+      {%     for tv in fab.vlans | default([]) %}
+      {%       if (tv.vid | string) == rvid and (tv.relay_vlan | default('', true) | string | trim) | length > 0 %}
+      {%         set _ = bad.append(fab.fabric ~ ":VID " ~ (v.vid | string) ~ " relays to VID " ~ rvid ~ " which is itself relayed (MAAS forbids chained relays)") %}
+      {%       endif %}
+      {%     endfor %}
+      {%   endif %}
+      {% endfor %}
+      {{ bad }}
+
+- name: Fail on invalid relay_vlan settings
+  assert:
+    that:
+      - (_relay_vlan_violations | default([])) | length == 0
+    fail_msg: >-
+      Invalid relay_vlan configuration:
+      {{ (_relay_vlan_violations | default([])) | to_nice_json }}
+
 # --- Check for undefined primary rack controller per VLAN ---------------------
 
 # 1) Capture global if provided (and non-empty)

--- a/roles/maas/tasks/networking/vlan_update.yml
+++ b/roles/maas/tasks/networking/vlan_update.yml
@@ -1,6 +1,6 @@
 ---
 # Purpose: Update one existing VLAN's mutable properties (name, mtu, space,
-# primary_rack, dhcp_on). Called once per (fabric, vlan) pair from the loop
+# primary_rack, dhcp_on, relay_vlan). Called once per (fabric, vlan) pair from the loop
 # in networking.yml AFTER subnets and IP ranges exist — MAAS rejects
 # dhcp_on=true on a VLAN with no dynamic range, which is why this is split
 # from vlan_create.yml.
@@ -43,6 +43,9 @@
     _vobj: "{{ none }}"
     _prc_candidate: ""
     _primary_rack_controller: "{{ none }}"
+    _relay_requested: false
+    _relay_vid: ""
+    _relay_vlan_id: ""
 
 - name: Resolve VLAN object
   set_fact:
@@ -61,6 +64,38 @@
 - name: Decide primary rack controller for this VLAN
   set_fact:
     _primary_rack_controller: "{{ _prc_candidate if (_prc_candidate | length) > 0 else (_global_primary_rack_controller | default(omit)) }}"
+
+# --- DHCP relay ---------------------------------------------------------------
+# `relay_vlan: <vid>` on a VLAN tells MAAS that DHCP/PXE traffic for this VLAN
+# arrives relayed on another VLAN of the same fabric, so MAAS stops "fixing"
+# things by moving the subnet to the VLAN the traffic was seen on. The MAAS API
+# wants the target VLAN's database id, not its vid, so resolve it through
+# _vlan_index (which holds every VLAN MAAS knows about on the fabric, not just
+# the ones defined in maas_networking). `relay_vlan: ''` (or null) explicitly
+# clears an existing relay; omitting the key leaves MAAS untouched.
+- name: Compute requested relay target
+  set_fact:
+    _relay_requested: "{{ 'relay_vlan' in vlan }}"
+    _relay_vid: "{{ vlan.relay_vlan | default('', true) | string | trim }}"
+
+- name: Ensure relay target VLAN exists on the fabric
+  assert:
+    that:
+      - _vlan_index[_fname][_relay_vid] is defined
+    fail_msg: >-
+      relay_vlan {{ _relay_vid }} on {{ _fname }}:{{ vlan.vid }} does not match
+      any VLAN MAAS knows about on fabric {{ _fname }}.
+      Known vids: {{ _vlan_index.get(_fname, {}) | dict2items | map(attribute='key') | list }}
+  when:
+    - _relay_requested | bool
+    - _relay_vid | length > 0
+
+- name: Resolve relay target VLAN database id
+  set_fact:
+    _relay_vlan_id: "{{ _vlan_index[_fname][_relay_vid].id | string }}"
+  when:
+    - _relay_requested | bool
+    - _relay_vid | length > 0
 
 - name: Build VLAN update body
   vars:
@@ -93,6 +128,10 @@
         | combine(
             (vlan.dhcp_on | default(false) | bool and _has_dynamic_for_vlan)
             | ternary({'dhcp_on': true}, {}), recursive=True
+          )
+        | combine(
+            (_relay_requested | bool)
+            | ternary({'relay_vlan': (_relay_vlan_id if (_relay_vid | length > 0) else '')}, {}), recursive=True
           )
       }}
 


### PR DESCRIPTION
## What

Adds an optional per-VLAN `relay_vlan: <vid>` key to the `maas_networking` schema, applied during the VLAN update pass (`networking/vlan_update.yml`).

## Why

MAAS relocates a subnet to whichever VLAN its DHCP/PXE traffic is observed on. For VLANs whose boot traffic reaches the rack controller relayed through another VLAN (e.g. `pok` vlan107 hosts PXE via the rack's 1338 leg), this auto "fix-up" keeps moving the subnet off the VLAN we configured. Setting `relay_vlan` on the VLAN tells MAAS the traffic is relayed and stops the relocation.

## How

- The vid is resolved to the target VLAN's MAAS **database id** (what the API expects) via `_vlan_index`, which is built from MAAS itself, so the relay target does not have to be defined in `maas_networking` — it just has to exist on the fabric. A per-VLAN assert fails with the known vids if it doesn't.
- `relay_vlan: ''` (or null) explicitly clears an existing relay; omitting the key leaves MAAS untouched, consistent with the role's reconcile-only philosophy.
- Pre-flight validation in `networking.yml` fails fast on configs MAAS would reject: `dhcp_on: true` combined with `relay_vlan`, a VLAN relaying to itself, or a relay target that is itself relayed (chained relays).
- README schema and flow docs updated.

## Testing

Verified in production on the `pok` fabric: applied `relay_vlan: 1338` to vlan107 and the subnet stopped being relocated; PXE now completes NBP download on the relayed VLAN.