### PR TITLE
fog-server, generate-fog-csv: per-machine-type boot exit types

### DIFF
--- a/roles/fog-server/README.rst
+++ b/roles/fog-server/README.rst
@@ -44,5 +44,36 @@ If none of these are set, the FOG defaults will be used.  For simplicity's sake,
 * fog_webroot
 * fog_httpproto
 
+Per-machine-type boot exit types
+++++++++++++++++++++++++++++++++
+
+FOG's per-host boot "exit type" is the iPXE method used to hand off to the
+freshly-imaged local disk, and different testnode hardware needs a different
+one (the older BIOS sleds boot reliably with ``exit`` while smithi uses
+``sanboot``).  ``fog_machine_type_exit_types`` maps a machine-type prefix
+(hosts named ``<type><NNN>``) to the exit method(s) for its hosts and stamps
+them onto every matching FOG host::
+
+    fog_machine_type_exit_types:
+      smithi:     { bios: sanboot }          # efi left at the FOG global
+      trial:      { bios: exit, efi: exit }
+      trial-perf: { bios: exit, efi: exit }
+      gibba:      { bios: exit, efi: exit }
+
+Only the keys given for a type are enforced; omit ``bios`` or ``efi`` to
+leave that one at the FOG global default.  It defaults to ``{}`` (nothing
+managed) and is safe to run against a live FOG server -- it only updates
+``hostExitBios``/``hostExitEfi``, which FOG reads live at PXE time, and is a
+no-op once they already match.  Define the map in group_vars for the FOG
+server (see ceph-sepia-secrets).
+
+The task is tagged so it can be run on its own::
+
+    ansible-playbook fog-server.yml --tags exit-types
+
+``tools/generate-fog-csv.yml`` reads the same map, so hosts imported into
+FOG via CSV get their exit types from day one; this task converges hosts
+that already exist.
+
 .. _FOG: https://fogproject.org/
 .. _fogsettings: https://wiki.fogproject.org/wiki/index.php?title=.fogsettings

--- a/roles/fog-server/defaults/main.yml
+++ b/roles/fog-server/defaults/main.yml
@@ -2,3 +2,11 @@
 fog_user: fog
 fog_branch: stable
 fog_dhcp_server: false
+
+# Per-machine-type FOG boot exit types; see tasks/exit-types.yml.  Empty by
+# default (no host exit types are managed); set it in group_vars for the FOG
+# server.  Example:
+#   fog_machine_type_exit_types:
+#     smithi: { bios: sanboot }
+#     trial:  { bios: exit, efi: exit }
+fog_machine_type_exit_types: {}

