### PR TITLE
testnode: Ubuntu 26.04 (Resolute) support

### DIFF
--- a/roles/ansible-managed/templates/cephlab_sudo
+++ b/roles/ansible-managed/templates/cephlab_sudo
@@ -1,5 +1,7 @@
 # {{ ansible_managed }}
 %sudo ALL=(ALL) NOPASSWD: ALL
+{% if not (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version | int >= 26) %}
 # For ansible pipelining
 Defaults !requiretty
 Defaults visiblepw
+{% endif %}

--- a/roles/common/tasks/apt_systems.yml
+++ b/roles/common/tasks/apt_systems.yml
@@ -1,6 +1,8 @@
 ---
+# Ubuntu >= 25.10 no longer ships /etc/timezone; the /etc/localtime
+# symlink (read via timedatectl) is the source of truth there.
 - name: Get the current timezone
-  shell: cat /etc/timezone
+  shell: cat /etc/timezone 2>/dev/null || timedatectl show -p Timezone --value
   register: current_tz
   changed_when: false
   tags:

--- a/roles/maas/tasks/config_maas.yml
+++ b/roles/maas/tasks/config_maas.yml
@@ -85,7 +85,10 @@
             88_create_sudo_group: ["curtin", "in-target", "--", "sh", "-c", "groupadd -f sudo"]
             90_create_cm_user: ["curtin", "in-target", "--", "sh", "-c", "useradd {{ cm_user }} -u 1001 -m -s /bin/bash -g sudo"]
             92_delete_cm_pass: ["curtin", "in-target", "--", "sh", "-c", "passwd -d cm"]
-            94_configure_sudo: ["curtin", "in-target", "--", "sh", "-c", "printf '%%sudo ALL=(ALL) NOPASSWD: ALL\nDefaults !requiretty\nDefaults visiblepw' >> /etc/sudoers.d/cephlab_sudo"]
+            # No legacy Defaults here: requiretty hasn't been a distro
+            # default since EL7, and Ubuntu >= 25.10's sudo-rs rejects
+            # requiretty/visiblepw (and a missing trailing newline) outright.
+            94_configure_sudo: ["curtin", "in-target", "--", "sh", "-c", "printf '%%sudo ALL=(ALL) NOPASSWD: ALL\n' >> /etc/sudoers.d/cephlab_sudo"]
             96_create_ssh_directory: ["curtin", "in-target", "--", "sh", "-c", "mkdir -p /home/cm/.ssh"]
             98_copy_ssh_keys_cm: ["curtin", "in-target", "--", "sh", "-c", "echo '{{ cm_user_ssh_keys|join('\n') }}' >> /home/cm/.ssh/authorized_keys"]
       when: "cm_user_ssh_keys is defined and cm_user is defined"

--- a/roles/testnode/tasks/ntp.yml
+++ b/roles/testnode/tasks/ntp.yml
@@ -21,9 +21,12 @@
   tags:
     - packages
 
+# Ubuntu 26.04 dropped the transitional "ntp" package outright; ntpsec is
+# the replacement and its unit ships Alias=ntp.service, so the service
+# tasks below keep working with ntp_service_name unchanged.
 - name: Install ntp package on apt based systems.
   apt:
-    name: ntp
+    name: "{{ 'ntpsec' if (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version | int >= 26) else 'ntp' }}"
     state: present
   when: ansible_pkg_mgr  == "apt"
   tags:

