### PR TITLE
public_facing: add sentry.ceph.com site

### DIFF
--- a/roles/public_facing/defaults/main.yml
+++ b/roles/public_facing/defaults/main.yml
@@ -144,6 +144,16 @@ reverse_proxy_site_catalog:
     # answer challenges.
     conf: quay.ceph.io.conf
     upstream: quay-quay-app.apps.pok.os.sepia.ceph.com
+  sentry:
+    conf: sentry.ceph.com.conf
+    upstream: sentry-sentry.apps.pok.os.sepia.ceph.com
+    anubis:
+      port: 8932
+      metrics_port: 9992
+      # https + cacert: the sentry Routes redirect http, so Anubis must
+      # talk TLS to the router (default wildcard cert, ingress CA).
+      scheme: https
+      cacert: true
   status:
     # No Anubis: the page is two small documents behind a 30s micro-cache
     # (see the template), so the backend sees ~2 req/min per URL no matter

--- a/roles/public_facing/templates/reverse_proxy/sites/sentry.ceph.com.conf.j2
+++ b/roles/public_facing/templates/reverse_proxy/sites/sentry.ceph.com.conf.j2
@@ -1,0 +1,79 @@
+{% set site = reverse_proxy_site_catalog['sentry'] %}
+# {{ ansible_managed }}
+# sentry.ceph.com -> Sentry on OpenShift ('sentry' namespace, edge Route).
+# Public entry point so the GitHub app (sentrycephcom) OAuth callbacks and
+# webhook deliveries work; sentry's system.url-prefix is this name.
+# Lab/VPN users can also browse via sentry.front.sepia.ceph.com directly.
+server {
+  listen 80;
+  server_name sentry.ceph.com;
+
+  location ^~ /.well-known/acme-challenge/ {
+    root /var/www/letsencrypt;
+    default_type "text/plain";
+  }
+
+  location / {
+    return 301 https://$host$request_uri;
+  }
+}
+
+server {
+  listen 443 ssl http2;
+  server_name sentry.ceph.com;
+
+  ssl_certificate     /etc/letsencrypt/live/sentry.ceph.com/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/sentry.ceph.com/privkey.pem;
+  include /etc/letsencrypt/options-ssl-nginx.conf;
+
+  access_log /var/log/nginx/sentry-access.log;
+  error_log  /var/log/nginx/sentry-error.log;
+
+  # OpenShift Route host (no scheme, no slash)
+  set $upstream_host {{ site.upstream }};
+
+  # SDK event envelopes can be chunky (matches the in-cluster nginx cap)
+  client_max_body_size 100m;
+
+  # Machine endpoints that can't answer an Anubis challenge: SDK ingestion
+  # and API clients (/api/...) plus GitHub webhook/setup deliveries
+  # (/extensions/...). Straight to the route over TLS; requests are
+  # DSN/token/HMAC-authenticated by sentry itself.
+  location ~ ^/(api|extensions)/ {
+    proxy_pass https://$upstream_host;
+    proxy_set_header Host $upstream_host;
+    proxy_ssl_server_name on;
+    proxy_ssl_name $upstream_host;
+
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+
+    proxy_http_version 1.1;
+    proxy_buffering off;
+  }
+
+  location / {
+    # Per-site Anubis instance (anubis@sentry), same pattern as the
+    # 2026-08-10 all-sites rollout. Anubis connects to the route over TLS
+    # itself (SSL_CERT_FILE in /etc/anubis/sentry.env).
+    proxy_pass http://127.0.0.1:{{ site.anubis.port }};
+
+    # Rewrite backend redirects that leak the internal route hostname.
+    proxy_redirect http://{{ site.upstream }}/ /;
+    proxy_redirect https://{{ site.upstream }}/ /;
+
+    # Make the OpenShift router match the correct route; sentry rebuilds
+    # the public name from X-Forwarded-Host (USE_X_FORWARDED_HOST).
+    proxy_set_header Host {{ site.upstream }};
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+
+    proxy_http_version 1.1;
+    proxy_read_timeout 120s;
+    proxy_buffering off;
+  }
+}


### PR DESCRIPTION
Stacked on #879 (based to that branch so only the sentry commit shows; retarget to main if #879 merges first).

Sentry moved to OpenShift (ceph/sepia-openshift#80). This adds the public reverse-proxy site for **sentry.ceph.com** so the GitHub app (sentrycephcom) OAuth callbacks and webhook deliveries work:

- onboarding-style vhost: Anubis (`anubis@sentry`, 8932/9992) fronting the UI
- `/api/` (SDK ingestion, API clients) and `/extensions/` (GitHub webhooks) bypass Anubis straight to the edge Route — DSN/token/HMAC-authenticated by sentry itself
- Anubis targets the route over https with the ingress CA (the sentry Routes redirect plain http)

Outside this repo, still needed:
- ceph-sepia-secrets: `reverse_proxy_sites` += `sentry` and an `anubis_ed25519_keys.sentry` entry for soko01 (whenever #879's host_vars land)
- NS1: `sentry.ceph.com` A 8.43.84.129 → **192.86.31.5** (currently points at the old gw)

The vhost/cert/anubis instance are being hand-applied on soko01 to match, same as the pre-#879 sites.