### PR TITLE
fog-server: manage FOS capture/deploy hooks

### DIFF
--- a/roles/fog-server/files/clean_cephlab_flags.sh
+++ b/roles/fog-server/files/clean_cephlab_flags.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Sourced by fog.postinit inside the FOG (FOS) boot environment.
+# Before a Capture task, remove cephlab first-boot flag files and logs from
+# the target filesystems.  prep-fog-capture.yml already removes these, but
+# the OS keeps running between that playbook and the capture reboot, and a
+# NetworkManager dispatcher event in that window can recreate them --
+# baking the capture host's hostname into the image (deployed nodes then
+# skip hostname configuration and come up as the capture host).  Removing
+# them here is deterministic: no OS is running to recreate them.
+if [[ "$type" == "up" ]]; then
+  mnt=/tmp/cleanflags
+  mkdir -p $mnt
+  for part in $(blkid -o device | grep "^${hd}"); do
+    fstype=$(blkid -o value -s TYPE "$part")
+    case "$fstype" in
+      ext2|ext3|ext4|xfs)
+        if mount "$part" $mnt 2>/dev/null; then
+          rm -f \
+            $mnt/.cephlab_net_configured \
+            $mnt/.cephlab_hostname_set \
+            $mnt/ceph-qa-ready \
+            $mnt/etc/udev/rules.d/70-persistent-net.rules \
+            $mnt/var/log/cephlab-set-hostname.log \
+            $mnt/var/log/nm-from-link.log \
+            $mnt/var/log/netplan-from-link.log
+          umount $mnt
+        fi
+        ;;
+    esac
+  done
+fi

--- a/roles/fog-server/files/fsck_before_capture.sh
+++ b/roles/fog-server/files/fsck_before_capture.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Sourced by fog.postinit inside the FOG (FOS) boot environment.
+# Before a Capture task, force-fsck the target disk's filesystems so
+# partclone/resize2fs start from a clean filesystem.
+# The sepia-fog-images job in ceph-build.git relies on this hook to fsck
+# root filesystems without an extra reboot into a rescue environment.
+if [[ "$type" == "up" ]]; then
+  for part in $(blkid -o device | grep "^${hd}"); do
+    fstype=$(blkid -o value -s TYPE "$part")
+    case "$fstype" in
+      ext2|ext3|ext4)
+        e2fsck -fp "$part" || e2fsck -fy "$part" || true
+        ;;
+      xfs)
+        xfs_repair "$part" || true
+        ;;
+    esac
+  done
+fi

--- a/roles/fog-server/files/inject_jenkins_key.sh
+++ b/roles/fog-server/files/inject_jenkins_key.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Sourced by fog.postdownload inside the FOG (FOS) environment after a
+# Deploy task writes the image to disk.  Ensures the jenkins-build@soko04
+# key (also in ceph-sepia-secrets group_vars/all.yml) is present on the
+# deployed filesystem so the sepia-fog-images job in ceph-build.git can
+# reach nodes deployed from images captured before the key existed.
+if [[ "$type" == "down" ]]; then
+  jbkey='ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGRpTKfYlFn7eSAprIL+ENT/cIgGV7uvSt+Fgnzuy1nM jenkins-build@soko04.front.sepia.ceph.com'
+  mnt=/tmp/keyinject
+  mkdir -p $mnt
+  for part in $(blkid -o device | grep "^${hd}"); do
+    fstype=$(blkid -o value -s TYPE "$part")
+    case "$fstype" in
+      ext2|ext3|ext4|xfs)
+        if mount "$part" $mnt 2>/dev/null; then
+          ak="$mnt/home/ubuntu/.ssh/authorized_keys"
+          if [ -f "$ak" ] && ! grep -qF "jenkins-build@soko04" "$ak"; then
+            echo "$jbkey" >> "$ak"
+          fi
+          umount $mnt
+        fi
+        ;;
+    esac
+  done
+fi

