### PR TITLE
testnode: un-pin Rocky repos from the minor; skip failed Micron NVMes in the firmware task

### DIFF
--- a/roles/testnode/tasks/check-micron-nvme-firmware.yml
+++ b/roles/testnode/tasks/check-micron-nvme-firmware.yml
@@ -25,6 +25,23 @@
         *) continue ;;
       esac
 
+      # A drive that has failed into its safe mode (SMART critical_warning
+      # set -- 0xc = reliability degraded + media read-only, all counters
+      # zeroed, no usable namespace) rejects fw-download with an Internal
+      # Error no matter what.  Flashing won't fix it and flagging it as
+      # UPDATE_NEEDED would fail the play on every job that lands on the
+      # node (trial012/094/163, 2026-08-19).  Report it and leave it alone.
+      critical_warning="$(nvme smart-log "$dev" 2>/dev/null | \
+        sed -n 's/^critical_warning[[:space:]]*:[[:space:]]*//p' | head -n1 | xargs)"
+      case "$critical_warning" in
+        ""|0|0x0|0x00)
+          ;;
+        *)
+          echo "UNHEALTHY: $dev model=$model fw=$current_fw critical_warning=$critical_warning, skipping firmware update (RMA candidate)"
+          continue
+          ;;
+      esac
+
       latest_fw="$(curl -k -fsSL "$BASE_URL/$family/" 2>/dev/null | \
         sed -n 's/.*href="\([^"?/][^"?]*\)\/".*/\1/p' | \
         grep -v '^\.\.$' | sort -V | tail -n1)"

--- a/roles/testnode/tasks/check-micron-nvme-firmware.yml
+++ b/roles/testnode/tasks/check-micron-nvme-firmware.yml
@@ -29,7 +29,7 @@
       # A drive that has failed into its safe mode (SMART critical_warning
       # set -- 0xc = reliability degraded + media read-only, all counters
       # zeroed, no usable namespace) rejects fw-download with an Internal
-      # Error no matter what.  Flashing won't fix it, so don't flag it as
+      # Error no matter what.  Flashing will not fix it, so do not flag it as
       # UPDATE_NEEDED; report it as UNHEALTHY instead so main.yml can fail
       # the play with a message teuthology recognises and marks the node
       # down on (trial012/094/163, 2026-08-19).

--- a/roles/testnode/tasks/check-micron-nvme-firmware.yml
+++ b/roles/testnode/tasks/check-micron-nvme-firmware.yml
@@ -13,6 +13,7 @@
 
       model="$(echo "$id_ctrl" | sed -n 's/^mn[[:space:]]*:[[:space:]]*//p' | head -n1 | xargs)"
       current_fw="$(echo "$id_ctrl" | sed -n 's/^fr[[:space:]]*:[[:space:]]*//p' | head -n1 | xargs)"
+      serial="$(echo "$id_ctrl" | sed -n 's/^sn[[:space:]]*:[[:space:]]*//p' | head -n1 | xargs)"
       subnqn="$(echo "$id_ctrl" | sed -n 's/^subnqn[[:space:]]*:[[:space:]]*//p' | head -n1 | xargs)"
 
       # The model allowlist below is the real Micron gate; a generic
@@ -28,16 +29,17 @@
       # A drive that has failed into its safe mode (SMART critical_warning
       # set -- 0xc = reliability degraded + media read-only, all counters
       # zeroed, no usable namespace) rejects fw-download with an Internal
-      # Error no matter what.  Flashing won't fix it and flagging it as
-      # UPDATE_NEEDED would fail the play on every job that lands on the
-      # node (trial012/094/163, 2026-08-19).  Report it and leave it alone.
+      # Error no matter what.  Flashing won't fix it, so don't flag it as
+      # UPDATE_NEEDED; report it as UNHEALTHY instead so main.yml can fail
+      # the play with a message teuthology recognises and marks the node
+      # down on (trial012/094/163, 2026-08-19).
       critical_warning="$(nvme smart-log "$dev" 2>/dev/null | \
         sed -n 's/^critical_warning[[:space:]]*:[[:space:]]*//p' | head -n1 | xargs)"
       case "$critical_warning" in
         ""|0|0x0|0x00)
           ;;
         *)
