### PR TITLE
users: don't log emails and WireGuard peer info

### DIFF
--- a/roles/users/tasks/create_users.yml
+++ b/roles/users/tasks/create_users.yml
@@ -16,6 +16,9 @@
     append: yes
     home: "{{ ('teuthology' in group_names) | ternary('/tank/home', '/home') }}/{{ item.name }}"
   with_items: "{{ managed_admin_users }}"
+  # The user dicts carry emails and WireGuard peer info; only log the username
+  loop_control:
+    label: "{{ item.name }}"
   when: item.name not in getent_passwd or item.name not in sudo_group_members
 
 - name: Create all users without sudo access.
@@ -25,4 +28,7 @@
     state: present
     home: "{{ ('teuthology' in group_names) | ternary('/tank/home', '/home') }}/{{ item.name }}"
   with_items: "{{ managed_users }}"
+  # The user dicts carry emails and WireGuard peer info; only log the username
+  loop_control:
+    label: "{{ item.name }}"
   when: item.name not in getent_passwd

--- a/roles/users/tasks/filter_users.yml
+++ b/roles/users/tasks/filter_users.yml
@@ -32,6 +32,10 @@
           ]
       }}
   loop: "{{ extra_admin_users }}"
+  # Items may be full user dicts (with emails/WireGuard peer info) or bare
+  # names; only log the name either way
+  loop_control:
+    label: "{{ item.name | default(item) }}"
   when:
     - extra_admin_users is defined
     - extra_admin_users | length > 0

--- a/roles/users/tasks/update_keys.yml
+++ b/roles/users/tasks/update_keys.yml
@@ -51,6 +51,9 @@
   debug:
     msg: "WARNING: No pubkey found for '{{ item.name }}' in {{ keys_repo }}; skipping their authorized_keys."
   with_items: "{{ pubkey_users }}"
+  # The user dicts carry emails and WireGuard peer info; only log the username
+  loop_control:
+    label: "{{ item.name }}"
   delegate_to: localhost
   become: false
   run_once: true
@@ -68,6 +71,9 @@
     user: "{{ item.name }}"
     key: "{{ item.key if item.key is defined else lookup('file', keys_repo_path + '/ssh/' + item.name + '.pub') }}"
   with_items: "{{ pubkey_users }}"
+  # The user dicts carry emails and WireGuard peer info; only log the username
+  loop_control:
+    label: "{{ item.name }}"
   when: >-
     item.key is defined
     or (keys_repo is defined and item.name in keys_repo_pubkeys)


### PR DESCRIPTION
The `lab_users` dicts carry each user's email address and WireGuard peer details (`public_key`, `allowed_ips`).  Every loop over those dicts printed the entire item in the per-item result line, so all of it ended up in public Jenkins console logs (e.g. sepia-fog-images) and in teuthology's per-run `ansible.log`.

Add `loop_control` labels so only the username is logged:

- `create_users.yml`: both user-creation loops
- `update_keys.yml`: the missing-pubkey warning and the `authorized_keys` loop
- `filter_users.yml`: the `extra_admin_users` canonicalization loop (label falls back to the bare item since entries may be plain names)

No behavior change; labels only affect what ansible prints.

Note: this only stops future leaks — existing Jenkins console logs and archived teuthology `ansible.log` files still contain the data.