### PR TITLE
wireguard: never let a config sync drop the interface's private key

### DIFF
--- a/roles/wireguard/handlers/main.yml
+++ b/roles/wireguard/handlers/main.yml
@@ -1,15 +1,46 @@
 ---
 # Apply config changes (e.g., peer additions/removals) to the running
-# interface without tearing down existing tunnels
-# Strip first and only sync if that succeeded; piping a failed strip
-# straight into syncconf would wipe all peers
+# interface without tearing down existing tunnels.
+#
+# INCIDENT 2026-08-17: `wg syncconf` REPLACES the interface's entire config
+# from its input, and `wg-quick strip` drops PostUp lines. Because the
+# rendered wg.conf deliberately carries no PrivateKey (it is loaded by
+# `PostUp = wg set %i private-key %i.key`), syncing the stripped conf left
+# the live interface with NO private key -- every peer's handshake failed
+# and the lab lost VPN until the key was re-set by hand from the console.
+#
+# So: strip, then re-append the private key from the key file, verify the
+# resulting config still yields the public key the interface has NOW, and
+# only then sync. Any failure leaves the running interface untouched.
 - name: sync wireguard config
   shell: |
     set -euo pipefail
-    stripped="$(wg-quick strip {{ wireguard_interface }})"
-    wg syncconf {{ wireguard_interface }} /dev/stdin <<< "$stripped"
+    iface="{{ wireguard_interface }}"
+    keyfile="{{ wireguard_conf_dir }}/${iface}.key"
+    stripped="$(wg-quick strip "$iface")"
+    if grep -q '^PrivateKey' <<< "$stripped"; then
+      conf="$stripped"
+    else
+      # Insert the key right after [Interface] so syncconf keeps it.
+      conf="$(awk -v key="$(cat "$keyfile")" \
+        '{print} /^\[Interface\]/ && !done {print "PrivateKey = " key; done=1}' <<< "$stripped")"
+    fi
+    want="$(wg show "$iface" public-key)"
+    have="$(grep '^PrivateKey' <<< "$conf" | head -1 | awk '{print $3}' | wg pubkey)"
+    if [ "$want" != "(none)" ] && [ "$want" != "$have" ]; then
+      echo "refusing to sync: config public key $have != live $want" >&2
+      exit 1
+    fi
+    wg syncconf "$iface" /dev/stdin <<< "$conf"
+    after="$(wg show "$iface" public-key)"
+    if [ "$after" != "$have" ]; then
+      echo "post-sync public key mismatch; restoring from key file" >&2
+      wg set "$iface" private-key "$keyfile"
+      exit 1
+    fi
   args:
     executable: /bin/bash
+  no_log: true
 
 # Full restart. Drops existing tunnels; only needed for [Interface]
 # changes (Address, ListenPort, etc.)

--- a/roles/wireguard/tasks/main.yml
+++ b/roles/wireguard/tasks/main.yml
@@ -34,15 +34,36 @@
 # The private key is kept out of the main config (it's loaded via PostUp)
 # so the peer list can be diffed with --check --diff. Tagged users so the
 # key file the config references always exists when the config is written
+#
+# Resolve the (vaulted) key into a plain fact first: on ansible-core 2.17,
+# passing a !vault value straight into copy's content under no_log fails
+# during result censoring, which is opaque and led to the 2026-08-17 outage
+# investigation. Also: a key change must NOT restart the service (that
+# drops every tunnel); `wg set` applies it live, and the restart handler is
+# reserved for genuine [Interface] changes.
+- name: Resolve WireGuard private key
+  set_fact:
+    _wg_private_key: "{{ wireguard_private_key | string | trim }}"
+  no_log: true
+  tags:
+    - users
+
+- name: Refuse to proceed without a WireGuard private key
+  fail:
+    msg: "wireguard_private_key is empty/undefined; refusing to touch the gateway"
+  when: _wg_private_key | length < 40
+  tags:
+    - users
+
 - name: Write WireGuard private key
   copy:
-    content: "{{ wireguard_private_key }}\n"
+    content: "{{ _wg_private_key }}\n"
     dest: "{{ wireguard_conf_dir }}/{{ wireguard_interface }}.key"
     owner: root
     group: root
     mode: 0600
   no_log: true
-  notify: restart wireguard
+  notify: sync wireguard config
   tags:
     - users
 

--- a/roles/wireguard/templates/wg.conf.j2
+++ b/roles/wireguard/templates/wg.conf.j2
@@ -8,6 +8,10 @@ MTU = {{ wireguard_mtu }}
 {% for cmd in wireguard_preup|default([]) %}
 PreUp = {{ cmd }}
 {% endfor %}
+{# The key lives in the conf too (not only via PostUp): `wg-quick strip`
+   drops PostUp lines, so a strip|syncconf with only the PostUp form left
+   the live interface keyless on 2026-08-17. Belt and braces: both. #}
+PrivateKey = {{ _wg_private_key | default(wireguard_private_key) | string | trim }}
 PostUp = wg set %i private-key {{ wireguard_conf_dir }}/%i.key
 {% for cmd in wireguard_postup|default([]) %}
 PostUp = {{ cmd }}


### PR DESCRIPTION
**Incident 2026-08-17:** the wireguard gateway (soko01) lost its private key on a config sync — `wg show wg0 public-key` returned `(none)`, all 127 peers' handshakes failed, lab VPN was down ~20 min until the key was re-set from the console.

**Root cause is in the role, not the trigger.** The rendered `wg.conf` deliberately has no `PrivateKey` (it's loaded by `PostUp = wg set %i private-key %i.key`). But `wg-quick strip` drops PostUp lines and `wg syncconf` *replaces* the interface config from its input — so the `sync wireguard config` handler (or the identical strip|syncconf done by hand) unsets the key every time it fires on a live interface. It only ever needed a changed conf to trigger.

Three independent fixes:
1. **template** — `PrivateKey` written into `wg.conf` explicitly as well as via PostUp; a raw strip|syncconf now keeps it.
2. **handler** — after strip, re-insert the key from the key file if absent; verify the candidate's public key matches the *live* interface's before syncing; verify the identity survived after; on any mismatch restore from the key file and fail. Failure leaves the running interface untouched.
3. **key task** — resolve the vaulted value via `set_fact` first (ansible-core 2.17 fails opaquely passing `!vault` content into `copy` under `no_log` — this is what sent us debugging in the first place), fail fast on an empty key, and notify the *sync* handler rather than a full restart (a key-file change must never drop every tunnel).

`--check --diff` against soko01 with these changes: the only diff is `+PrivateKey = …`.

Related: the onboarding service's post-merge Job no longer runs this role at all until this merges and a supervised first run proves it (see ceph/sepia-openshift#56).