### PR TITLE
fog-server: sideline stale EFI dirs on foreign ESPs after deploy

### DIFF
--- a/roles/fog-server/files/clean_foreign_boot.sh
+++ b/roles/fog-server/files/clean_foreign_boot.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Sourced by fog.postdownload inside the FOG (FOS) environment after a
+# Deploy task writes the image to disk.  Sidelines EFI bootloader files on
+# ESPs of disks OTHER than the deploy target so stale installs (e.g. an old
+# MAAS deployment on a repurposed node) can't hijack the UEFI boot order.
+# Without this, the firmware/rEFInd can chainload the leftover install's
+# GRUB, whose BLS entries reference filesystems the deploy just destroyed
+# (observed as a kernel panic: VFS unable to mount root fs).
+# The directory is renamed, not deleted, so this is reversible.
+# Only runs for smithi/trial testnodes (which includes trial-perf); other
+# FOG-managed hosts are left alone.
+if [[ "$type" == "down" ]]; then
+  case "$hostname" in
+    trial*|smithi*)
+      mnt=/tmp/foreignesp
+      mkdir -p $mnt
+      for part in $(blkid -o device); do
+        case "$part" in
+          ${hd}*) continue ;;
+        esac
+        fstype=$(blkid -o value -s TYPE "$part")
+        if [[ "$fstype" == "vfat" ]]; then
+          if mount "$part" $mnt 2>/dev/null; then
+            if [[ -d $mnt/EFI ]]; then
+              echo "Sidelining stale EFI dir on foreign ESP $part"
+              rm -rf $mnt/EFI.stale
+              mv $mnt/EFI $mnt/EFI.stale
+            fi
+            umount $mnt
+          fi
+        fi
+      done
+      ;;
+  esac
+fi

--- a/roles/fog-server/tasks/hooks.yml
+++ b/roles/fog-server/tasks/hooks.yml
@@ -28,6 +28,7 @@
     - { script: fsck_before_capture.sh, dir: /images/dev/postinitscripts }
     - { script: clean_cephlab_flags.sh, dir: /images/dev/postinitscripts }
     - { script: inject_jenkins_key.sh, dir: /images/postdownloadscripts }
+    - { script: clean_foreign_boot.sh, dir: /images/postdownloadscripts }
 
 - name: Source postinit scripts from fog.postinit
   lineinfile:
@@ -41,11 +42,14 @@
     - clean_cephlab_flags.sh
     - fsck_before_capture.sh
 
-- name: Source inject_jenkins_key.sh from fog.postdownload
+- name: Source postdownload scripts from fog.postdownload
   lineinfile:
     path: /images/postdownloadscripts/fog.postdownload
-    line: ". ${postdownpath}inject_jenkins_key.sh"
+    line: ". ${postdownpath}{{ item }}"
     create: yes
     owner: "{{ fog_user }}"
     group: "{{ fog_user }}"
     mode: "0755"
+  loop:
+    - inject_jenkins_key.sh
+    - clean_foreign_boot.sh


### PR DESCRIPTION
Follow-up to #867 (this commit landed on that branch after it merged, so re-branched from main).

After a Deploy task, renames `EFI` → `EFI.stale` on ESPs of disks **other than the deploy target**, so a repurposed node's leftover install (e.g. a prior MAAS deployment) can't hijack UEFI boot into a GRUB whose BLS entries reference filesystems the deploy just destroyed (the trial-perf003/004 `VFS: unable to mount root fs` panic).

Scoped per review feedback: only runs for `trial*`/`smithi*` hosts (covers trial-perf), never touches the deploy target disk, and renames instead of deleting so it's reversible.