### PR TITLE
alloy: instance/nodename from inventory_hostname, not ansible_fqdn

### DIFF
--- a/roles/alloy/README.md
+++ b/roles/alloy/README.md
@@ -31,18 +31,22 @@ The dashboard and alerts select hosts by three labels, and the role emits them
 | Label | Value | Why it's this |
 | --- | --- | --- |
 | `job` | `node` | What dashboard 1860's `$job` variable and every alert filter on. |
-| `instance` | `<ansible_fqdn>:9100` | Dashboard's `$node` variable. Alerts match literal values (`instance=~"chacra[123]:9100"`, `instance="soko04.front.sepia.ceph.com:9100"`). |
-| `nodename` | `<ansible_fqdn>` | Dashboard's `$nodename` variable (`node_uname_info{job="$job"}` by `nodename`). |
-| `host` | `inventory_hostname` | **New.** The same canonical name the log pipeline uses, so metrics and logs join on one label. |
+| `instance` | `<inventory_hostname>:9100` | Dashboard's `$node` variable. Alerts match literal values (`instance=~"[123].chacra.ceph.com:9100"`, `instance="soko04.front.sepia.ceph.com:9100"`). |
+| `nodename` | `<inventory_hostname>` | Dashboard's `$nodename` variable (`node_uname_info{job="$job"}` by `nodename`). |
+| `host` | `inventory_hostname` | The same name on both pipelines, so metrics and logs join on one label. |
 
-`instance` and `nodename` deliberately stay on `ansible_fqdn`, even though the
-logs use `inventory_hostname` and `ansible_fqdn` is inconsistent across the fleet
-(bare `soko05` on some hosts, full FQDN on others). ~60 hosts have months of
-history under those exact values, and changing them would orphan every existing
-series and silently unhook the alerts in `sepia-openshift` that match on them.
-The canonical name rides along as `host` instead. If you ever do want to move
-`instance` to the inventory name, it's one variable (`alloy_node_instance`) --
-but update the alert expressions in `sepia-openshift` in the same change.
+Everything is `inventory_hostname` -- the canonical name from the sepia
+inventory -- never `ansible_fqdn`. grafana-agent used `ansible_fqdn`, which
+reflects whatever `/etc/hostname` and the resolver say and therefore drifts:
+during the 2026-09 rollout the adami hosts silently flipped from
+`.front.sepia.ceph.com` to `.maas` because MAAS DNS changed underneath them,
+orphaning their series and proving the "continuity" it offered was an illusion.
+The provisioned node-exporter alerts in `ceph/sepia-openshift` match these
+instance values; if you change `alloy_node_instance`, update the alert
+expressions there in the same change or they silently unhook. (During the
+fqdn->inventory_hostname cutover the alerts matched both spellings, so no
+alert went NoData; the old-spelling halves can be dropped once the stale
+series age out.)
 
 ### When the role does not install node_exporter
 
@@ -182,8 +186,8 @@ alloy_extra_log_paths:
 | `alloy_manage_node_exporter` | `true` | Install/start the distro node_exporter (auto-skipped when something else already owns `:9100`) |
 | `alloy_node_exporter_address` | `localhost:9100` | What Alloy scrapes |
 | `alloy_node_job` | `node` | `job` label |
-| `alloy_node_instance` | `<ansible_fqdn>:9100` | `instance` label — see the label contract above before changing |
-| `alloy_node_nodename` | `<ansible_fqdn>` | `nodename` label |
+| `alloy_node_instance` | `<inventory_hostname>:9100` | `instance` label — see the label contract above before changing |
+| `alloy_node_nodename` | `<inventory_hostname>` | `nodename` label |
 | `alloy_node_scrape_interval` | `60s` | |
 | `alloy_mimir_url` | `{{ agent_mimir_url }}` | remote_write URL (from secrets) |
 | `alloy_mimir_ca_file` | ingress CA when the URL is under `.apps.pok.os.sepia.ceph.com`, else empty (system bundle) | |

--- a/roles/alloy/defaults/main.yml
+++ b/roles/alloy/defaults/main.yml
@@ -65,19 +65,17 @@ alloy_node_exporter_known_packages:
 alloy_node_exporter_port: 9100
 alloy_node_exporter_address: "localhost:{{ alloy_node_exporter_port }}"
 
-# The job/instance/nodename labels grafana-agent produced, verbatim.
-#
-# These stay on ansible_fqdn, even though the log pipeline below uses
-# inventory_hostname, because the metrics have history: ~60 hosts have been
-# pushing under these exact instance values, and the provisioned alerts in
-# sepia-openshift match on them (instance=~"chacra[123]:9100",
-# instance="soko04.front.sepia.ceph.com:9100"). Changing them would orphan the
-# existing series and silently unhook those alerts. The canonical name is
-# carried on the `host` external label instead, which is the same label the
-# log pipeline uses, so metrics and logs for a host can be joined on it.
+# instance/nodename come from inventory_hostname -- the same canonical name
+# the `host` external label and the log pipeline use -- NOT ansible_fqdn.
+# ansible_fqdn reflects whatever /etc/hostname and the resolver say, which
+# drifts: during the 2026-09 rollout the adami hosts silently flipped from
+# .front.sepia.ceph.com to .maas because MAAS DNS changed underneath them,
+# orphaning their series. inventory_hostname is stable and identical in form
+# for every host. The provisioned node-exporter alerts in ceph/sepia-openshift
+# match these labels; change them in lockstep or alerts silently unhook.
 alloy_node_job: "node"
