### PR TITLE
testnode: use local distro mirror first, fall back to public mirrors

### DIFF
--- a/roles/testnode/defaults/main.yml
+++ b/roles/testnode/defaults/main.yml
@@ -1,5 +1,9 @@
 ---
 mirror_host: apt-mirror.sepia.ceph.com
+# Local distro package mirror.  Listed first in baseurls so it's tried
+# before the public mirrors; dnf falls back to the next URL if it's
+# unreachable or missing a repo.
+distro_mirror_host: distro-mirror.front.sepia.ceph.com
 git_mirror_host: git.ceph.com
 key_host: download.ceph.com
 gitbuilder_host: gitbuilder.ceph.com

--- a/roles/testnode/vars/centos_9.yml
+++ b/roles/testnode/vars/centos_9.yml
@@ -8,6 +8,39 @@ common_yum_repos:
     enabled: 1
     gpgcheck: 0
 
+# CentOS 9 only exists as Stream so the -stream suffix is safe to hardcode.
+# The local mirror is listed first; dnf falls back to the public mirror if
+# it's unreachable or missing a repo.
+yum_repos:
+  baseos:
+    name: "CentOS Stream $releasever - BaseOS"
+    baseurls:
+      - "https://{{ distro_mirror_host }}/centos/{{ ansible_distribution_major_version }}-stream/BaseOS/{{ ansible_architecture }}/os/"
+      - "https://mirror.stream.centos.org/{{ ansible_distribution_major_version }}-stream/BaseOS/{{ ansible_architecture }}/os/"
+    enabled: 1
+    gpgcheck: 0
+
+  appstream:
+    name: "CentOS Stream $releasever - AppStream"
+    baseurls:
+      - "https://{{ distro_mirror_host }}/centos/{{ ansible_distribution_major_version }}-stream/AppStream/{{ ansible_architecture }}/os/"
+      - "https://mirror.stream.centos.org/{{ ansible_distribution_major_version }}-stream/AppStream/{{ ansible_architecture }}/os/"
+    enabled: 1
+    gpgcheck: 0
+
+  crb:
+    name: "CentOS Stream $releasever - CRB"
+    baseurls:
+      - "https://{{ distro_mirror_host }}/centos/{{ ansible_distribution_major_version }}-stream/CRB/{{ ansible_architecture }}/os/"
+      - "https://mirror.stream.centos.org/{{ ansible_distribution_major_version }}-stream/CRB/{{ ansible_architecture }}/os/"
+    enabled: 1
+    gpgcheck: 0
+
+# The stock centos.repo defines the same repo ids (baseos, appstream, crb)
+# and would override the definitions above because dnf reads repo files in
+# alphabetical order.  centos-addons.repo (extras-common, etc.) is left alone.
+yum_repos_to_remove:
+  - centos.repo
 
 # When mirrors become available, these will be filenames in roles/testnodes/templates/mirrorlists/9/
 yum_mirrorlists: []

--- a/roles/testnode/vars/rocky_10.yml
+++ b/roles/testnode/vars/rocky_10.yml
@@ -12,6 +12,7 @@ yum_repos:
   baseos:
     name: "Rocky Linux $releasever - BaseOS"
     baseurls:
+      - "https://{{ distro_mirror_host }}/rocky/{{ ansible_distribution_major_version }}/BaseOS/{{ ansible_architecture }}/os/"
       - "https://nyc.mirrors.clouvider.net/rocky/{{ ansible_distribution_major_version }}/BaseOS/{{ ansible_architecture }}/os/"
       - "https://plug-mirror.rcac.purdue.edu/rocky/{{ ansible_distribution_major_version }}/BaseOS/{{ ansible_architecture }}/os/"
       - "https://rocky-linux-us-east4.production.gcp.mirrors.ctrliq.cloud/pub/rocky/{{ ansible_distribution_major_version }}/BaseOS/{{ ansible_architecture }}/os/"
@@ -21,6 +22,7 @@ yum_repos:
   appstream:
     name: "Rocky Linux $releasever - AppStream"
     baseurls:
+      - "https://{{ distro_mirror_host }}/rocky/{{ ansible_distribution_major_version }}/AppStream/{{ ansible_architecture }}/os/"
       - "https://nyc.mirrors.clouvider.net/rocky/{{ ansible_distribution_major_version }}/AppStream/{{ ansible_architecture }}/os/"
       - "https://plug-mirror.rcac.purdue.edu/rocky/{{ ansible_distribution_major_version }}/AppStream/{{ ansible_architecture }}/os/"
       - "https://rocky-linux-us-east4.production.gcp.mirrors.ctrliq.cloud/pub/rocky/{{ ansible_distribution_major_version }}/AppStream/{{ ansible_architecture }}/os/"
@@ -30,6 +32,7 @@ yum_repos:
   crb:
     name: "Rocky Linux $releasever - CRB"
     baseurls:
+      - "https://{{ distro_mirror_host }}/rocky/{{ ansible_distribution_major_version }}/CRB/{{ ansible_architecture }}/os/"
       - "https://nyc.mirrors.clouvider.net/rocky/{{ ansible_distribution_major_version }}/CRB/{{ ansible_architecture }}/os/"
       - "https://plug-mirror.rcac.purdue.edu/rocky/{{ ansible_distribution_major_version }}/CRB/{{ ansible_architecture }}/os/"
       - "https://rocky-linux-us-east4.production.gcp.mirrors.ctrliq.cloud/pub/rocky/{{ ansible_distribution_major_version }}/CRB/{{ ansible_architecture }}/os/"


### PR DESCRIPTION
## What

Wires the new `distro-mirror.front.sepia.ceph.com` host into testnode repo configuration as the first line of defense, with automatic fallback to public mirrors:

- **New `distro_mirror_host` var** in testnode defaults so other labs can override it.
- **Rocky 10**: the local mirror is prepended to each existing `baseurls` list (BaseOS, AppStream, CRB). No mechanism change — `yum_repo.j2` already renders multiple `baseurl=` lines and dnf tries them in order.
- **CentOS 9 Stream**: new `yum_repos` block (baseos, appstream, crb) with the local mirror first and `mirror.stream.centos.org` as fallback. Stream nodes previously rode on the stock repo files.

## Why

Package installs on testnodes currently depend entirely on public mirror availability. With the local mirror listed first, dnf silently moves to the next URL if it's down or missing a repo, so this is strictly additive: worst case is today's behavior.

## Reviewer notes

- The mirror currently serves `/rocky/10/` and `/centos/9-stream/` in upstream-identical layouts (verified against the live host).
- For CentOS Stream, the stock `centos.repo` is added to `yum_repos_to_remove` because it defines the same repo ids (`baseos`/`appstream`/`crb`) and dnf reads repo files alphabetically, so it would override our definitions. `centos-addons.repo` (extras-common, etc.) is deliberately left alone.
- `gpgcheck: 0` and the general shape follow the existing Rocky 10 pattern.
- Ubuntu is out of scope: apt doesn't fail over between duplicate `deb` lines; doing this properly needs apt's `mirror+file:` method and the mirror doesn't serve Ubuntu yet.