--- a/roles/testnode/templates/ssh/sshd_config_ubuntu_26
+++ b/roles/testnode/templates/ssh/sshd_config_ubuntu_26
@@ -1,0 +1,81 @@
+# {{ ansible_managed }}
+# Package generated configuration file
+# See the sshd_config(5) manpage for details
+
+# What ports, IPs and protocols we listen for
+Port 22
+# Use these options to restrict which interfaces/protocols sshd will bind to
+#ListenAddress ::
+#ListenAddress 0.0.0.0
+Protocol 2
+# HostKeys for protocol version 2
+HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
+HostKey /etc/ssh/ssh_host_ed25519_key
+
+# Logging
+SyslogFacility AUTH
+LogLevel INFO
+
+# Authentication:
+LoginGraceTime 120
+PermitRootLogin without-password
+StrictModes yes
+
+PubkeyAuthentication yes
+#AuthorizedKeysFile	%h/.ssh/authorized_keys
+
+# Don't read the user's ~/.rhosts and ~/.shosts files
+IgnoreRhosts yes
+# similar for protocol version 2
+HostbasedAuthentication no
+# Uncomment if you don't trust ~/.ssh/known_hosts for RhostsRSAAuthentication
+#IgnoreUserKnownHosts yes
+
+# To enable empty passwords, change to yes (NOT RECOMMENDED)
+PermitEmptyPasswords no
+
+# Change to yes to enable challenge-response passwords (beware issues with
+# some PAM modules and threads)
+ChallengeResponseAuthentication no
+
+# Change to no to disable tunnelled clear text passwords
+#PasswordAuthentication yes
+
+# Kerberos options
+#KerberosAuthentication no
+#KerberosGetAFSToken no
+#KerberosOrLocalPasswd yes
+#KerberosTicketCleanup yes
+
+# GSSAPI options
+#GSSAPIAuthentication no
+#GSSAPICleanupCredentials yes
+
+X11Forwarding yes
+X11DisplayOffset 10
+PrintMotd no
+PrintLastLog yes
+TCPKeepAlive yes
+#UseLogin no
+
+#MaxStartups 10:30:60
+#Banner /etc/issue.net
+
+# Allow client to pass locale environment variables
+AcceptEnv LANG LC_*
+
+Subsystem sftp /usr/lib/openssh/sftp-server
+
+# Set this to 'yes' to enable PAM authentication, account processing,
+# and session processing. If this is enabled, PAM authentication will
+# be allowed through the ChallengeResponseAuthentication and
+# PasswordAuthentication.  Depending on your PAM configuration,
+# PAM authentication via ChallengeResponseAuthentication may bypass
+# the setting of "PermitRootLogin without-password".
+# If you just want the PAM account and session checks to run without
+# PAM authentication, then enable this but set PasswordAuthentication
+# and ChallengeResponseAuthentication to 'no'.
+UsePAM yes
+
+MaxSessions 1000

--- a/roles/testnode/vars/ubuntu_26.yml
+++ b/roles/testnode/vars/ubuntu_26.yml
@@ -1,0 +1,29 @@
+---
+packages:
+  - mpich
+  - qemu-system-x86
+#  - blkin
+  - lttng-tools
+  # for building xfstests #18067
+  - libtool-bin
+  # for ceph-daemon (no podman on ubuntu/debian, yet)
+  - docker.io
+  # qa/workunits/rbd/test_librbd_python.sh
+  - python3-nose
+  # python3 version of deps
+  - python3-venv
+  - python3-virtualenv
+  - python3-configobj
+  - python3-gevent
+  - python3-numpy
+  - python3-matplotlib
+  - python3-setuptools
+  - python3-dev
+
+non_aarch64_packages:
+  - libgoogle-perftools4t64
+  - iozone3
+
+non_aarch64_packages_to_upgrade: []
+
+python_apt_package_name: python3-apt

--- a/roles/testnode/vars/ubuntu_26.yml
+++ b/roles/testnode/vars/ubuntu_26.yml
@@ -27,3 +27,9 @@ non_aarch64_packages:
 non_aarch64_packages_to_upgrade: []
 
 python_apt_package_name: python3-apt
+
+# Overrides ubuntu.yml's list: resolute dropped smbios-utils (libsmbios is
+# gone upstream) and the bare "libfcgi" name (time_t transition).
+non_aarch64_common_packages:
+  - libfcgi0t64
+  - sysprof