-alloy_node_instance: "{{ ansible_fqdn }}:{{ alloy_node_exporter_port }}"
-alloy_node_nodename: "{{ ansible_fqdn }}"
+alloy_node_instance: "{{ inventory_hostname }}:{{ alloy_node_exporter_port }}"
+alloy_node_nodename: "{{ inventory_hostname }}"
 alloy_node_scrape_interval: "60s"
 
 # Mimir remote_write target. The default is the in-cluster route; the

--- a/roles/alloy/tasks/remove-grafana-agent.yml
+++ b/roles/alloy/tasks/remove-grafana-agent.yml
@@ -4,15 +4,29 @@
 # host: service, package, config, WAL, and the user the package created. Every
 # task here is a no-op on a host that never had it.
 
-- name: grafana-agent - Gather service facts
-  ansible.builtin.service_facts:
+# service_facts can't tell an installed-but-crashed grafana-agent from a
+# leftover in-memory "not-found, failed" stub whose unit file is already gone
+# (both report status=failed; several hosts had July-era stubs). `systemctl
+# cat` succeeds only when a real unit file exists, so probe with that.
+- name: grafana-agent - Check whether a unit file exists
+  ansible.builtin.command: systemctl cat grafana-agent.service
+  register: grafana_agent_unit
+  failed_when: false
+  changed_when: false
 
 - name: grafana-agent - Stop and disable the service
   ansible.builtin.systemd:
     name: grafana-agent
     state: stopped
     enabled: false
-  when: "'grafana-agent.service' in ansible_facts.services"
+  when: grafana_agent_unit.rc == 0
+
+- name: grafana-agent - Clear a leftover failed unit stub
+  ansible.builtin.command: systemctl reset-failed grafana-agent.service
+  register: grafana_agent_reset
+  failed_when: false
+  changed_when: grafana_agent_reset.rc == 0
+  when: grafana_agent_unit.rc != 0
 
 - name: grafana-agent - Remove the package (apt)
   ansible.builtin.apt:

--- a/roles/alloy/templates/config.alloy.j2
+++ b/roles/alloy/templates/config.alloy.j2
@@ -5,13 +5,12 @@
 //   metrics  node_exporter on localhost -> Mimir   (alloy_metrics_enabled)
 //   logs     journald + auditd + allowlist -> LokiStack  (alloy_logs_enabled)
 //
-// Both carry host = inventory_hostname, the canonical name from the sepia
-// inventory, so a host's metrics and logs can be joined on one label.
-// ansible_fqdn is NOT used for that: it reflects whatever /etc/hostname says,
-// which is inconsistent across this fleet -- soko05 reports the bare "soko05"
-// while other hosts report a full FQDN -- which makes {host="..."} queries
-// unguessable. The metrics `instance`/`nodename` labels are the one exception,
-// on purpose; see below.
+// Everything carries inventory_hostname, the canonical name from the sepia
+// inventory: the host external label on both pipelines, and the metrics
+// instance/nodename labels. ansible_fqdn is never used -- it reflects whatever
+// /etc/hostname and the resolver say, which drifts (the adami hosts flipped
+// .front -> .maas mid-2026 when MAAS DNS changed) and is inconsistent across
+// the fleet, making {host="..."} and {instance="..."} queries unguessable.
 
 logging {
   level  = "{{ alloy_log_level }}"
@@ -20,14 +19,14 @@ logging {
 
 {% if alloy_metrics_enabled | bool %}
 // ==================================================================== metrics
-// Exactly what grafana-agent did: scrape node_exporter on localhost and
-// remote_write to Mimir. The label set is kept identical -- job="node",
-// instance="<fqdn>:9100", nodename="<fqdn>" -- because the "Node Exporter
-// Full" dashboard (grafana.com 1860, jenkins-grafana/dashboards/
-// node-exporter-lab.yaml in ceph/sepia-openshift) selects hosts by exactly
-// those labels, the provisioned node-exporter alerts there match on literal
-// instance values, and ~60 hosts have history under them. Changing them would
-// orphan every existing series and silently unhook the alerts.
+// What grafana-agent did: scrape node_exporter on localhost and remote_write
+// to Mimir, with the same label shape -- job="node", instance="<name>:9100",
+// nodename="<name>" -- because the "Node Exporter Full" dashboard
+// (grafana.com 1860, jenkins-grafana/dashboards/node-exporter-lab.yaml in
+// ceph/sepia-openshift) selects hosts by those labels and the provisioned
+// node-exporter alerts there match literal instance values. <name> is
+// inventory_hostname; the alert expressions in sepia-openshift were updated
+// in the same change that made it so. Change one only with the other.
 
 prometheus.scrape "node" {
   targets = [


### PR DESCRIPTION
Follow-up to #862, planned there as the label cleanup.

The rollout proved `ansible_fqdn`'s series-continuity argument was an illusion: the adami hosts silently flipped `.front.sepia.ceph.com` → `.maas` mid-fleet because MAAS DNS changed underneath them, orphaning their history anyway. This moves the metrics `instance`/`nodename` labels to `inventory_hostname` — the same canonical name the `host` label and the log pipeline already use — so every label on every pipeline is the stable inventory name.

Companion alert change in ceph/sepia-openshift (chacra alerts dual-match old+new instance spellings during the transition, so nothing goes NoData; `soko04.front.sepia.ceph.com:9100` is already the inventory name). Deployed fleet-wide together with that change.