-          echo "UNHEALTHY: $dev model=$model fw=$current_fw critical_warning=$critical_warning, skipping firmware update (RMA candidate)"
+          echo "UNHEALTHY: $dev model=$model sn=$serial fw=$current_fw critical_warning=$critical_warning"
           continue
           ;;
       esac

--- a/roles/testnode/tasks/main.yml
+++ b/roles/testnode/tasks/main.yml
@@ -81,6 +81,23 @@
 
 - import_tasks: check-micron-nvme-firmware.yml
 
+# A failed scratch drive makes the node useless to most jobs (see the
+# "Wanted N disks" disable pattern), so fail here with a message teuthology's
+# disable_targets.ansible_failure_patterns can match -- the supervisor matches
+# the failure record's msg, which for a plain shell failure is just "non-zero
+# return code".  Pattern: 'Micron NVMe .* failed into safe mode'
+- name: Fail the play when a Micron NVMe has failed into safe mode
+  fail:
+    msg: >-
+      Micron NVMe {{ micron_nvme_firmware_check.stdout_lines
+      | select('search', '^UNHEALTHY:')
+      | map('regex_replace', '^UNHEALTHY: ', '')
+      | join('; ') }} failed into safe mode (SMART critical_warning set,
+      rejects fw-download): RMA candidate
+  when:
+    - micron_nvme_firmware_check is defined
+    - micron_nvme_firmware_check.stdout is search("UNHEALTHY:")
+
 - import_tasks: micron_nvme_firmware.yml
   when:
     - micron_nvme_firmware_check is defined

--- a/roles/testnode/tasks/micron_nvme_firmware.yml
+++ b/roles/testnode/tasks/micron_nvme_firmware.yml
@@ -77,6 +77,21 @@
           ;;
       esac
 
+      # Same health gate as the check task: a drive that has failed into
+      # safe mode (SMART critical_warning set) rejects fw-download with an
+      # Internal Error (0x4006) and nothing we do here will change that.
+      # Skip it without failing the play; it's an RMA, not a flash.
+      critical_warning="$(nvme smart-log "$dev" 2>/dev/null | \
+        sed -n 's/^critical_warning[[:space:]]*:[[:space:]]*//p' | head -n1 | xargs)"
+      case "$critical_warning" in
+        ""|0|0x0|0x00)
+          ;;
+        *)
+          echo "UNHEALTHY: $dev critical_warning=$critical_warning, skipping firmware update (RMA candidate)"
+          continue
+          ;;
+      esac
+
       target_fw="$(curl -k -fsSL "$BASE_URL/$family/" 2>/dev/null | \
         sed -n 's/.*href="\([^"?/][^"?]*\)\/".*/\1/p' | \
         grep -v '^\.\.$' | sort -V | tail -n1)"

--- a/roles/testnode/tasks/micron_nvme_firmware.yml
+++ b/roles/testnode/tasks/micron_nvme_firmware.yml
@@ -80,7 +80,7 @@
       # Same health gate as the check task: a drive that has failed into
       # safe mode (SMART critical_warning set) rejects fw-download with an
       # Internal Error (0x4006) and nothing we do here will change that.
-      # Skip it without failing the play; it's an RMA, not a flash.
+      # Skip it without failing the play; that is an RMA, not a flash.
       critical_warning="$(nvme smart-log "$dev" 2>/dev/null | \
         sed -n 's/^critical_warning[[:space:]]*:[[:space:]]*//p' | head -n1 | xargs)"
       case "$critical_warning" in

--- a/roles/testnode/vars/rocky_10.yml
+++ b/roles/testnode/vars/rocky_10.yml
@@ -1,22 +1,11 @@
 ---
 # vars specific to any rocky 10.x version
 
