### PR TITLE
Speed up the users role

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,11 +3,32 @@
 # be changed when it lives in a production environment
 vault_password_file = ~/.vault_pass.txt
 timeout = 120
-callback_whitelist = profile_tasks
+# callback_whitelist was renamed in ansible-core 2.10; the old spelling is
+# silently ignored, so profile_tasks never actually loaded.
+callbacks_enabled = profile_tasks
 # default is 0.001, resulting in a storm of select(NULL, ..., 1ms) syscalls
 internal_poll_interval = 0.01
 # shut up about discovering python.  do what you gotta do.
 interpreter_python = auto_silent
+# default is 5, which throttles fleet-wide runs to five hosts at a time
+forks = 50
 
 [ssh_connection]
 retries = 5
+# Send the module over the existing ssh session instead of sftp'ing it to a
+# tempdir and executing it separately.  Roughly a 4x cut in ssh operations per
+# task, which dominates the per-user loops in the users role.  Safe here
+# because every provisioning path sets 'Defaults !requiretty'.
+#
+# NOTE: teuthology does not get its pipelining from this file.  It exports
+# ANSIBLE_SSH_PIPELINING=1 in teuthology/task/ansible.py (it has since 2015),
+# and environment variables take precedence over ansible.cfg, so teuthology
+# runs are pipelined whatever this setting says.  This line is what makes
+# manual ansible-playbook runs match.  If you change one, change the other.
+#
+# Beware when verifying: 'ansible-config dump' reports
+# ANSIBLE_PIPELINING(default) = False even when ssh pipelining is on -- that
+# is a separate global setting.  The one that matters is the ssh connection
+# plugin's, so check with:
+#   ansible-config dump --type connection | grep -A30 '^ssh:' | grep pipelining
+pipelining = True

--- a/roles/users/tasks/create_users.yml
+++ b/roles/users/tasks/create_users.yml
@@ -16,6 +16,7 @@
     append: yes
     home: "{{ ('teuthology' in group_names) | ternary('/tank/home', '/home') }}/{{ item.name }}"
   with_items: "{{ managed_admin_users }}"
+  when: item.name not in getent_passwd or item.name not in sudo_group_members
 
 - name: Create all users without sudo access.
   user:
@@ -24,3 +25,4 @@
     state: present
     home: "{{ ('teuthology' in group_names) | ternary('/tank/home', '/home') }}/{{ item.name }}"
   with_items: "{{ managed_users }}"
+  when: item.name not in getent_passwd

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -35,6 +35,11 @@
   tags:
     - always
 
+- import_tasks: read_state.yml
+  when: perform_users_role|bool
+  tags:
+    - always
+
 - import_tasks: create_users.yml
   when: perform_users_role|bool
   tags:

--- a/roles/users/tasks/read_state.yml
+++ b/roles/users/tasks/read_state.yml
@@ -1,0 +1,23 @@
+---
+# Reading passwd and the sudo group once lets create_users.yml and
+# revoke_users.yml skip their per-user 'user' module calls for accounts that are
+# already in the desired state. Each of those calls is a full round trip, so on
+# a testnode with ~300 managed users this replaces ~360 round trips with 2.
+- name: Read the existing passwd database
+  getent:
+    database: passwd
+
+- name: Read the existing sudo group
+  getent:
+    database: group
+    key: sudo
+    fail_key: false
+
+- name: Build the list of current sudo group members
+  set_fact:
+    sudo_group_members: >-
+      {{
+        (((getent_group | default({})).get('sudo') or ['', '', ''])[2]).split(',')
+        | select
+        | list
+      }}

--- a/roles/users/tasks/revoke_users.yml
+++ b/roles/users/tasks/revoke_users.yml
@@ -14,3 +14,4 @@
     name: "{{ item }}"
     state: absent
   with_items: "{{ revoked_users }}"
+  when: item in getent_passwd

--- a/roles/users/tasks/update_keys.yml
+++ b/roles/users/tasks/update_keys.yml
@@ -45,28 +45,29 @@
       }}
 
 # A missing pubkey shouldn't be fatal; the user simply doesn't get access.
+# The warning is about the keys repo rather than the host, so emit it once on
+# the controller instead of once per user per host.
 - name: Warn about users with no pubkey in the keys repo
   debug:
     msg: "WARNING: No pubkey found for '{{ item.name }}' in {{ keys_repo }}; skipping their authorized_keys."
   with_items: "{{ pubkey_users }}"
+  delegate_to: localhost
+  become: false
+  run_once: true
   when:
     - keys_repo is defined
     - item.key is undefined
     - item.name not in keys_repo_pubkeys
 
