### PR TITLE
fog-server: tune php-fpm/MariaDB for reimage storms; enforce lab FOG settings

### DIFF
--- a/roles/fog-server/defaults/main.yml
+++ b/roles/fog-server/defaults/main.yml
@@ -18,3 +18,19 @@ fog_php_fpm_pm_settings:
   pm.min_spare_servers: 15
   pm.max_spare_servers: 40
 fog_mysql_max_connections: 350
+
+# Deliberate deviations from the FOG defaults, enforced in the FOG
+# database; see tasks/settings.yml
+fog_global_settings:
+  # teuthology drives FOG through the REST API
+  FOG_API_ENABLED: 1
+  # BIOS hosts exit the boot menu via sanboot when they have no task
+  FOG_BOOT_EXIT_TYPE: sanboot
+  # verbose kernel console output for debugging via conserver
+  FOG_KERNEL_LOGLEVEL: 7
+  # zstd image compression (FOG default is gzip)
+  FOG_IMAGE_COMPRESSION_FORMAT_DEFAULT: 5
+  FOG_PIGZ_COMP: 6
+# Concurrent unicast deploys before further nodes wait in line
+# (FOG default: 10)
+fog_storage_max_clients: 30

--- a/roles/fog-server/defaults/main.yml
+++ b/roles/fog-server/defaults/main.yml
@@ -10,3 +10,11 @@ fog_dhcp_server: false
 #     smithi: { bios: sanboot }
 #     trial:  { bios: exit, efi: exit }
 fog_machine_type_exit_types: {}
+
+# php-fpm pool sizing for parallel reimage storms; see tasks/tuning.yml
+fog_php_fpm_pm_settings:
+  pm.max_children: 250
+  pm.start_servers: 20
+  pm.min_spare_servers: 15
+  pm.max_spare_servers: 40
+fog_mysql_max_connections: 350

--- a/roles/fog-server/handlers/main.yml
+++ b/roles/fog-server/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: reload php-fpm
+  service:
+    name: "php{{ php_version.stdout }}-fpm"
+    state: reloaded
+
+- name: restart mariadb
+  service:
+    name: mariadb
+    state: restarted

--- a/roles/fog-server/tasks/main.yml
+++ b/roles/fog-server/tasks/main.yml
@@ -56,3 +56,6 @@
 
 # Safe to run on a live FOG server; not gated behind fog_force
 - import_tasks: tuning.yml
+
+# Safe to run on a live FOG server; not gated behind fog_force
+- import_tasks: settings.yml

--- a/roles/fog-server/tasks/main.yml
+++ b/roles/fog-server/tasks/main.yml
@@ -53,3 +53,6 @@
 # Also safe on a live server: only stamps per-host exit types (read live at
 # PXE time), and is a no-op once they match
 - import_tasks: exit-types.yml
+
+# Safe to run on a live FOG server; not gated behind fog_force
+- import_tasks: tuning.yml

--- a/roles/fog-server/tasks/settings.yml
+++ b/roles/fog-server/tasks/settings.yml
@@ -1,0 +1,27 @@
+---
+# FOG settings the lab deliberately changed from the FOG defaults.  FOG
+# keeps these in its database, so a reinstall or a fresh FOG server would
+# silently revert them; enforce them here instead.  Values are quoted for
+# the shell but not escaped for SQL, so keep them to simple tokens.
+
+- name: Apply FOG global settings
+  command: >
+    mysql fog -N -B -e
+    "UPDATE globalSettings
+     SET settingValue = '{{ item.value }}'
+     WHERE settingKey = '{{ item.key }}'
+       AND settingValue != '{{ item.value }}';
+     SELECT ROW_COUNT();"
+  register: fog_global_setting
+  changed_when: fog_global_setting.stdout | int > 0
+  loop: "{{ fog_global_settings | dict2items }}"
+
+- name: Set storage node max clients
+  command: >
+    mysql fog -N -B -e
+    "UPDATE nfsGroupMembers
+     SET ngmMaxClients = {{ fog_storage_max_clients }}
+     WHERE ngmMaxClients != {{ fog_storage_max_clients }};
+     SELECT ROW_COUNT();"
+  register: fog_max_clients
+  changed_when: fog_max_clients.stdout | int > 0

--- a/roles/fog-server/tasks/tuning.yml
+++ b/roles/fog-server/tasks/tuning.yml
@@ -1,0 +1,32 @@
+---
+# When the dispatcher reimages many testnodes at once, every node hammers
+# FOG's checkin/progress endpoints.  The distro php-fpm default of
+# pm.max_children = 50 saturates during those storms: FOS clients print
+# "Attempting to check in... Failed" / "No Active Task found", eventually
+# give up, and boot the old OS from disk, which teuthology reports as
+# "Expected <os> but found <other os>".  php-fpm workers are ~25MB each,
+# so the sizing below costs a few GB of RAM at full load.
+
+- name: Get PHP version
+  command: php -r 'echo PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION;'
+  changed_when: false
+  register: php_version
+
+- name: Tune php-fpm pool for reimage storms
+  lineinfile:
+    path: "/etc/php/{{ php_version.stdout }}/fpm/pool.d/www.conf"
+    regexp: '^;?{{ item.key }} = '
+    line: "{{ item.key }} = {{ item.value }}"
+  loop: "{{ fog_php_fpm_pm_settings | dict2items }}"
+  notify: reload php-fpm
+
+# More php-fpm workers need more database connection headroom than the
+# MariaDB default of 151.
+- name: Raise MariaDB connection limit for reimage storms
+  copy:
+    dest: /etc/mysql/mariadb.conf.d/99-fog-tuning.cnf
+    content: |
+      # Managed by the ceph-cm-ansible fog-server role
+      [mysqld]
+      max_connections = {{ fog_mysql_max_connections }}
+  notify: restart mariadb


### PR DESCRIPTION
## What

Two changes to the `fog-server` role, both safe to run on a live FOG server (not gated behind `fog_force`):

1. **php-fpm and MariaDB tuning** (`tasks/tuning.yml`): raise `pm.max_children` 50 → 250 (with warmer spare-server floors) and MariaDB `max_connections` 151 → 350, both overridable via role defaults.
2. **Enforce the lab's deliberate FOG settings** (`tasks/settings.yml`): FOG keeps its settings in its database, so a reinstall or rebuilt server silently reverts anything changed through the web UI. Capture the settings that differ from FOG's defaults (found by diffing the live `globalSettings` table against `commons/schema.php`) and enforce them idempotently: `FOG_API_ENABLED=1` (teuthology drives FOG via the REST API), `FOG_BOOT_EXIT_TYPE=sanboot`, `FOG_KERNEL_LOGLEVEL=7`, zstd image compression (format 5, pigz 6), and storage-node max clients 30 (FOG default 10).

## Why

On 2026-09-05 a large rados run reimaged 50+ nodes concurrently and saturated the FOG server's php-fpm pool (`server reached pm.max_children setting (50)` in the log). FOS clients logged `Attempting to check in... Failed` / `No Active Task found` on their serial consoles, gave up after a few minutes, and booted the old OS from disk, which teuthology reported as `Expected <os> to be X but found Y` — ~60 dead jobs across several runs.

The tuning has been applied live on soko03 and verified: `boot.php` responds in ~44 ms and a subsequent deploy checked in instantly and completed cleanly. The settings task is a no-op against the current live values.