### PR TITLE
testnode: baseurl creation is broken

### DIFF
--- a/roles/testnode/templates/yum_repo.j2
+++ b/roles/testnode/templates/yum_repo.j2
@@ -5,9 +5,7 @@
 [{{ item.key }}]
 {% for k, v in item.value.items() | sort %}
 {% if k == "baseurls" %}
-{%   for url in v %}
-baseurl={{ url }}
-{%   endfor %}
+baseurl={{ v | join(',') }}
 {% else %}
 {{ k }}={{ v }}
 {% endif %}


### PR DESCRIPTION
baseurl= overrides all previous baseurls, so with multiples we were only using the last one.  Change the template to output comma-separated baseurls, which should try them in order, which is what we want.