--- a/roles/fog-server/files/apply-fog-exit-types.sh
+++ b/roles/fog-server/files/apply-fog-exit-types.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Stamp hostExitBios/hostExitEfi onto every FOG host of one machine type.
+# Driven by the fog-server role's exit-types task; inputs arrive as
+# environment variables:
+#   FOG_MTYPE      machine-type prefix (hosts are named <type><NNN>)
+#   FOG_EXIT_BIOS  bios exit method, or empty to leave it unmanaged
+#   FOG_EXIT_EFI   efi exit method, or empty to leave it unmanaged
+# Prints "CHANGED <n>" when rows were updated, "OK" otherwise.
+set -euo pipefail
+
+fs=/opt/fog/.fogsettings
+U=$(sed -n "s/^snmysqluser='\(.*\)'/\1/p" "$fs")
+P=$(sed -n "s/^snmysqlpass='\(.*\)'/\1/p" "$fs")
+H=$(sed -n "s/^snmysqlhost='\(.*\)'/\1/p" "$fs"); H=${H:-localhost}
+DB=$(sed -n "s/^mysqldbname='\(.*\)'/\1/p" "$fs"); DB=${DB:-fog}
+myq(){ MYSQL_PWD="$P" mysql -N -h"$H" -u"$U" "$DB" -e "$1"; }
+
+re="^${FOG_MTYPE}[0-9]+\$"
+sets=()
+diffs=()
+if [ -n "${FOG_EXIT_BIOS:-}" ]; then
+  sets+=("hostExitBios='$FOG_EXIT_BIOS'")
+  diffs+=("NOT (hostExitBios <=> '$FOG_EXIT_BIOS')")
+fi
+if [ -n "${FOG_EXIT_EFI:-}" ]; then
+  sets+=("hostExitEfi='$FOG_EXIT_EFI'")
+  diffs+=("NOT (hostExitEfi <=> '$FOG_EXIT_EFI')")
+fi
+if [ ${#sets[@]} -eq 0 ]; then
+  echo OK
+  exit 0
+fi
+set_clause="${sets[0]}"; for s in "${sets[@]:1}"; do set_clause="$set_clause, $s"; done
+diff_clause="${diffs[0]}"; for d in "${diffs[@]:1}"; do diff_clause="$diff_clause OR $d"; done
+
+n=$(myq "SELECT COUNT(*) FROM hosts WHERE hostName REGEXP '$re' AND ($diff_clause);")
+if [ "${n:-0}" -gt 0 ]; then
+  myq "UPDATE hosts SET $set_clause WHERE hostName REGEXP '$re' AND ($diff_clause);"
+  echo "CHANGED $n"
+else
+  echo OK
+fi

--- a/roles/fog-server/tasks/exit-types.yml
+++ b/roles/fog-server/tasks/exit-types.yml
@@ -1,0 +1,38 @@
+---
+# Stamp the FOG per-host boot "exit type" onto testnodes by machine type.
+#
+# FOG has no concept of a machine type, but our testnodes are named
+# <type><NNN> (smithi042, trial079, gibba014), and different hardware needs
+# a different iPXE exit method to hand off to the freshly-imaged local disk:
+# the BIOS sleds (smithi, gibba) boot reliably with `sanboot` while the UEFI
+# trial sleds use `exit`.  When the method is wrong the node images fine but
+# never boots the result.
+#
+# fog_machine_type_exit_types maps a machine-type prefix to the exit
+# method(s) for its hosts:
+#
+#   fog_machine_type_exit_types:
+#     smithi:     { bios: sanboot }          # efi left at the FOG global
+#     trial:      { bios: exit, efi: exit }
+#     gibba:      { bios: sanboot }
+#
+# Only the keys given for a type are enforced; an omitted key is left alone
+# (so the FOG global default keeps applying).  hostExitBios/hostExitEfi are
+# read live by FOG's boot menu at PXE time, so no cache rebuild or restart is
+# needed.  Safe on a running FOG server: it only UPDATEs those two columns
+# and is a no-op once they already match.
+
+- name: Apply FOG exit types per machine type
+  script: apply-fog-exit-types.sh
+  environment:
+    FOG_MTYPE: "{{ item.key }}"
+    FOG_EXIT_BIOS: "{{ item.value.bios | default('') }}"
+    FOG_EXIT_EFI: "{{ item.value.efi | default('') }}"
+  register: fog_exit_apply
+  changed_when: fog_exit_apply.stdout is search('CHANGED')
+  loop: "{{ fog_machine_type_exit_types | dict2items }}"
+  loop_control:
+    label: "{{ item.key }} -> {{ item.value }}"
+  when: fog_machine_type_exit_types | length > 0
+  tags:
+    - exit-types

--- a/roles/fog-server/tasks/main.yml
+++ b/roles/fog-server/tasks/main.yml
@@ -49,3 +49,7 @@
 
 # Safe to run on a live FOG server; not gated behind fog_force
 - import_tasks: hooks.yml
+
+# Also safe on a live server: only stamps per-host exit types (read live at
+# PXE time), and is a no-op once they match
+- import_tasks: exit-types.yml

--- a/tools/roles/generate-fog-csv/templates/csv.j2
+++ b/tools/roles/generate-fog-csv/templates/csv.j2
@@ -1,5 +1,13 @@
+{# Columns follow FOG's Host databaseFields order (mac first, id skipped):
+   ..., 27 = biosexit, 28 = efiexit, 29 = enforce.  The exit types come from
+   fog_machine_type_exit_types (group_vars for the FOG server, keyed by
+   machine-type prefix) so newly imported hosts boot with the right iPXE
+   handoff from day one; the fog-server role converges existing hosts. #}
+{% set _fogsrv = (groups['fog_server'] | default([])) | first | default('') %}
+{% set fog_exit_map = hostvars[_fogsrv]['fog_machine_type_exit_types'] | default({}) if _fogsrv else {} %}
 {% for host in groups['cobbler_managed'] %}
 {% if hostvars[host]['mac'] is defined %}
-"{{ hostvars[host]['mac'] }}","{{ hostvars[host]['inventory_hostname_short'] }}","","","1","0","","","fog","","","","","","","","","{{ hostvars[host]['kernel_options'] }}","","{{ hostvars[host]['fog_install_drive']|default('/dev/sda') }}","","","","","0000-00-00 00:00:00","110","","",""
+{% set fog_exits = fog_exit_map.get(hostvars[host]['inventory_hostname_short'] | regex_replace('[0-9]+$', ''), {}) %}
+"{{ hostvars[host]['mac'] }}","{{ hostvars[host]['inventory_hostname_short'] }}","","","1","0","","","fog","","","","","","","","","{{ hostvars[host]['kernel_options'] }}","","{{ hostvars[host]['fog_install_drive']|default('/dev/sda') }}","","","","","0000-00-00 00:00:00","110","{{ fog_exits.get('bios', '') }}","{{ fog_exits.get('efi', '') }}",""
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
## What

Adds `fog_machine_type_exit_types` — a map from machine-type prefix (testnodes are named `<type><NNN>`) to the FOG boot **exit type(s)** for that type — and uses it in **both** places hosts get their FOG settings:

- **`fog-server` role** (new `tasks/exit-types.yml`, tagged `exit-types`): stamps `hostExitBios`/`hostExitEfi` onto every matching *existing* FOG host. Live-safe (FOG reads the columns at PXE time, no-op once matched). Run just it with:
  ```
  ansible-playbook fog-server.yml --tags exit-types
  ```
- **`tools/generate-fog-csv`**: fills the `biosexit`/`efiexit` CSV columns (27/28 of FOG's host-import order, verified against `host.class.php` `databaseFields`) from the same map, so *newly imported* hosts are right from day one. Types not in the map render empty exactly as before.

```yaml
fog_machine_type_exit_types:
  smithi: { bios: sanboot }
  trial:  { bios: exit, efi: exit }
  gibba:  { bios: sanboot }
```

Only the keys given per type are enforced; omitted keys stay on the FOG global default. Defaults to `{}` (nothing managed). Values live in ceph/ceph-sepia-secrets#1224.

## Why

Wrong exit type = node images fine but never boots the result — how MAAS-seeded gibba nodes came up dark (ceph/ceph-build#2705). The BIOS sleds (smithi, gibba) need `sanboot`; the UEFI trial sleds use `exit`. (Note the exit type only matters once iPXE loads — BIOS types also need dnsmasq to serve them `undionly.kpxe`, fixed separately on soko01.)

Template change mock-rendered against Ansible's Jinja settings: gibba → sanboot, trial-perf → exit/exit (hyphenated prefixes work), unmapped types unchanged, missing fog_server group degrades gracefully.