--- a/roles/fog-server/tasks/hooks.yml
+++ b/roles/fog-server/tasks/hooks.yml
@@ -1,0 +1,47 @@
+---
+# FOS-environment hooks sourced during FOG capture/deploy tasks.  The
+# sepia-fog-images job in ceph-build.git relies on both:
+# - fsck_before_capture.sh fscks the root fs right before a capture, so no
+#   extra reboot into a rescue environment is needed
+# - inject_jenkins_key.sh lets the job ssh to nodes deployed from images
+#   captured before the jenkins-build key existed
+
+- name: Ensure postinit and postdownload script dirs exist
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "{{ fog_user }}"
+    group: "{{ fog_user }}"
+    mode: "0775"
+  loop:
+    - /images/dev/postinitscripts
+    - /images/postdownloadscripts
+
+- name: Install FOS hook scripts
+  copy:
+    src: "{{ item.script }}"
+    dest: "{{ item.dir }}/{{ item.script }}"
+    owner: "{{ fog_user }}"
+    group: "{{ fog_user }}"
+    mode: "0755"
+  loop:
+    - { script: fsck_before_capture.sh, dir: /images/dev/postinitscripts }
+    - { script: inject_jenkins_key.sh, dir: /images/postdownloadscripts }
+
+- name: Source fsck_before_capture.sh from fog.postinit
+  lineinfile:
+    path: /images/dev/postinitscripts/fog.postinit
+    line: ". ${postinitpath}fsck_before_capture.sh"
+    create: yes
+    owner: "{{ fog_user }}"
+    group: "{{ fog_user }}"
+    mode: "0755"
+
+- name: Source inject_jenkins_key.sh from fog.postdownload
+  lineinfile:
+    path: /images/postdownloadscripts/fog.postdownload
+    line: ". ${postdownpath}inject_jenkins_key.sh"
+    create: yes
+    owner: "{{ fog_user }}"
+    group: "{{ fog_user }}"
+    mode: "0755"

--- a/roles/fog-server/tasks/hooks.yml
+++ b/roles/fog-server/tasks/hooks.yml
@@ -26,16 +26,20 @@
     mode: "0755"
   loop:
     - { script: fsck_before_capture.sh, dir: /images/dev/postinitscripts }
+    - { script: clean_cephlab_flags.sh, dir: /images/dev/postinitscripts }
     - { script: inject_jenkins_key.sh, dir: /images/postdownloadscripts }
 
-- name: Source fsck_before_capture.sh from fog.postinit
+- name: Source postinit scripts from fog.postinit
   lineinfile:
     path: /images/dev/postinitscripts/fog.postinit
-    line: ". ${postinitpath}fsck_before_capture.sh"
+    line: ". ${postinitpath}{{ item }}"
     create: yes
     owner: "{{ fog_user }}"
     group: "{{ fog_user }}"
     mode: "0755"
+  loop:
+    - clean_cephlab_flags.sh
+    - fsck_before_capture.sh
 
 - name: Source inject_jenkins_key.sh from fog.postdownload
   lineinfile:

--- a/roles/fog-server/tasks/main.yml
+++ b/roles/fog-server/tasks/main.yml
@@ -46,3 +46,6 @@
   file:
     path: "/home/{{ fog_user }}/temp_settings"
     state: absent
+
+# Safe to run on a live FOG server; not gated behind fog_force
+- import_tasks: hooks.yml


### PR DESCRIPTION
Codifies the two FOS hooks the reworked [sepia-fog-images job](https://github.com/ceph/ceph-build/pull/2678) relies on, currently hand-installed on soko03:

- **`/images/dev/postinitscripts/fsck_before_capture.sh`** — force-fscks the target disk's filesystems inside the FOS environment right before a Capture task (`$type == up`), so captures start from a clean filesystem with no extra rescue-boot round trip.
- **`/images/postdownloadscripts/inject_jenkins_key.sh`** — after a Deploy task (`$type == down`), mounts the deployed filesystem and appends the jenkins-build@soko04 pubkey (the same one in ceph-sepia-secrets `group_vars/all.yml`) to `ubuntu`'s authorized_keys, so the Jenkins job can reach nodes deployed from images that predate the key.

Both are wired in via `lineinfile` on `fog.postinit`/`fog.postdownload` and are idempotent/safe on a live FOG server, so they run unconditionally rather than behind `fog_force`.

Deployed state on soko03 already matches these files (verified by sepia-fog-images pipeline builds 1 and 5).