--- a/roles/testnode/vars/ubuntu_26.yml
+++ b/roles/testnode/vars/ubuntu_26.yml
@@ -33,3 +33,88 @@ python_apt_package_name: python3-apt
 non_aarch64_common_packages:
   - libfcgi0t64
   - sysprof
+
+# Overrides ubuntu.yml's common_packages for resolute renames/removals:
+# libfcgi0ldbl->libfcgi0t64, git-core->git, libncurses5-dev->libncurses-dev,
+# libgnutls30->libgnutls30t64.
+common_packages:
+  # for apache
+  - libfcgi0t64
+  ###
+  # for s3 tests
+  - libev-dev
+  ###
+  # for cpan
+  - perl
+  - libwww-perl
+  ###
+  - lsb-release
+  - build-essential
+  - sysstat
+  - gdb
+  # for running ceph
+  - libedit2
+  - cryptsetup-bin
+  - xfsprogs
+  - gdisk
+  - parted
+  ###
+  # for setting BIOS settings
+  ###
+  - libuuid1
+  # for compiling helpers and such
+  - libatomic-ops-dev
+  ###
+  # used by workunits
+  - git
+  - attr
+  - dbench
+  - bonnie++
+  - valgrind
+  - ant
+  ###
+  # used by the xfstests tasks
+  - libtool
+  - automake
+  - gettext
+  - uuid-dev
+  - libacl1-dev
+  - bc
+  - xfsdump
+  - xfslibs-dev
+  - libattr1-dev
+  - quota
+  - libcap2-bin
+  - libncurses-dev
+  - lvm2
+  ###
+  - vim
+  - pdsh
+  # for blktrace and seekwatcher
+  - blktrace
+  ###
+  # qemu
+  - genisoimage
+  ###
+  # for json_xs to investigate JSON by hand
+  - libjson-xs-perl
+  # for pretty-printing xml
+  - xml-twig-tools
+  # for java bindings, hadoop, etc.
+  - default-jdk
+  - junit4
+  ###
+  # for samba testing
+  - cifs-utils
+  # for Static IP
+  - ipcalc
+  # nfs
+  - nfs-common
+  - nfs-kernel-server
+  # for add-apt-repository
+  - software-properties-common
+  # for https://twitter.com/letsencrypt/status/1443621997288767491
+  - libgnutls30t64
+  # for nvme firmware updates
+  - nvme-cli
+  - curl

--- a/tools/roles/prep-fog-capture/files/netplan-from-link.sh
+++ b/tools/roles/prep-fog-capture/files/netplan-from-link.sh
@@ -12,6 +12,9 @@ exec > >(tee -a "$LOG") 2>&1
 
 log() {
   echo "$(date -u +%FT%T.%N | cut -c1-23) netplan-from-link: $*" >&2
+  # Best-effort copy to the serial console so a node that loses its
+  # network can still be diagnosed over SOL
+  echo "netplan-from-link: $*" > /dev/console 2>/dev/null || true
 }
 
 log "starting"

--- a/tools/roles/prep-fog-capture/tasks/apt.yml
+++ b/tools/roles/prep-fog-capture/tasks/apt.yml
@@ -95,3 +95,11 @@
   command: netplan apply
   changed_when: true
   failed_when: false
+
+# netplan apply restarts networkd and renegotiates DHCP; give the node
+# time to come back instead of failing the next task on a blip (resolute
+# drops the address noticeably longer than noble here).
+- name: Wait for the connection to settle after netplan apply
+  wait_for_connection:
+    delay: 5
+    timeout: 300

--- a/tools/roles/prep-fog-capture/tasks/main.yml
+++ b/tools/roles/prep-fog-capture/tasks/main.yml
@@ -36,27 +36,24 @@
   when: ansible_os_family == "Debian"
 
 # FOG's "exit" boot type hands control back to the firmware, which walks
