### PR TITLE
wireguard: add role to manage a WireGuard gateway

### DIFF
--- a/roles/wireguard/README.rst
+++ b/roles/wireguard/README.rst
@@ -1,0 +1,149 @@
+wireguard
+=========
+
+This role can be used to set up a WireGuard gateway (e.g., soko01) as well as
+maintain the peer (user) list provided a secrets repo is configured.
+
+It does the following:
+
+- Installs and updates necessary packages
+- Enables IPv4 forwarding
+- Maintains the WireGuard config and peer list
+- Makes sure the ``wg-quick@$interface`` service is running and enabled
+
+Hosts should be added to the ``wireguard`` group in the inventory and the
+playbook run with::
+
+    ansible-playbook wireguard.yml
+
+To only update the peer list::
+
+    ansible-playbook wireguard.yml --tags users
+
+To preview peer changes without applying them::
+
+    ansible-playbook wireguard.yml --tags users --check --diff -e wireguard_force_diff=true
+
+The server's private key is stored in a separate file
+(``$wireguard_conf_dir/$wireguard_interface.key``, loaded via ``PostUp``)
+rather than in the config itself.  Because the config contains peer
+preshared keys, logging/diff output is suppressed unless
+``wireguard_force_diff=true`` is passed.
+
+The candidate config is validated with ``wg-quick strip`` before being
+installed, and peer changes are applied to the running interface with
+``wg syncconf`` so existing tunnels are not interrupted.
+
+Prerequisites
++++++++++++++
+
+- Ubuntu (any release with WireGuard in the kernel, i.e. 20.04+)
+
+Variables
++++++++++
+
+The WireGuard interface name.  This determines the config file name
+(``$wireguard_conf_dir/$wireguard_interface.conf``) and the systemd service
+(``wg-quick@$wireguard_interface``).  Defined in
+``roles/wireguard/defaults/main.yml``::
+
+    wireguard_interface: wg0
+
+The directory in which the WireGuard config should be saved.  Defined in
+``roles/wireguard/defaults/main.yml``::
+
+    wireguard_conf_dir: /etc/wireguard
+
+The UDP port WireGuard listens on.  Defined in
+``roles/wireguard/defaults/main.yml``::
+
+    wireguard_port: 51820
+
+Whether to enable IPv4 forwarding.  Defined in
+``roles/wireguard/defaults/main.yml``::
+
+    wireguard_ip_forward: true
+
+The server's tunnel address.  Defined in the secrets repo::
+
+    wireguard_address: []
+    # Example: wireguard_address: "192.168.100.1/24"
+
+The server's private key (``wg genkey``).  Written to
+``$wireguard_conf_dir/$wireguard_interface.key``.  Defined in the secrets
+repo and should be an ansible-vault encrypted value::
+
+    wireguard_private_key: !vault |
+      $ANSIBLE_VAULT;1.1;AES256
+      ...
+
+An optional MTU for the interface.  Defined in the secrets repo::
+
+    wireguard_mtu: []
+    # Example: wireguard_mtu: 1380
+
+Optional lists of commands to run when the interface comes up or goes down
+(e.g., firewall/NAT rules, traffic shaping).  Each entry becomes its own
+``PreUp``/``PostUp``/``PreDown``/``PostDown`` line and they are executed in
+order.  Defined in the secrets repo::
+
+    wireguard_preup: []
+    wireguard_postup: []
+    wireguard_predown: []
+    wireguard_postdown: []
+
+Peers come from two places, both defined in the secrets repo.
+``preshared_key``, ``endpoint``, and ``persistent_keepalive`` are optional
+per peer/device.
+
+Per-user peers are defined on the ``admin_users``/``lab_users`` entries in
+the inventory ``group_vars`` as a ``wireguard`` list of devices.  The
+``name`` on the user entry must match the username in keys.git::
+
+    lab_users:
+      - name: someuser
+        wireguard:
+          - name: "someuser's laptop"
+            public_key: "base64pubkey="
+            preshared_key: "base64psk="
+            allowed_ips: "192.168.100.2/32"
+          - name: "someuser's desktop"
+            public_key: "base64pubkey="
+            allowed_ips: "192.168.100.3/32"
+        email: "someuser@example.com"
+
+Peers not tied to a user account (other hosts, external users) go in the
+standalone list::
+
+    wireguard_peers: []
+
+    # Example:
+    wireguard_peers:
+      - name: some-host
+        public_key: "base64pubkey="
+        allowed_ips: "192.168.100.4/32"
+
+Tags
+++++
+
+packages
+    Install *and update* packages
+
+users
+    Update the WireGuard config/peer list and sync it to the running
+    interface without interrupting existing tunnels
+
+**NOTE:** Changes to ``[Interface]`` settings (``Address``, ``ListenPort``)
+are not applied by ``wg syncconf``; restart the service manually with
+``systemctl restart wg-quick@$interface`` to apply those (this drops
+existing tunnels).
+
+Dependencies
+++++++++++++
+
+This role depends on the following roles:
+
+secrets
+    Provides a var, ``secrets_path``, containing the path of the secrets
+    repository, a tree of ansible variable files.  This role expects a
+    ``wireguard.yml`` in that tree.

