### PR TITLE
testnode: pin Rocky repos to the deployed minor version

### DIFF
--- a/roles/testnode/vars/rocky_10.yml
+++ b/roles/testnode/vars/rocky_10.yml
@@ -1,6 +1,21 @@
 ---
 # vars specific to any rocky 10.x version
 
+# The BaseOS/AppStream/CRB baseurls below use ansible_distribution_version (the
+# full 10.x) rather than the major version on purpose.  Upstream's /rocky/10 is
+# a symlink to the newest point release, so pointing at it lets a routine
+# `dnf update` walk a node from 10.1 to 10.2 -- which is how the rocky_10.1 FOG
+# image ended up containing an el10_2 kernel.  Pinning the baseurl to the minor
+# keeps a node on the point release it was deployed with.
+#
+# Pinning here rather than in /etc/dnf/vars/releasever is deliberate: releasever
+# applies to every repo on the box and EPEL's URLs are major-only (epel-10), so
+# a global pin would break EPEL.
+#
+# The internal mirror carries a tree per minor (see distro-mirror in
+# sepia-openshift); the public fallbacks below carry point releases too, though
+# they may drop older ones once upstream moves them to vault.
+
 common_yum_repos:
   lab-extras:
     name: "lab-extras"
@@ -12,30 +27,30 @@ yum_repos:
   baseos:
     name: "Rocky Linux $releasever - BaseOS"
     baseurls:
-      - "https://{{ distro_mirror_host }}/rocky/{{ ansible_distribution_major_version }}/BaseOS/{{ ansible_architecture }}/os/"
-      - "https://nyc.mirrors.clouvider.net/rocky/{{ ansible_distribution_major_version }}/BaseOS/{{ ansible_architecture }}/os/"
-      - "https://plug-mirror.rcac.purdue.edu/rocky/{{ ansible_distribution_major_version }}/BaseOS/{{ ansible_architecture }}/os/"
-      - "https://rocky-linux-us-east4.production.gcp.mirrors.ctrliq.cloud/pub/rocky/{{ ansible_distribution_major_version }}/BaseOS/{{ ansible_architecture }}/os/"
+      - "https://{{ distro_mirror_host }}/rocky/{{ ansible_distribution_version }}/BaseOS/{{ ansible_architecture }}/os/"
+      - "https://nyc.mirrors.clouvider.net/rocky/{{ ansible_distribution_version }}/BaseOS/{{ ansible_architecture }}/os/"
+      - "https://plug-mirror.rcac.purdue.edu/rocky/{{ ansible_distribution_version }}/BaseOS/{{ ansible_architecture }}/os/"
+      - "https://rocky-linux-us-east4.production.gcp.mirrors.ctrliq.cloud/pub/rocky/{{ ansible_distribution_version }}/BaseOS/{{ ansible_architecture }}/os/"
     enabled: 1
     gpgcheck: 0
 
   appstream:
     name: "Rocky Linux $releasever - AppStream"
     baseurls:
-      - "https://{{ distro_mirror_host }}/rocky/{{ ansible_distribution_major_version }}/AppStream/{{ ansible_architecture }}/os/"
-      - "https://nyc.mirrors.clouvider.net/rocky/{{ ansible_distribution_major_version }}/AppStream/{{ ansible_architecture }}/os/"
-      - "https://plug-mirror.rcac.purdue.edu/rocky/{{ ansible_distribution_major_version }}/AppStream/{{ ansible_architecture }}/os/"
-      - "https://rocky-linux-us-east4.production.gcp.mirrors.ctrliq.cloud/pub/rocky/{{ ansible_distribution_major_version }}/AppStream/{{ ansible_architecture }}/os/"
+      - "https://{{ distro_mirror_host }}/rocky/{{ ansible_distribution_version }}/AppStream/{{ ansible_architecture }}/os/"
+      - "https://nyc.mirrors.clouvider.net/rocky/{{ ansible_distribution_version }}/AppStream/{{ ansible_architecture }}/os/"
+      - "https://plug-mirror.rcac.purdue.edu/rocky/{{ ansible_distribution_version }}/AppStream/{{ ansible_architecture }}/os/"
+      - "https://rocky-linux-us-east4.production.gcp.mirrors.ctrliq.cloud/pub/rocky/{{ ansible_distribution_version }}/AppStream/{{ ansible_architecture }}/os/"
     enabled: 1
     gpgcheck: 0
 
   crb:
     name: "Rocky Linux $releasever - CRB"
     baseurls:
-      - "https://{{ distro_mirror_host }}/rocky/{{ ansible_distribution_major_version }}/CRB/{{ ansible_architecture }}/os/"
-      - "https://nyc.mirrors.clouvider.net/rocky/{{ ansible_distribution_major_version }}/CRB/{{ ansible_architecture }}/os/"
-      - "https://plug-mirror.rcac.purdue.edu/rocky/{{ ansible_distribution_major_version }}/CRB/{{ ansible_architecture }}/os/"
-      - "https://rocky-linux-us-east4.production.gcp.mirrors.ctrliq.cloud/pub/rocky/{{ ansible_distribution_major_version }}/CRB/{{ ansible_architecture }}/os/"
+      - "https://{{ distro_mirror_host }}/rocky/{{ ansible_distribution_version }}/CRB/{{ ansible_architecture }}/os/"
+      - "https://nyc.mirrors.clouvider.net/rocky/{{ ansible_distribution_version }}/CRB/{{ ansible_architecture }}/os/"
+      - "https://plug-mirror.rcac.purdue.edu/rocky/{{ ansible_distribution_version }}/CRB/{{ ansible_architecture }}/os/"
+      - "https://rocky-linux-us-east4.production.gcp.mirrors.ctrliq.cloud/pub/rocky/{{ ansible_distribution_version }}/CRB/{{ ansible_architecture }}/os/"
     enabled: 1
     gpgcheck: 0
 


### PR DESCRIPTION
`roles/testnode/vars/rocky_10.yml` built its BaseOS/AppStream/CRB `baseurl`s from `ansible_distribution_major_version`, i.e. `/rocky/10/` — and upstream's `10` is a symlink to the newest point release. So a routine `dnf update` walks a testnode from 10.1 to 10.2, which is how the `rocky_10.1` FOG image ended up containing an `el10_2` kernel while teuthology still hands it to jobs that asked for 10.1.

Switches those 12 baseurls to `ansible_distribution_version` (the full `10.1`), so **a node stays on the point release it was deployed with**. `lab-extras` is our own repo and keeps its major-version path.

Depends on ceph/sepia-openshift#59, which mirrors Rocky per minor (`/rocky/10.1/`, `/rocky/10.2/`) and keeps `/rocky/10` as a symlink to the newest minor for anything that still wants latest. The public fallback mirrors already carry point releases.

**Why not `/etc/dnf/vars/releasever`:** that would be the obvious global pin, but it applies to every repo on the box and EPEL's URLs are major-only (`epel-$releasever` → `epel-10`), so pinning it to `10.1` risks breaking EPEL — which these nodes use for `dbench`/`gdisk`. Pinning the Rocky baseurls only leaves EPEL alone.

Supersedes #870 (which pinned `releasever` for the `dnf update` in prep-fog-capture) — that had the same EPEL exposure and is redundant once the repos themselves are pinned.