-# The BaseOS/AppStream/CRB baseurls below point at the *major* (/rocky/10/),
-# which upstream and the internal mirror keep as a symlink to the newest point
-# release.  That is deliberate: Rocky only maintains its newest minor, shaman's
-# rocky/10 ceph builds are compiled on that newest minor and inherit its
-# library versions (2026-08: ceph-osd-crimson needs c-ares >= 1.28, which only
-# 10.2 ships), so a testnode held back on an older minor can't install ceph at
-# all -- `nothing provides c-ares(x86-64) >= 1.28.0`.  Rocky 10 is therefore
-# treated like CentOS Stream here: the image is named by major (rocky_10),
-# jobs ask for os_version "10", the sepia-fog-images capture job upgrades the
-# image to whatever the newest minor is, and a job's own installs/upgrades
-# from these repos are per-job and gone at the next reimage.  Don't pin these
-# to ansible_distribution_version (f2c9440 did, and broke every Rocky job).
-#
-# The internal mirror carries a tree per minor plus the /rocky/10 symlink (see
-# distro-mirror in sepia-openshift).  The public fallbacks only carry the
-# current minor under /rocky/10/; older minors move to vault.
+# The BaseOS/AppStream/CRB baseurls pin to the deployed point release: a job
+# that asked for rocky 10.1 stays on 10.1.  Jobs that ask for "10" get the
+# newest-minor image (teuthology resolves it), so their pin tracks what
+# shaman builds against.  Only the internal mirror keeps old minors; the
+# public mirrors vault them.
 
 common_yum_repos:
   lab-extras:
@@ -29,30 +18,30 @@ yum_repos:
   baseos:
     name: "Rocky Linux $releasever - BaseOS"
     baseurls:
-      - "https://{{ distro_mirror_host }}/rocky/{{ ansible_distribution_major_version }}/BaseOS/{{ ansible_architecture }}/os/"
-      - "https://nyc.mirrors.clouvider.net/rocky/{{ ansible_distribution_major_version }}/BaseOS/{{ ansible_architecture }}/os/"
-      - "https://plug-mirror.rcac.purdue.edu/rocky/{{ ansible_distribution_major_version }}/BaseOS/{{ ansible_architecture }}/os/"
-      - "https://rocky-linux-us-east4.production.gcp.mirrors.ctrliq.cloud/pub/rocky/{{ ansible_distribution_major_version }}/BaseOS/{{ ansible_architecture }}/os/"
+      - "https://{{ distro_mirror_host }}/rocky/{{ ansible_distribution_version }}/BaseOS/{{ ansible_architecture }}/os/"
+      - "https://nyc.mirrors.clouvider.net/rocky/{{ ansible_distribution_version }}/BaseOS/{{ ansible_architecture }}/os/"
+      - "https://plug-mirror.rcac.purdue.edu/rocky/{{ ansible_distribution_version }}/BaseOS/{{ ansible_architecture }}/os/"
+      - "https://rocky-linux-us-east4.production.gcp.mirrors.ctrliq.cloud/pub/rocky/{{ ansible_distribution_version }}/BaseOS/{{ ansible_architecture }}/os/"
     enabled: 1
     gpgcheck: 0
 
   appstream:
     name: "Rocky Linux $releasever - AppStream"
     baseurls:
-      - "https://{{ distro_mirror_host }}/rocky/{{ ansible_distribution_major_version }}/AppStream/{{ ansible_architecture }}/os/"
-      - "https://nyc.mirrors.clouvider.net/rocky/{{ ansible_distribution_major_version }}/AppStream/{{ ansible_architecture }}/os/"
-      - "https://plug-mirror.rcac.purdue.edu/rocky/{{ ansible_distribution_major_version }}/AppStream/{{ ansible_architecture }}/os/"
-      - "https://rocky-linux-us-east4.production.gcp.mirrors.ctrliq.cloud/pub/rocky/{{ ansible_distribution_major_version }}/AppStream/{{ ansible_architecture }}/os/"
+      - "https://{{ distro_mirror_host }}/rocky/{{ ansible_distribution_version }}/AppStream/{{ ansible_architecture }}/os/"
+      - "https://nyc.mirrors.clouvider.net/rocky/{{ ansible_distribution_version }}/AppStream/{{ ansible_architecture }}/os/"
+      - "https://plug-mirror.rcac.purdue.edu/rocky/{{ ansible_distribution_version }}/AppStream/{{ ansible_architecture }}/os/"
+      - "https://rocky-linux-us-east4.production.gcp.mirrors.ctrliq.cloud/pub/rocky/{{ ansible_distribution_version }}/AppStream/{{ ansible_architecture }}/os/"
     enabled: 1
     gpgcheck: 0
 
   crb:
     name: "Rocky Linux $releasever - CRB"
     baseurls:
-      - "https://{{ distro_mirror_host }}/rocky/{{ ansible_distribution_major_version }}/CRB/{{ ansible_architecture }}/os/"
-      - "https://nyc.mirrors.clouvider.net/rocky/{{ ansible_distribution_major_version }}/CRB/{{ ansible_architecture }}/os/"
-      - "https://plug-mirror.rcac.purdue.edu/rocky/{{ ansible_distribution_major_version }}/CRB/{{ ansible_architecture }}/os/"
-      - "https://rocky-linux-us-east4.production.gcp.mirrors.ctrliq.cloud/pub/rocky/{{ ansible_distribution_major_version }}/CRB/{{ ansible_architecture }}/os/"
+      - "https://{{ distro_mirror_host }}/rocky/{{ ansible_distribution_version }}/CRB/{{ ansible_architecture }}/os/"
+      - "https://nyc.mirrors.clouvider.net/rocky/{{ ansible_distribution_version }}/CRB/{{ ansible_architecture }}/os/"
+      - "https://plug-mirror.rcac.purdue.edu/rocky/{{ ansible_distribution_version }}/CRB/{{ ansible_architecture }}/os/"
+      - "https://rocky-linux-us-east4.production.gcp.mirrors.ctrliq.cloud/pub/rocky/{{ ansible_distribution_version }}/CRB/{{ ansible_architecture }}/os/"
     enabled: 1
     gpgcheck: 0
 

--- a/roles/testnode/vars/rocky_10.yml
+++ b/roles/testnode/vars/rocky_10.yml
@@ -1,20 +1,22 @@
 ---
 # vars specific to any rocky 10.x version
 
-# The BaseOS/AppStream/CRB baseurls below use ansible_distribution_version (the
-# full 10.x) rather than the major version on purpose.  Upstream's /rocky/10 is
-# a symlink to the newest point release, so pointing at it lets a routine
-# `dnf update` walk a node from 10.1 to 10.2 -- which is how the rocky_10.1 FOG
-# image ended up containing an el10_2 kernel.  Pinning the baseurl to the minor
-# keeps a node on the point release it was deployed with.
+# The BaseOS/AppStream/CRB baseurls below point at the *major* (/rocky/10/),
+# which upstream and the internal mirror keep as a symlink to the newest point
+# release.  That is deliberate: Rocky only maintains its newest minor, shaman's
+# rocky/10 ceph builds are compiled on that newest minor and inherit its
+# library versions (2026-08: ceph-osd-crimson needs c-ares >= 1.28, which only
+# 10.2 ships), so a testnode held back on an older minor can't install ceph at
+# all -- `nothing provides c-ares(x86-64) >= 1.28.0`.  Rocky 10 is therefore
+# treated like CentOS Stream here: the image is named by major (rocky_10),
+# jobs ask for os_version "10", the sepia-fog-images capture job upgrades the
+# image to whatever the newest minor is, and a job's own installs/upgrades
+# from these repos are per-job and gone at the next reimage.  Don't pin these
+# to ansible_distribution_version (f2c9440 did, and broke every Rocky job).
 #