--- a/roles/wireguard/defaults/main.yml
+++ b/roles/wireguard/defaults/main.yml
@@ -1,0 +1,19 @@
+---
+# These defaults are present to allow certain tasks to no-op if a secrets repo
+# hasn't been defined. If you want to override these, do so in the secrets repo
+# itself.
+secrets_repo:
+  name: UNDEFINED
+  url: null
+
+wireguard_interface: wg0
+
+wireguard_conf_dir: /etc/wireguard
+
+wireguard_port: 51820
+
+# Enable IPv4 forwarding so peers can reach hosts behind the gateway
+wireguard_ip_forward: true
+
+# List of peers (users). Defined in the secrets repo. See README.rst
+wireguard_peers: []

--- a/roles/wireguard/handlers/main.yml
+++ b/roles/wireguard/handlers/main.yml
@@ -1,0 +1,19 @@
+---
+# Apply config changes (e.g., peer additions/removals) to the running
+# interface without tearing down existing tunnels
+# Strip first and only sync if that succeeded; piping a failed strip
+# straight into syncconf would wipe all peers
+- name: sync wireguard config
+  shell: |
+    set -euo pipefail
+    stripped="$(wg-quick strip {{ wireguard_interface }})"
+    wg syncconf {{ wireguard_interface }} /dev/stdin <<< "$stripped"
+  args:
+    executable: /bin/bash
+
+# Full restart. Drops existing tunnels; only needed for [Interface]
+# changes (Address, ListenPort, etc.)
+- name: restart wireguard
+  service:
+    name: "wg-quick@{{ wireguard_interface }}"
+    state: restarted

--- a/roles/wireguard/meta/main.yml
+++ b/roles/wireguard/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: secrets

--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -1,0 +1,58 @@
+---
+- name: Include secrets
+  include_vars: "{{ secrets_path | mandatory }}/wireguard.yml"
+  no_log: true
+  tags:
+    - always
+
+# The wg/wg-quick userland; the kernel module is in-tree on modern kernels.
+# Deliberately not the 'wireguard' meta-package from universe, which can
+# pull in wireguard-dkms
+- name: Install wireguard-tools
+  apt:
+    name: wireguard-tools
+    state: latest
+    update_cache: yes
+  tags:
+    - packages
+
+- name: Enable IPv4 forwarding
+  sysctl:
+    name: net.ipv4.ip_forward
+    value: "1"
+    sysctl_set: yes
+    state: present
+    reload: yes
+  when: wireguard_ip_forward|bool
+
+- name: Ensure config directory exists
+  file:
+    path: "{{ wireguard_conf_dir }}"
+    state: directory
+    mode: 0700
+
+# The private key is kept out of the main config (it's loaded via PostUp)
+# so the peer list can be diffed with --check --diff. Tagged users so the
+# key file the config references always exists when the config is written
+- name: Write WireGuard private key
+  copy:
+    content: "{{ wireguard_private_key }}\n"
+    dest: "{{ wireguard_conf_dir }}/{{ wireguard_interface }}.key"
+    owner: root
+    group: root
+    mode: 0600
+  no_log: true
+  notify: restart wireguard
+  tags:
+    - users
+
+# Manage WireGuard config and peer list using secrets repo
+- import_tasks: users.yml
+  tags:
+    - users
+
+- name: Make sure WireGuard service is running and enabled
+  service:
+    name: "wg-quick@{{ wireguard_interface }}"
+    state: started
+    enabled: yes

--- a/roles/wireguard/tasks/users.yml
+++ b/roles/wireguard/tasks/users.yml
@@ -1,0 +1,16 @@
+---
+- name: Update WireGuard config and peer list
+  template:
+    src: wg.conf.j2
+    dest: "{{ wireguard_conf_dir }}/{{ wireguard_interface }}.conf"
+    owner: root
+    group: root
+    mode: 0600
+    # wg-quick only accepts paths named like an interface, so the candidate
+    # config gets copied to a well-formed name before parsing it
+    validate: /bin/bash -c 'install -m 0600 "$1" /run/wgcheck.conf && wg-quick strip /run/wgcheck.conf > /dev/null' -- %s
+  # The config contains peer preshared keys, so logging/diff output is
+  # suppressed by default. Pass -e wireguard_force_diff=true to see the
+  # diff anyway (e.g., with --check --diff to preview peer changes)
+  no_log: "{{ not wireguard_force_diff|default(false)|bool }}"
+  notify: sync wireguard config

