### PR TITLE
prep-fog-capture: don't lose the hostname race on a slow first boot

### DIFF
--- a/tools/roles/prep-fog-capture/files/cephlab-set-hostname.service
+++ b/tools/roles/prep-fog-capture/files/cephlab-set-hostname.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Ceph Lab hostname configuration
-After=network-online.target nss-lookup.target
+After=network-online.target nss-lookup.target netplan-from-link.service
 Wants=nss-lookup.target
 
 [Service]

--- a/tools/roles/prep-fog-capture/files/cephlab-set-hostname.sh
+++ b/tools/roles/prep-fog-capture/files/cephlab-set-hostname.sh
@@ -17,7 +17,7 @@ LOG="/var/log/cephlab-set-hostname.log"
 
 NAMESERVER="${NAMESERVER:-${1:-${DEFAULT_NAMESERVER}}}"
 
-MAX_WAIT_SECONDS="300"        # wait for /.cephlab_net_configured
+MAX_WAIT_SECONDS="900"        # netplan-from-link can take >5min on a slow first boot
 PING_WINDOW_SECONDS="600"     # 10 minutes
 DNS_WINDOW_SECONDS="600"      # 10 minutes
 LOOP_SLEEP_SECONDS="2"


### PR DESCRIPTION
`cephlab-set-hostname` waits for `/.cephlab_net_configured` (created by `netplan-from-link`) before doing reverse-DNS hostname setup — but only for **300s**. On gibba010's first ubuntu 24.04 boot, netplan-from-link created the flag at 22:50:34, *two seconds after* the 300s deadline, so the service exited FAILED and the node kept the capture host's baked-in hostname (`gibba014`) while otherwise healthy on its own IP. A reboot fixed it (fast second-boot networking).

Fixes:
- `MAX_WAIT_SECONDS` 300 → 900
- unit ordered `After=netplan-from-link.service`, so on fog-prepped images the flag exists before the wait even starts (systemd ignores ordering against absent units, so non-fog images are unaffected)

Found during the gibba fleet reimage validation (ceph/ceph-build#2705 workstream). The fix lands in deployed images at their next capture refresh.