### PR TITLE
users: warn instead of failing when a pubkey is missing

### DIFF
--- a/roles/users/tasks/update_keys.yml
+++ b/roles/users/tasks/update_keys.yml
@@ -22,12 +22,47 @@
   retries: 5
   delay: 10
 
+- name: Find the pubkeys available in the keys repo
+  find:
+    paths: "{{ keys_repo_path }}/ssh"
+    patterns: "*.pub"
+  delegate_to: localhost
+  become: false
+  connection: local
+  run_once: true
+  register: found_pubkeys
+  when: keys_repo is defined
+
+- name: Build the list of users with a pubkey in the keys repo
+  set_fact:
+    keys_repo_pubkeys: >-
+      {{
+        found_pubkeys.files | default([])
+        | map(attribute='path')
+        | map('basename')
+        | map('regex_replace', '\.pub$', '')
+        | list
+      }}
+
+# A missing pubkey shouldn't be fatal; the user simply doesn't get access.
+- name: Warn about users with no pubkey in the keys repo
+  debug:
+    msg: "WARNING: No pubkey found for '{{ item.name }}' in {{ keys_repo }}; skipping their authorized_keys."
+  with_items: "{{ pubkey_users }}"
+  when:
+    - keys_repo is defined
+    - item.key is undefined
+    - item.name not in keys_repo_pubkeys
+
 - name: Update authorized_keys using the keys repo
   authorized_key:
     user: "{{ item.name }}"
     key: "{{ lookup('file', keys_repo_path + '/ssh/' + item.name + '.pub') }}"
   with_items: "{{ pubkey_users }}"
-  when: item.key is undefined and keys_repo is defined
+  when:
+    - item.key is undefined
+    - keys_repo is defined
+    - item.name in keys_repo_pubkeys
 
 - name: Update authorized_keys for each user with literal keys
   authorized_key:


### PR DESCRIPTION
## What

A user with no `<name>.pub` in [ceph/keys](https://github.com/ceph/keys) currently aborts the entire play, because the `file` lookup that builds `authorized_keys` is fatal:

```
teuthology.exceptions.AnsibleFailedError: ["The 'file' lookup had an issue accessing the file '~/.cache/src/keys/ssh/mohant.pub'. file not found, use -vvvvv to see paths searched"]
```

Instead of letting the lookup blow up mid-loop, the role now enumerates what's actually in the cloned keys repo up front and skips users that aren't there:

1. A single `find` on localhost (`run_once`, so it's one task regardless of host or user count) lists `{{ keys_repo_path }}/ssh/*.pub`.
2. `keys_repo_pubkeys` holds those basenames with `.pub` stripped.
3. A `debug` task warns per user whose key is missing, naming the user and the repo.
4. The `authorized_key` task additionally requires `item.name in keys_repo_pubkeys`, so the lookup only ever runs on a file known to exist.

## Why

One user missing from keys.git shouldn't take down a whole teuthology run for every other user on the node.

## Notes for reviewers

- Users with a literal `key:` in their definition are unaffected.
- When `keys_repo` is undefined, the new tasks are skipped as before — `found_pubkeys.files | default([])` keeps the fact defined either way.
- **Behavior change worth naming:** a typo'd or missing username used to fail loudly; now it passes with only a warning line in the log. If someone's access quietly stops working, that warning is the only signal.

## Testing

- `ansible-playbook --syntax-check` on a play including the role: clean.
- Smoke-ran the new tasks against a fake keys dir containing `alice.pub`, plus a `mohant` (no key file) and a `carol` (literal key). `mohant` produced the warning and was skipped, `alice` proceeded, `carol` was untouched by the repo task — `failed=0`.
- Confirmed `find` expands the `~` in the default `keys_repo_path`; against a real `~/.cache/src/keys/ssh` it matched 403 pubkeys.