### PR TITLE
testnode: stage Micron NVMe firmware instead of activating it live

### DIFF
--- a/roles/testnode/tasks/check-micron-nvme-firmware.yml
+++ b/roles/testnode/tasks/check-micron-nvme-firmware.yml
@@ -15,8 +15,10 @@
       current_fw="$(echo "$id_ctrl" | sed -n 's/^fr[[:space:]]*:[[:space:]]*//p' | head -n1 | xargs)"
       subnqn="$(echo "$id_ctrl" | sed -n 's/^subnqn[[:space:]]*:[[:space:]]*//p' | head -n1 | xargs)"
 
-      echo "$model $subnqn" | grep -qi micron || continue
-
+      # The model allowlist below is the real Micron gate; a generic
+      # "grep -i micron" test breaks on drives like the 7500 whose model
+      # string (MTFDKCC1T9TGP) doesn't contain "Micron" and whose subnqn
+      # is empty
       case "$model" in
         *Micron_7450*) family="7450" ;;
         *MTFDKCC1T9TGP*) family="7500" ;;
@@ -35,7 +37,13 @@
       echo "$dev model=$model current=$current_fw latest=$latest_fw"
 
       if [ "$current_fw" != "$latest_fw" ]; then
-        echo "UPDATE_NEEDED: $dev $current_fw -> $latest_fw"
+        # If the target firmware is already staged in a slot it will
+        # activate at the next reboot; don't re-flash on every job
+        if nvme fw-log "$dev" 2>/dev/null | grep -q "$latest_fw"; then
+          echo "PENDING_RESET: $dev $current_fw -> $latest_fw staged, awaiting reboot"
+        else
+          echo "UPDATE_NEEDED: $dev $current_fw -> $latest_fw"
+        fi
       fi
     done
 

--- a/roles/testnode/tasks/micron_nvme_firmware.yml
+++ b/roles/testnode/tasks/micron_nvme_firmware.yml
@@ -59,12 +59,9 @@
       echo "Current firmware: $current_fw"
       echo "SubNQN: $subnqn"
 
-      echo "$model $subnqn" | grep -qi micron
-      if [ "$?" -ne 0 ]; then
-        echo "SKIP: $dev is not detected as Micron"
-        continue
-      fi
-
+      # The model allowlist below is the real Micron gate; a generic
+      # "grep -i micron" test is fragile when the model string lacks
+      # "Micron" (7500 = MTFDKCC1T9TGP) and subnqn reads back empty
       case "$model" in
         *Micron_7450*)
           family="7450"
@@ -97,6 +94,11 @@
 
       if [ "$current_fw" = "$target_fw" ]; then
         echo "SKIP: $dev already running $target_fw"
+        continue
+      fi
+
+      if nvme fw-log "$dev" 2>/dev/null | grep -q "$target_fw"; then
+        echo "SKIP: $target_fw already staged on $dev, activates at next reboot"
         continue
       fi
 
@@ -136,18 +138,38 @@
         continue
       fi
 
-      echo "Running: nvme $NVME_COMMIT_CMD $target_dev -s $SLOT -a 3"
-      fw_commit_output="$(nvme "$NVME_COMMIT_CMD" "$target_dev" -s "$SLOT" -a 3 2>&1)"
+      # Stage the update instead of activating it live: commit the
+      # downloaded image to the slot (-a 0), then schedule activation at
+      # the next controller reset (-a 2). Immediate activation (-a 3)
+      # against a drive the OS is using can drop the controller out from
+      # under the running system; it bricked the trial114/trial195 boot
+      # drives on 2026-08-13. Testnodes reboot at every reimage, so the
+      # staged firmware takes effect on the next job cycle.
+      echo "Running: nvme $NVME_COMMIT_CMD $target_dev -s $SLOT -a 0"
+      fw_commit_output="$(nvme "$NVME_COMMIT_CMD" "$target_dev" -s "$SLOT" -a 0 2>&1)"
       fw_commit_rc=$?
       echo "$fw_commit_output"
 
       if [ "$fw_commit_rc" -ne 0 ]; then
-        echo "FATAL: $NVME_COMMIT_CMD failed for $target_dev"
+        echo "FATAL: $NVME_COMMIT_CMD -a 0 (commit to slot) failed for $target_dev"
         firmware_update_failed=1
         continue
       fi
 
-      echo "UPDATED: $target_dev $model $current_fw -> $target_fw"
+      echo "Running: nvme $NVME_COMMIT_CMD $target_dev -s $SLOT -a 2"
+      fw_activate_output="$(nvme "$NVME_COMMIT_CMD" "$target_dev" -s "$SLOT" -a 2 2>&1)"
+      fw_activate_rc=$?
+      echo "$fw_activate_output"
+
+      # A "firmware requires ... reset" status here is success: the
+      # image is committed and will activate at the reset it asks for
+      if [ "$fw_activate_rc" -ne 0 ] && ! echo "$fw_activate_output" | grep -qi "reset"; then
+        echo "FATAL: $NVME_COMMIT_CMD -a 2 (activate at next reset) failed for $target_dev"
+        firmware_update_failed=1
+        continue
+      fi
+
+      echo "STAGED: $target_dev $model $current_fw -> $target_fw (activates at next reboot)"
     done
 
     if [ "$firmware_update_failed" -ne 0 ]; then
@@ -160,7 +182,7 @@
   args:
     executable: /bin/bash
   register: micron_nvme_firmware_update
-  changed_when: "'UPDATED:' in micron_nvme_firmware_update.stdout"
+  changed_when: "'STAGED:' in micron_nvme_firmware_update.stdout"
 
 - name: Show Micron NVMe firmware update output
   debug:


### PR DESCRIPTION
## What changed

Micron NVMe firmware updates are now **staged instead of activated live**, for every drive including the boot drive:

- `fw-commit -s $SLOT -a 0` commits the downloaded image to the slot, then `fw-commit -s $SLOT -a 2` schedules activation at the next controller reset. No more `-a 3` (activate immediately). Testnodes reboot at every reimage, so staged firmware takes effect on the next job cycle.
- Both the check and update scripts consult `nvme fw-log` and report `PENDING_RESET`/`SKIP` when the target firmware is already staged, so nodes awaiting their activation reboot aren't re-flashed on every job.
- A "requires reset" status from `fw-commit -a 2` is treated as success (the commit landed; activation happens at the reset it names).
- The fragile `grep -i micron` pre-filter is gone; the per-model `case` allowlist is the real gate and keeps working when `subnqn` reads back empty.

## Why

On 2026-08-13, post-reimage ansible runs live-flashed the Micron 7450 **boot** drives of trial114 and trial195 (`E2MU200` → `E2MU300`) with `nvme fw-commit -s 2 -a 3` while the OS was running from them. `fw-commit` returned `Input/output error` and both drives dropped off PCIe — no re-enumeration even after IPMI power cycles, leaving the nodes in an endless FOG deploy loop (`Fatal: No valid drives found for 'Host Primary Disk'='960197124096'`). Redfish/NVMe-MI shows both drives actually took the flash (reporting E2MU300, healthy) — the immediate activation killed the PCIe link out from under the running OS.

The task had been merged since mid-July but only went live when teuthology's ceph-cm-ansible pin was lifted 2026-08-12. `nvme fw-log` across the fleet shows ~83 nodes survived the identical live `E2MU200`→`E2MU300` transition — the bricks are the ~2% tail risk of immediate activation racing live I/O, which staging eliminates.

A Redfish sweep of all 200 trial BMCs found 25 nodes still on `E2MU200`; every schedulable one is marked down in paddles until this merges, after which their first job cycle stages + activates them safely.