### PR TITLE
testnode: use local Ubuntu mirror first, fall back to public archive

### DIFF
--- a/roles/testnode/README.rst
+++ b/roles/testnode/README.rst
@@ -39,6 +39,22 @@ The host to use as a package mirror::
 
     mirror_host: apt-mirror.sepia.ceph.com
 
+The local distro mirror, tried before the public mirrors with automatic
+fallback (dnf: ordered baseurls; apt: the ``mirror+file:`` method with
+``/etc/apt/mirrorlist``)::
+
+    distro_mirror_host: distro-mirror.front.sepia.ceph.com
+
+Ubuntu releases carried by the local distro mirror.  On these releases the
+stock apt sources are replaced with mirror-first ones
+(``/etc/apt/sources.list.d/sepia-mirror.sources``); other releases keep
+their stock sources::
+
+    distro_mirror_ubuntu_releases:
+      - jammy
+      - noble
+      - resolute
+
 The host to use as a github mirror::
 
     git_mirror_host: git.ceph.com

--- a/roles/testnode/defaults/main.yml
+++ b/roles/testnode/defaults/main.yml
@@ -4,6 +4,12 @@ mirror_host: apt-mirror.sepia.ceph.com
 # before the public mirrors; dnf falls back to the next URL if it's
 # unreachable or missing a repo.
 distro_mirror_host: distro-mirror.front.sepia.ceph.com
+# Ubuntu releases carried by the local distro mirror.  Releases not in
+# this list keep their stock apt sources (public archive only).
+distro_mirror_ubuntu_releases:
+  - jammy
+  - noble
+  - resolute
 git_mirror_host: git.ceph.com
 key_host: download.ceph.com
 gitbuilder_host: gitbuilder.ceph.com

--- a/roles/testnode/tasks/apt/repos.yml
+++ b/roles/testnode/tasks/apt/repos.yml
@@ -1,4 +1,57 @@
 ---
+# Mirror-first base Ubuntu sources.  APT's mirror method (mirror+file:)
+# tries the local distro mirror first and falls back to the public
+# archive automatically — the apt equivalent of the dnf mirror-first
+# baseurls used on the RPM distros.
+- name: Point base Ubuntu sources at the local distro mirror
+  when:
+    - ansible_distribution == "Ubuntu"
+    - ansible_distribution_release in distro_mirror_ubuntu_releases
+  tags:
+    - repos
+  block:
+    - name: Write apt mirrorlist
+      template:
+        dest: /etc/apt/mirrorlist
+        src: apt/mirrorlist.j2
+        owner: root
+        group: root
+        mode: 0644
+
+    - name: Write mirror-first base apt sources
+      template:
+        dest: /etc/apt/sources.list.d/sepia-mirror.sources
+        src: apt/sepia-mirror.sources.j2
+        owner: root
+        group: root
+        mode: 0644
+
+    # The local mirror serves canonical index paths (debmirror does not
+    # populate by-hash/), so make APT fetch indexes by canonical name.
+    - name: Disable APT by-hash index fetching
+      copy:
+        content: |
+          Acquire::By-Hash "no";
+        dest: /etc/apt/apt.conf.d/90sepia-mirror
+        owner: root
+        group: root
+        mode: 0644
+
+    - name: Neuter stock sources.list (replaced by sepia-mirror.sources)
+      copy:
+        content: |
+          # Base sources are managed in
+          # /etc/apt/sources.list.d/sepia-mirror.sources (ceph-cm-ansible)
+        dest: /etc/apt/sources.list
+        owner: root
+        group: root
+        mode: 0644
+
+    - name: Remove stock ubuntu.sources (replaced by sepia-mirror.sources)
+      file:
+        path: /etc/apt/sources.list.d/ubuntu.sources
+        state: absent
+
 - name: Set apt preferences
   template:
     dest: "/etc/apt/preferences.d/ceph.pref"

--- a/roles/testnode/templates/apt/mirrorlist.j2
+++ b/roles/testnode/templates/apt/mirrorlist.j2
@@ -1,0 +1,12 @@
+# {{ ansible_managed }}
+# Ordered mirror list for APT's mirror method (referenced from
+# sepia-mirror.sources).  APT tries entries in priority order and falls
+# back automatically if the local mirror is unreachable or missing a
+# file — the APT equivalent of dnf trying baseurls in order.
+{% if ansible_architecture == "aarch64" %}
+https://{{ distro_mirror_host }}/ubuntu-ports/ priority:1
+http://ports.ubuntu.com/ubuntu-ports/
+{% else %}
+https://{{ distro_mirror_host }}/ubuntu/ priority:1
+http://archive.ubuntu.com/ubuntu/
+{% endif %}

--- a/roles/testnode/templates/apt/sepia-mirror.sources.j2
+++ b/roles/testnode/templates/apt/sepia-mirror.sources.j2
@@ -1,0 +1,11 @@
+# {{ ansible_managed }}
+# Mirror-first base Ubuntu sources: the local distro mirror is tried
+# first, with automatic fallback to the public archive.  Mirror order
+# lives in /etc/apt/mirrorlist.  Signatures are the stock Ubuntu archive
+# signatures (the mirror serves upstream metadata verbatim), verified
+# against the ubuntu-keyring shipped with the OS.
+Types: deb
+URIs: mirror+file:/etc/apt/mirrorlist
+Suites: {{ ansible_distribution_release }} {{ ansible_distribution_release }}-updates {{ ansible_distribution_release }}-security
+Components: main restricted universe multiverse
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg


### PR DESCRIPTION
Companion to #861, extending the mirror-first pattern to Ubuntu testnodes now that the internal distro mirror carries the jammy, noble, and resolute archives (ceph/sepia-openshift distro-mirror PR).

On mirrored releases (`distro_mirror_ubuntu_releases`, default jammy+noble+resolute) the stock apt sources are replaced with `sources.list.d/sepia-mirror.sources` (deb822) using APT's `mirror+file:` method: `/etc/apt/mirrorlist` lists the internal mirror at `priority:1` with the public archive after it, and APT fails over automatically when the mirror is unreachable or missing a file — the apt equivalent of the ordered dnf baseurls from #861.

Details:
- amd64 → `/ubuntu` (fallback archive.ubuntu.com); arm64 → `/ubuntu-ports` (fallback ports.ubuntu.com), matching the upstream archive split
- Signature verification unchanged: the mirror serves upstream metadata verbatim, so the stock `ubuntu-archive-keyring` validates it
- `-backports` dropped (not mirrored, not used by the suites)
- `Acquire::By-Hash "no"` because debmirror publishes canonical index paths, not `by-hash/`
- Non-mirrored releases keep their stock sources untouched