### PR TITLE
ansible-managed: write cephlab_sudo before validating /etc/sudoers

### DIFF
--- a/roles/ansible-managed/tasks/main.yml
+++ b/roles/ansible-managed/tasks/main.yml
@@ -25,16 +25,12 @@
   tags:
    - user
 
-- name: Ensure includedir is present in sudoers.
-  lineinfile:
-    dest: /etc/sudoers
-    line: "#includedir /etc/sudoers.d"
-    state: present
-    validate: visudo -cf %s
-  tags:
-    - sudoers
-    - user
-
+# Write our sudoers.d fragment BEFORE validating /etc/sudoers below.  A node
+# imaged from an older capture can carry a stale /etc/sudoers.d/cephlab_sudo
+# that newer sudo rejects (e.g. Ubuntu 26.04 dropped `requiretty`), which
+# makes `visudo -cf /etc/sudoers` -- and thus the includedir task -- fail on
+# the pre-existing file before we ever get a chance to replace it.  Writing
+# the current template first clears that.
 - name: Create the cephlab_sudo sudoers.d file.
   template:
     src: cephlab_sudo
@@ -42,6 +38,16 @@
     owner: root
     group: root
     mode: 0440
+    validate: visudo -cf %s
+  tags:
+    - sudoers
+    - user
+
+- name: Ensure includedir is present in sudoers.
+  lineinfile:
+    dest: /etc/sudoers
+    line: "#includedir /etc/sudoers.d"
+    state: present
     validate: visudo -cf %s
   tags:
     - sudoers


### PR DESCRIPTION
## Why

sepia-fog-images builds #34/#35 (`ubuntu_26.04` via STARTWITHMAAS) failed in cephlab's `ansible-managed` play at **"Ensure includedir is present in sudoers"**:

```
/etc/sudoers.d/cephlab_sudo:2:11: unknown setting: 'requiretty'
visudo: invalid sudoers file
```

That task runs `validate: visudo -cf /etc/sudoers`, which validates the whole tree including `/etc/sudoers.d/*`. The MAAS-seeded 26.04 node carries a **stale `cephlab_sudo` baked into the image** (old format: `Defaults !requiretty` / `visiblepw`, no guard), and 26.04's sudo rejects `requiretty` — so validation fails on the pre-existing fragment **before** the later "Create the cephlab_sudo sudoers.d file" task can overwrite it with the fixed, guarded template.

The 26.04 guard from #877-era commit 92f695e is correct (verified: renders 2 valid lines for major_version 26, includes the legacy Defaults for 24) — it just never got to run.

## Fix

Reorder: write the current `cephlab_sudo` template **first** (clearing the stale fragment), then do the includedir + `/etc/sudoers` validation. Order-only; no change for nodes whose fragment was already current. Also lets a clean 26.04 capture be taken, after which deployed images no longer carry the bad fragment.