-# BootOrder from where PXE left off.  A MAAS/curtin install (and a grub
-# reinstall on it) leaves the OS entry *behind* the firmware's built-in
-# EFI shell, so every reboot parks in the shell instead of reaching the
-# OS (trial025, sepia-fog-images #31).  FOS recreates the OS entry at the
-# front on image deploy, so imaged nodes are fine; fix the seed node's
-# NVRAM here by moving the shell to the end.  PXE-first is preserved.
-- name: Keep the firmware EFI shell last in BootOrder
+# BootOrder from where PXE left off.  A MAAS/curtin-seeded node ends up
+# with the firmware's built-in EFI shell *ahead* of the OS entry, so a
+# plain reboot parks in the shell (trial001/trial025/trial045,
+# sepia-fog-images #31).  On the trial Supermicro (AMI) firmware a
+# BootOrder rewrite from the OS does not survive POST, but a one-shot
+# BootNext does, so point the next boot straight at the OS entry for the
+# reboot below (no FOG task is pending, so skipping PXE once is fine).
+# The lasting fix is `bcfg boot mv <os> <shell>` from the UEFI shell over
+# SOL; FOS does not repair it on deploy either.
+- name: Point the next boot at the OS entry (seed nodes park in the EFI shell otherwise)
   shell: |
     set -e
     [ -d /sys/firmware/efi ] && command -v efibootmgr >/dev/null || exit 0
-    entries=$(efibootmgr)
-    order=$(echo "$entries" | awk -F': ' '/^BootOrder/{print $2}')
-    shell=$(echo "$entries" | awk '/Built-in EFI Shell/{print substr($1,5,4)}' | head -n1)
-    [ -n "$order" ] && [ -n "$shell" ] || exit 0
-    new=$(echo "$order" | tr ',' '\n' | grep -vx "$shell" | paste -sd, -)
-    new="${new},${shell}"
-    [ "$new" != "$order" ] || exit 0
-    efibootmgr -o "$new" >/dev/null
-    echo "changed: $order -> $new"
-  register: efi_bootorder
-  changed_when: "'changed' in efi_bootorder.stdout"
+    cur=$(efibootmgr | awk -F': ' '/^BootCurrent/{print $2}')
+    [ -n "$cur" ] || exit 0
+    efibootmgr -n "$cur" >/dev/null && echo "BootNext=$cur"
+  register: efi_bootnext
+  changed_when: "'BootNext' in efi_bootnext.stdout"
 
 # If we updated the kernel in apt/rpm.yml
 - name: Reboot if required

--- a/tools/roles/prep-fog-capture/tasks/main.yml
+++ b/tools/roles/prep-fog-capture/tasks/main.yml
@@ -72,9 +72,11 @@
 # if the time is off, it slowly drifts back in sync.  Since our testnodes
 # are ephemeral, they don't ever have enough time to correctly drift
 # back to the correct time.  So we'll force it in the captured OS images.
+# Ubuntu >= 26.04 only ships ntpsec-ntpdate (no Provides: ntpdate), which
+# still installs the ntpdate command the task below relies on.
 - name: Install ntpdate command if missing
   package:
-    name: ntpdate
+    name: "{{ 'ntpsec-ntpdate' if (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version | int >= 26) else 'ntpdate' }}"
     state: present
   when: '"ntp" in ntp_service'
 

--- a/tools/roles/prep-fog-capture/tasks/main.yml
+++ b/tools/roles/prep-fog-capture/tasks/main.yml
@@ -35,6 +35,29 @@
   import_tasks: apt.yml
   when: ansible_os_family == "Debian"
 
