### PR TITLE
prep-fog-capture: keep dnf updates within the current point release

### DIFF
--- a/tools/roles/prep-fog-capture/tasks/rpm.yml
+++ b/tools/roles/prep-fog-capture/tasks/rpm.yml
@@ -1,9 +1,18 @@
 ---
+# Stay within the point release the image is already running.  Rocky's
+# default $releasever tracks the newest minor (the /pub/rocky/10/ symlink),
+# so an unpinned `state: latest` walks a rocky_10.1 image up to 10.2 during
+# capture prep and the captured image no longer matches its name.
+# Override deliberately to move an image between point releases, e.g.
+#   ansible-playbook ... -e fog_capture_releasever=10.2
+# or pass the major version (-e fog_capture_releasever=10) for the old
+# always-latest behavior.
 - name: Upgrade all packages to latest (dnf)
   dnf:
     name: "*"
     state: latest
     update_cache: true
+    releasever: "{{ fog_capture_releasever | default(ansible_facts.distribution_version) }}"
   when: ansible_facts.os_family == "RedHat"
 
 - name: Ensure dnf-utils present (for needs-restarting)


### PR DESCRIPTION
`prep-fog-capture.yml` runs an unconditional `dnf update`, so capturing "rocky_10.1" silently produces a 10.2 image — the current `trial_rocky_10.1` FOG image runs an `el10_2` kernel today, and teuthology hands it to jobs that asked for 10.1.

This pins `releasever` to the version the node is already running, so a capture preserves its point release. Moving between point releases becomes explicit:

```
ansible-playbook ... -e fog_capture_releasever=10.2
```

## Where this helps, and where it can't

The pin only affects repos whose URLs contain `$releasever`:

| repo config | effect |
|---|---|
| stock `rocky.repo` (`mirrorlist=...repo=BaseOS-$releasever`) | **fixes the drift** — verified `repo=BaseOS-10.1` returns live mirrors serving `/10.1/`, and dl.rockylinux.org keeps 10.0/10.1/10.2 next to the floating `10` |
| internal `distro-mirror` (`/rocky/10/`, major hardcoded) | **no-op** — no `$releasever` in the URL, so nothing changes and nothing breaks |
| CentOS Stream / Debian family | no-op (Stream URLs use `$stream`; apt sources are codename-pinned) |

So it's safe everywhere, but it is **not a complete fix for nodes using the internal mirror**: `https://distro-mirror.front.sepia.ceph.com/rocky/` carries only `10/`, and that tree is currently 10.2 content. A node updating against it gets 10.2 no matter what `releasever` says.

To actually hold a point release lab-wide, one of:

1. **Sync point-release trees on distro-mirror** (`/rocky/10.1/`, `/rocky/10.2/`) so the pinned URLs resolve internally — then this PR is sufficient.
2. **Name the images for what the mirror can deliver** (`rocky_10` rather than `rocky_10.1`) and accept tracking the newest minor.

Also worth noting for in-flight work: the WIP `roles/testnode/templates/mirrorlists/` templates build URLs from `ansible_distribution_major_version` (`/rocky/10/...`), which would keep testnodes on the floating tree regardless of this pin — they'd want `ansible_distribution_version` if option 1 is the direction.

Independently, the existing `trial_rocky_10.1`/`smithi_rocky_10.1` images are **already at 10.2** and need a one-time decision: rename them to `rocky_10.2`/`rocky_10`, or `dnf distro-sync --releasever=10.1` back down and recapture.