-- name: Update authorized_keys using the keys repo
+# NOTE: the key has to be a conditional expression rather than
+# "item.key | default(lookup(...))" -- Jinja evaluates default()'s argument
+# eagerly, so the lookup would run (and fail) for literal-key users who have no
+# file in the keys repo.
+- name: Update authorized_keys
   authorized_key:
     user: "{{ item.name }}"
-    key: "{{ lookup('file', keys_repo_path + '/ssh/' + item.name + '.pub') }}"
+    key: "{{ item.key if item.key is defined else lookup('file', keys_repo_path + '/ssh/' + item.name + '.pub') }}"
   with_items: "{{ pubkey_users }}"
-  when:
-    - item.key is undefined
-    - keys_repo is defined
-    - item.name in keys_repo_pubkeys
-
-- name: Update authorized_keys for each user with literal keys
-  authorized_key:
-    user: "{{ item.name }}"
-    key: "{{ item.key }}"
-  with_items: "{{ pubkey_users }}"
-  when: item.key is defined
+  when: >-
+    item.key is defined
+    or (keys_repo is defined and item.name in keys_repo_pubkeys)

--- a/users.yml
+++ b/users.yml
@@ -1,5 +1,7 @@
 ---
 - hosts: all
+  # The users role reads no ansible_* facts, so skip the setup module.
+  gather_facts: false
   roles:
     - users
   become: true


### PR DESCRIPTION
Cuts a forced `users` role run on a testnode from **572s to 82s**.

Measured on `trial147.front.sepia.ceph.com` (300 managed admin users, 61 revoked), in steady state, with `-e force_users_update=true`.

## Where the time went

The role made roughly 660 remote module calls per host per run — one `user` call per managed user, one `authorized_key` call per user, one `user` call per revoked user — regardless of whether anything had changed. Three tasks accounted for 97% of the runtime.

| Task | Baseline | + ansible.cfg | + role changes |
|---|---|---|---|
| Create all admin users | 254.6s | 72.1s | **0.8s** |
| Update authorized_keys | 250.1s | 75.0s | 73.5s |
| Remove revoked users | 50.6s | 13.8s | **0.2s** |
| Gathering Facts | 4.7s | 1.1s | *skipped* |
| **Total** | **572s** | **170s** | **82s** |

## ansible.cfg

Enables `pipelining`, which sends each module over the existing ssh session instead of sftp'ing it to a tempdir. The prerequisite has been in place since 2015 — 9e1c050 added `Defaults !requiretty` to the sudoers templates with the comment *"For ansible pipelining"* — but the setting itself was never turned on here.

**teuthology was already pipelined.** It exports `ANSIBLE_SSH_PIPELINING=1` in `teuthology/task/ansible.py` and has since 2015, and env vars beat `ansible.cfg`. So teuthology runs were already at roughly the 170s column; what this PR buys them is the role changes, 170s → 82s. The config change is what makes manual `ansible-playbook` runs match. There's a comment in the file recording that split so the two don't drift.

Also raises `forks` from the default of 5 (teuthology passes no `-f`, so it picks this up too), and fixes `callback_whitelist`, which was renamed in ansible-core 2.10 — the old spelling is silently ignored, so `profile_tasks` had never actually been loading.

## Role changes

A new `read_state.yml` reads passwd and the sudo group once with `getent`, letting `create_users.yml` and `revoke_users.yml` skip the per-user `user` calls for accounts already in the desired state.

The two `authorized_key` tasks are merged into one, and the missing-pubkey warning now runs once on the controller instead of once per user per host. The merged task needs a conditional expression rather than `item.key | default(lookup(...))` — Jinja evaluates `default()`'s argument eagerly, so the lookup would fire and fail for literal-key users with no file in the keys repo.

`users.yml` skips fact gathering; the role reads no `ansible_*` facts.

## Tradeoff worth a look during review

Accounts that already exist no longer get their shell and home reconciled on every run. Sudo group membership **is** still checked and repaired, and missing accounts are still created — but a manually changed shell or home directory will no longer be corrected. Reverting the `when:` in `create_users.yml` restores the old behavior at the cost of ~250s per run.

## Verification

On trial147, before/after `getent passwd`, `getent group sudo`, and md5sums of all 300 `authorized_keys` files are identical.

Drift repair was tested explicitly, since that's the real risk of skipping the `user` module:

- Removed `dgalloway` from the sudo group → re-added, other 299 skipped, 1.16s total
- Added a throwaway admin user → created, added to sudo, correctly warned about the missing pubkey
- Revoked that user → removed