+# FOG's "exit" boot type hands control back to the firmware, which walks
+# BootOrder from where PXE left off.  A MAAS/curtin install (and a grub
+# reinstall on it) leaves the OS entry *behind* the firmware's built-in
+# EFI shell, so every reboot parks in the shell instead of reaching the
+# OS (trial025, sepia-fog-images #31).  FOS recreates the OS entry at the
+# front on image deploy, so imaged nodes are fine; fix the seed node's
+# NVRAM here by moving the shell to the end.  PXE-first is preserved.
+- name: Keep the firmware EFI shell last in BootOrder
+  shell: |
+    set -e
+    [ -d /sys/firmware/efi ] && command -v efibootmgr >/dev/null || exit 0
+    entries=$(efibootmgr)
+    order=$(echo "$entries" | awk -F': ' '/^BootOrder/{print $2}')
+    shell=$(echo "$entries" | awk '/Built-in EFI Shell/{print substr($1,5,4)}' | head -n1)
+    [ -n "$order" ] && [ -n "$shell" ] || exit 0
+    new=$(echo "$order" | tr ',' '\n' | grep -vx "$shell" | paste -sd, -)
+    new="${new},${shell}"
+    [ "$new" != "$order" ] || exit 0
+    efibootmgr -o "$new" >/dev/null
+    echo "changed: $order -> $new"
+  register: efi_bootorder
+  changed_when: "'changed' in efi_bootorder.stdout"
+
 # If we updated the kernel in apt/rpm.yml
 - name: Reboot if required
   reboot:


### PR DESCRIPTION
Ubuntu 26.04 (resolute) testnode support, driven by iterating `sepia-fog-images` (`STARTWITHMAAS`, #2705) until it captured and verified `trial_ubuntu_26.04` (run #31). Modeled on the noble enablement (#777) plus everything resolute actually broke:

**testnode**
- `vars/ubuntu_26.yml`: noble list with `libgoogle-perftools4` → `libgoogle-perftools4t64`; overrides `non_aarch64_common_packages` (resolute dropped `smbios-utils` — libsmbios is gone upstream — and the bare `libfcgi` name) and `common_packages` with explicit current names (`libfcgi0t64`, `git`, `libncurses-dev`, `libgnutls30t64`; apt still resolves the old names via transitional Provides, but say what we mean).
- `sshd_config_ubuntu_26`: noble template minus the DSA host key (OpenSSH 10 dropped DSA).
- ntp: resolute removed the transitional `ntp` package entirely; install `ntpsec` on Ubuntu >= 26 (its unit ships `Alias=ntp.service`, so `ntp_service_name` and the service tasks stay unchanged).

**common / ansible-managed / maas**
- `/etc/timezone` no longer exists on resolute; fall back to `timedatectl`.
- Ubuntu 25.10+ ships **sudo-rs**, whose visudo rejects `Defaults !requiretty` / `visiblepw` (and a missing trailing newline): omit them from `cephlab_sudo` on Ubuntu >= 26, and stop writing them from the MAAS curtin preseed (soko02's live preseed already patched to match).

**prep-fog-capture**
- `ntpsec-ntpdate` on Ubuntu >= 26 (no `Provides: ntpdate`).
- `wait_for_connection` after the netplan apply (resolute drops the address longer than noble during DHCP renegotiation), and `netplan-from-link` mirrors its log to `/dev/console` so a network-dead node can be diagnosed over SOL.
- **BootNext for the in-job reboot**: a MAAS/curtin-seeded node ends up with the firmware's built-in EFI Shell *ahead* of the `ubuntu` entry, so FOG's `exit` boot type parks every reboot in the shell (the "reboot hang" on trial001/025/045, proven with `bcfg boot dump`). On the trial Supermicro/AMI firmware an `efibootmgr -o` rewrite does not survive POST and FOS does not repair NVRAM on deploy, but a one-shot `BootNext` is honored, so the post-upgrade reboot is pointed straight at the OS entry. The lasting repair for a seeded node is `bcfg boot mv <os> <shell>` from the UEFI shell over SOL (verified on all three).

The existing `>= 24` conditionals (timesyncd removal, global pip install) already cover 26, and `distro_mirror_ubuntu_releases` already lists resolute.