-# Pinning here rather than in /etc/dnf/vars/releasever is deliberate: releasever
-# applies to every repo on the box and EPEL's URLs are major-only (epel-10), so
-# a global pin would break EPEL.
-#
-# The internal mirror carries a tree per minor (see distro-mirror in
-# sepia-openshift); the public fallbacks below carry point releases too, though
-# they may drop older ones once upstream moves them to vault.
+# The internal mirror carries a tree per minor plus the /rocky/10 symlink (see
+# distro-mirror in sepia-openshift).  The public fallbacks only carry the
+# current minor under /rocky/10/; older minors move to vault.
 
 common_yum_repos:
   lab-extras:
@@ -27,30 +29,30 @@ yum_repos:
   baseos:
     name: "Rocky Linux $releasever - BaseOS"
     baseurls:
-      - "https://{{ distro_mirror_host }}/rocky/{{ ansible_distribution_version }}/BaseOS/{{ ansible_architecture }}/os/"
-      - "https://nyc.mirrors.clouvider.net/rocky/{{ ansible_distribution_version }}/BaseOS/{{ ansible_architecture }}/os/"
-      - "https://plug-mirror.rcac.purdue.edu/rocky/{{ ansible_distribution_version }}/BaseOS/{{ ansible_architecture }}/os/"
-      - "https://rocky-linux-us-east4.production.gcp.mirrors.ctrliq.cloud/pub/rocky/{{ ansible_distribution_version }}/BaseOS/{{ ansible_architecture }}/os/"
+      - "https://{{ distro_mirror_host }}/rocky/{{ ansible_distribution_major_version }}/BaseOS/{{ ansible_architecture }}/os/"
+      - "https://nyc.mirrors.clouvider.net/rocky/{{ ansible_distribution_major_version }}/BaseOS/{{ ansible_architecture }}/os/"
+      - "https://plug-mirror.rcac.purdue.edu/rocky/{{ ansible_distribution_major_version }}/BaseOS/{{ ansible_architecture }}/os/"
+      - "https://rocky-linux-us-east4.production.gcp.mirrors.ctrliq.cloud/pub/rocky/{{ ansible_distribution_major_version }}/BaseOS/{{ ansible_architecture }}/os/"
     enabled: 1
     gpgcheck: 0
 
   appstream:
     name: "Rocky Linux $releasever - AppStream"
     baseurls:
-      - "https://{{ distro_mirror_host }}/rocky/{{ ansible_distribution_version }}/AppStream/{{ ansible_architecture }}/os/"
-      - "https://nyc.mirrors.clouvider.net/rocky/{{ ansible_distribution_version }}/AppStream/{{ ansible_architecture }}/os/"
-      - "https://plug-mirror.rcac.purdue.edu/rocky/{{ ansible_distribution_version }}/AppStream/{{ ansible_architecture }}/os/"
-      - "https://rocky-linux-us-east4.production.gcp.mirrors.ctrliq.cloud/pub/rocky/{{ ansible_distribution_version }}/AppStream/{{ ansible_architecture }}/os/"
+      - "https://{{ distro_mirror_host }}/rocky/{{ ansible_distribution_major_version }}/AppStream/{{ ansible_architecture }}/os/"
+      - "https://nyc.mirrors.clouvider.net/rocky/{{ ansible_distribution_major_version }}/AppStream/{{ ansible_architecture }}/os/"
+      - "https://plug-mirror.rcac.purdue.edu/rocky/{{ ansible_distribution_major_version }}/AppStream/{{ ansible_architecture }}/os/"
+      - "https://rocky-linux-us-east4.production.gcp.mirrors.ctrliq.cloud/pub/rocky/{{ ansible_distribution_major_version }}/AppStream/{{ ansible_architecture }}/os/"
     enabled: 1
     gpgcheck: 0
 
   crb:
     name: "Rocky Linux $releasever - CRB"
     baseurls:
-      - "https://{{ distro_mirror_host }}/rocky/{{ ansible_distribution_version }}/CRB/{{ ansible_architecture }}/os/"
-      - "https://nyc.mirrors.clouvider.net/rocky/{{ ansible_distribution_version }}/CRB/{{ ansible_architecture }}/os/"
-      - "https://plug-mirror.rcac.purdue.edu/rocky/{{ ansible_distribution_version }}/CRB/{{ ansible_architecture }}/os/"
-      - "https://rocky-linux-us-east4.production.gcp.mirrors.ctrliq.cloud/pub/rocky/{{ ansible_distribution_version }}/CRB/{{ ansible_architecture }}/os/"
+      - "https://{{ distro_mirror_host }}/rocky/{{ ansible_distribution_major_version }}/CRB/{{ ansible_architecture }}/os/"
+      - "https://nyc.mirrors.clouvider.net/rocky/{{ ansible_distribution_major_version }}/CRB/{{ ansible_architecture }}/os/"
+      - "https://plug-mirror.rcac.purdue.edu/rocky/{{ ansible_distribution_major_version }}/CRB/{{ ansible_architecture }}/os/"
+      - "https://rocky-linux-us-east4.production.gcp.mirrors.ctrliq.cloud/pub/rocky/{{ ansible_distribution_major_version }}/CRB/{{ ansible_architecture }}/os/"
     enabled: 1
     gpgcheck: 0
 

--- a/tools/roles/prep-fog-capture/defaults/main.yml
+++ b/tools/roles/prep-fog-capture/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+# minor (default): upgrade within whatever the node's repos allow -- the
+# testnode role pins Rocky repos to the deployed point release, so a
+# trial_rocky_10.1 capture stays 10.1.
+# major: walk the node to the newest minor of its major first; used by
+# sepia-fog-images when capturing a major-tracking image (trial_rocky_10).
+rocky_upgrade_scope: minor
+
+# Internal distro mirror; carries a tree per Rocky minor plus the
+# /rocky/<major> symlink to the newest one.
+distro_mirror_host: distro-mirror.front.sepia.ceph.com

--- a/tools/roles/prep-fog-capture/tasks/rpm.yml
+++ b/tools/roles/prep-fog-capture/tasks/rpm.yml
@@ -1,10 +1,32 @@
 ---
+# On Rocky the node's repos pin to the deployed point release, so this
+# stays within the minor; everything else just goes to latest.
 - name: Upgrade all packages to latest (dnf)
   dnf:
     name: "*"
     state: latest
     update_cache: true
-  when: ansible_facts.os_family == "RedHat"
+  when:
+    - ansible_facts.os_family == "RedHat"
+    - not (ansible_facts.distribution == "Rocky" and rocky_upgrade_scope == "major")
+
+# Capturing a major-tracking image (trial_rocky_10): the pinned repos
+# would hold the node on its minor, so upgrade against the major tree on
+# the internal mirror instead.  The stale pinned repo files in the
+# captured image are harmless -- the testnode role rewrites them from the
+# running (new) minor on every job.
+- name: Upgrade Rocky to the newest minor (dnf)
+  command: >-
+    dnf -y upgrade --refresh --nogpgcheck
+    --disablerepo=baseos,appstream,crb
+    --repofrompath=baseos-major,https://{{ distro_mirror_host }}/rocky/{{ ansible_facts.distribution_major_version }}/BaseOS/{{ ansible_facts.architecture }}/os/
+    --repofrompath=appstream-major,https://{{ distro_mirror_host }}/rocky/{{ ansible_facts.distribution_major_version }}/AppStream/{{ ansible_facts.architecture }}/os/
+    --repofrompath=crb-major,https://{{ distro_mirror_host }}/rocky/{{ ansible_facts.distribution_major_version }}/CRB/{{ ansible_facts.architecture }}/os/
+  register: rocky_major_upgrade
+  changed_when: "'Nothing to do' not in rocky_major_upgrade.stdout"
+  when:
+    - ansible_facts.distribution == "Rocky"
+    - rocky_upgrade_scope == "major"
 
 - name: Ensure dnf-utils present (for needs-restarting)
   package:


### PR DESCRIPTION
Two fixes for what turned most of pulpito red on 2026-08-19.

## 1. Rocky repos back at the major (`/rocky/10/`)

#871 (f2c9440) pinned BaseOS/AppStream/CRB to `ansible_distribution_version` (10.1) to keep the FOG image from drifting. That broke **every package install of ceph on Rocky**: shaman's rocky/10 builds are compiled on the floating `rockylinux:10` container (= newest minor), and `ceph-osd-crimson` now needs `c-ares >= 1.28`, which only 10.2 ships (10.1 BaseOS has 1.25.0):

```
nothing provides c-ares(x86-64) >= 1.28.0 needed by ceph-osd-crimson-2:21.3.0-2028.g549ce99e.el10.x86_64
```

~70 jobs in the first hour after the pin merged (main, tentacle, umbrella — anything with crimson); a passing job from Aug 18 shows `c-ares-1.34.6-2.el10_2` being pulled from baseos, which is what the pin took away.

Rocky only maintains its newest minor and the builds follow it, so the lab has to as well — treat Rocky 10 like CentOS 9 Stream. This PR puts the repos back at `/rocky/<major>/` with a comment explaining why they must not be pinned. The rest of that model lives outside this repo (follow-ups, not blockers): name the FOG image by major (`trial_rocky_10`), set `os_version: "10"` in ceph's `qa/distros/all/rocky_10.yaml`, and recapture the image when a new minor lands. The testnode role itself never upgrades the OS (only `state: present` installs + libgcrypt), so nothing here moves an image between minors; only the sepia-fog-images capture job's `dnf upgrade '*'` does, and under this model that is intended.

Incidentally, the "All mirrors were tried" wave this morning (~300 jobs) was the same pin plus the last-`baseurl=`-wins template bug fixed in #872: public mirrors have vaulted 10.1 and 404 for it.

## 2. Micron firmware task: recognise drives that have failed into safe mode

trial012, trial094 and trial163 each have a 7500 (MTFDKCC1T9TGP) on E3MQ000 whose controller is in its failsafe state: SMART `critical_warning 0xc` (reliability degraded + media read-only), power_on_hours/power_cycles/host reads zeroed, no usable namespace, and every `nvme fw-download` answers `Internal Error (0x4006)` at offset 0 — idle, 4K or 128K transfers, no difference. RMAs, not flashes.

The check task saw E3MQ000 != E3MQ005 → `UPDATE_NEEDED`, the update task failed the download and (per 388c978) failed the play → `ansible.cephlab` failed on every job that landed on one of these nodes: ~60 dead jobs today, each node killing a fresh job every ~10 minutes as the queue re-locked it.

Now: both scripts gate on SMART `critical_warning`; a drive with any bit set is never flashed, and main.yml fails the play with an explicit `fail:` whose `msg` is

```
Micron NVMe /dev/nvme2 model=MTFDKCC1T9TGP-1BK1JABYY sn=012510B0023B fw=E3MQ000 critical_warning=0xc failed into safe mode (SMART critical_warning set, rejects fw-download): RMA candidate
```

so teuthology's `disable_targets.ansible_failure_patterns` (which matches the failure record's `msg`, not stdout) can take the node out of the pool on the first job. Companion site-config entry for teuthology:

```yaml
disable_targets:
  ansible_failure_patterns:
    trial:
      - 'Wanted \d+ disks? of .+ but only matched \d+'
      - 'Micron NVMe .* failed into safe mode'
```

Rendered with ansible against the real check output from trial012 and matched with teuthology's `FailureAnalyzer.find_matching_failures`. The three nodes are marked down in the lock server.
