### PR TITLE
testnode: separate apt mirrorlist URI and tags with a tab

### DIFF
--- a/roles/testnode/templates/apt/mirrorlist.j2
+++ b/roles/testnode/templates/apt/mirrorlist.j2
@@ -3,10 +3,15 @@
 # sepia-mirror.sources).  APT tries entries in priority order and falls
 # back automatically if the local mirror is unreachable or missing a
 # file — the APT equivalent of dnf trying baseurls in order.
+#
+# The URI and its tags MUST be separated by a TAB: apt splits each line
+# on '\t' only (apt-transport-mirror(1)).  With a space, " priority:1"
+# becomes part of the URI, every request to the mirror 404s and APT
+# silently falls through to the public archive (tracker #80192).
 {% if ansible_architecture == "aarch64" %}
-https://{{ distro_mirror_host }}/ubuntu-ports/ priority:1
+https://{{ distro_mirror_host }}/ubuntu-ports/	priority:1
 http://ports.ubuntu.com/ubuntu-ports/
 {% else %}
-https://{{ distro_mirror_host }}/ubuntu/ priority:1
+https://{{ distro_mirror_host }}/ubuntu/	priority:1
 http://archive.ubuntu.com/ubuntu/
 {% endif %}


### PR DESCRIPTION
Fixes https://tracker.ceph.com/issues/80192 (`sudo apt-get update` failing on trial nodes with `File has unexpected size (...). Mirror sync in progress?`).

### The mirror was never being used

apt's mirror method splits each `/etc/apt/mirrorlist` line on a **tab** only (`methods/mirror.cc`: `line.find('\t')`; `apt-transport-mirror(1)`). The template from #7ac8ad5 used a space, so ` priority:1` became part of the URI. The failing jobs show exactly that: the URI in the error line is

```
https://distro-mirror.front.sepia.ceph.com/ubuntu/ priority:1/dists/noble-updates/main/dep11/Components-amd64.yml
```

and the IP is `91.189.91.82` / `185.125.190.83` / `91.189.92.22`, all `archive.ubuntu.com`. Every request to the sepia mirror 404'd and APT silently failed over to the public archive.

### Why that turned into "unexpected size"

The same role sets `Acquire::By-Hash "no"` globally so APT fetches canonical index paths (debmirror does not populate `by-hash/`). That also applies to the fallback mirror, and a canonical-path fetch from `archive.ubuntu.com` races its publisher: the `InRelease` said one size, the index served moments later was another. With by-hash, each index is fetched by content hash and this race cannot happen.

### This PR

One-character fix: a tab between the URI and `priority:1`, plus a comment so it does not regress.

### Follow-up (not in this PR)

ceph/sepia-openshift#61 makes the mirror serve `by-hash/`. Once that has been applied and one `ubuntu-mirror-sync` run has completed, the `Disable APT by-hash index fetching` task (`/etc/apt/apt.conf.d/90sepia-mirror`) should be removed so the fallback keeps by-hash protection too. It must not be removed before then.