--- a/roles/wireguard/templates/wg.conf.j2
+++ b/roles/wireguard/templates/wg.conf.j2
@@ -1,0 +1,57 @@
+# {{ ansible_managed }}
+[Interface]
+Address = {{ wireguard_address }}
+ListenPort = {{ wireguard_port }}
+{% if wireguard_mtu is defined %}
+MTU = {{ wireguard_mtu }}
+{% endif %}
+{% for cmd in wireguard_preup|default([]) %}
+PreUp = {{ cmd }}
+{% endfor %}
+PostUp = wg set %i private-key {{ wireguard_conf_dir }}/%i.key
+{% for cmd in wireguard_postup|default([]) %}
+PostUp = {{ cmd }}
+{% endfor %}
+{% for cmd in wireguard_predown|default([]) %}
+PreDown = {{ cmd }}
+{% endfor %}
+{% for cmd in wireguard_postdown|default([]) %}
+PostDown = {{ cmd }}
+{% endfor %}
+
+{# Peers tied to user accounts (wireguard key on lab_users/admin_users entries) #}
+{% for user in admin_users|default([])|list + lab_users|default([])|list %}
+{% for device in user.wireguard|default([]) %}
+# {{ user.name }} ({{ device.name }})
+[Peer]
+PublicKey = {{ device.public_key }}
+{% if device.preshared_key is defined %}
+PresharedKey = {{ device.preshared_key }}
+{% endif %}
+AllowedIPs = {{ device.allowed_ips }}
+{% if device.endpoint is defined %}
+Endpoint = {{ device.endpoint }}
+{% endif %}
+{% if device.persistent_keepalive is defined %}
+PersistentKeepalive = {{ device.persistent_keepalive }}
+{% endif %}
+
+{% endfor %}
+{% endfor %}
+{# Standalone peers not tied to a user account (hosts, external users) #}
+{% for peer in wireguard_peers %}
+# {{ peer.name }}
+[Peer]
+PublicKey = {{ peer.public_key }}
+{% if peer.preshared_key is defined %}
+PresharedKey = {{ peer.preshared_key }}
+{% endif %}
+AllowedIPs = {{ peer.allowed_ips }}
+{% if peer.endpoint is defined %}
+Endpoint = {{ peer.endpoint }}
+{% endif %}
+{% if peer.persistent_keepalive is defined %}
+PersistentKeepalive = {{ peer.persistent_keepalive }}
+{% endif %}
+
+{% endfor %}

--- a/wireguard.yml
+++ b/wireguard.yml
@@ -1,0 +1,6 @@
+---
+- hosts: wireguard
+  roles:
+    - common
+    - wireguard
+  become: true


### PR DESCRIPTION
## What

Adds a `wireguard` role (modeled on the `gateway` role) and a top-level `wireguard.yml` playbook targeting a `wireguard` inventory group. Intended for soko01 (Ubuntu). Companion secrets PR: ceph/ceph-sepia-secrets#1186.

The role:
- Installs the `wireguard` package via apt
- Enables IPv4 forwarding
- Writes the vault-encrypted server private key to `/etc/wireguard/$interface.key` (loaded via `PostUp`, kept out of the main config)
- Templates `/etc/wireguard/$interface.conf`: interface settings (address, port, optional MTU, PreUp/PostUp/PreDown/PostDown hook lists) plus peers
- Ensures `wg-quick@$interface` is running and enabled

Peers come from two sources: a `wireguard:` device list on each `admin_users`/`lab_users` entry (usernames matching keys.git), and a standalone `wireguard_peers` list for hosts/external users.

## Usage

Full setup:
```
ansible-playbook wireguard.yml
```

Update just the peer list (and preview first):
```
ansible-playbook wireguard.yml --tags users --check --diff -e wireguard_force_diff=true
ansible-playbook wireguard.yml --tags users
```

## Notes for reviewers

- Peer updates are applied with `wg syncconf` (strip-then-sync, fail-fast) so existing tunnels are never dropped. The naive `wg syncconf wg0 <(wg-quick strip wg0)` form was deliberately avoided: if `strip` fails, `syncconf` reads an empty stream and removes every peer.
- The candidate config is validated with `wg-quick strip` (via `template`'s `validate:`) before replacing the live one.
- The config contains peer preshared keys, so the template task is `no_log` unless `wireguard_force_diff=true` is passed.
- Round-trip verified against soko01: rendering the template from the secrets-PR vars reproduces the live `wg0.conf` semantically exactly (interface + all 125 peers), so the first run should only change file layout (key moves to `wg0.key`), not tunnel behavior.

See `roles/wireguard/README.rst` for full variable documentation.