### PR TITLE
testnode: let ntp install on fresh Ubuntu >= 24.04

### DIFF
--- a/roles/testnode/tasks/ntp.yml
+++ b/roles/testnode/tasks/ntp.yml
@@ -7,6 +7,20 @@
   tags:
     - packages
 
+# On Ubuntu >= 24.04 "ntp" is a transitional package for ntpsec, and the
+# preinstalled systemd-timesyncd Conflicts with the time-daemon it provides,
+# so apt refuses the install on a freshly-installed node.  Nodes imaged from
+# existing captures never hit this because ntp is already present.
+- name: Remove systemd-timesyncd so ntp/ntpsec can install on Ubuntu >= 24.04
+  apt:
+    name: systemd-timesyncd
+    state: absent
+  when: ansible_pkg_mgr == "apt" and
+        ansible_distribution == "Ubuntu" and
+        ansible_distribution_major_version | int >= 24
+  tags:
+    - packages
+
 - name: Install ntp package on apt based systems.
   apt:
     name: ntp


### PR DESCRIPTION
On noble, `ntp` is a transitional package for **ntpsec**, and the preinstalled `systemd-timesyncd` Conflicts with the `time-daemon` ntpsec provides — apt refuses the install on a freshly-installed node:

```
ntpsec : Conflicts: time-daemon
systemd-timesyncd : Conflicts: time-daemon
E: Error, pkgProblemResolver::Resolve generated breaks
```

Hit by sepia-fog-images build #17 on a MAAS-seeded (fresh-install) gibba running `ubuntu_24.04`; jammy is unaffected (real ntp package, worked in build #15), and nodes imaged from existing captures never hit it because ntp is already present. Remove `systemd-timesyncd` first (Ubuntu ≥ 24.04 only) so the install resolves.

Will be validated by the next `STARTWITHMAAS` gibba capture run with `CMANSIBLEBRANCH=wip-noble-ntp-timesyncd` (ceph/ceph-build#2705).