### PR TITLE
alloy: Fedora node_exporter, force_handlers, and exclude DNS-alias hostnames

### DIFF
--- a/alloy.yml
+++ b/alloy.yml
@@ -18,6 +18,13 @@
 # ([testnodes:children] is smithi, ovh, gibba and trial). The testnode role can
 # pull this role in for metrics only with run_alloy_role: true.
 #
+# The trailing exclusions are DNS aliases, not machines: teuthology.front is a
+# CNAME for soko04.front, and o01/o02.front are CNAMEs for their .vlan107
+# names. Running the play against both names of one machine makes the last
+# writer win the instance/host labels, so the box flaps identities between
+# runs (that is how "teuthology" spent a week reporting as soko04 and vice
+# versa). One name per machine: the real hostname stays, the alias goes.
+#
 # Groups, and why each is here:
 #   infrastructure       lab services (hv01-04, store01, satellite, chacra, ...)
 #   ci_infrastructure    shaman, chacra, jenkins controllers and builders
@@ -27,7 +34,7 @@
 #   folio, sockeni       dev boxes
 #   vossi                dev boxes
 - hosts: >-
-    infrastructure:ci_infrastructure:public_facing:long_running_cluster:officinalis:mako:folio:sockeni:vossi:!infra_compute:!infra_storage:!cnv
+    infrastructure:ci_infrastructure:public_facing:long_running_cluster:officinalis:mako:folio:sockeni:vossi:!infra_compute:!infra_storage:!cnv:!teuthology:!o01.front.sepia.ceph.com:!o02.front.sepia.ceph.com
   strategy: free
   # A failed task (e.g. the wedged dpkg on soko02) must not eat the queued
   # "Restart alloy" handler -- that leaves alloy running an old config while

--- a/alloy.yml
+++ b/alloy.yml
@@ -29,6 +29,10 @@
 - hosts: >-
     infrastructure:ci_infrastructure:public_facing:long_running_cluster:officinalis:mako:folio:sockeni:vossi:!infra_compute:!infra_storage:!cnv
   strategy: free
+  # A failed task (e.g. the wedged dpkg on soko02) must not eat the queued
+  # "Restart alloy" handler -- that leaves alloy running an old config while
+  # the file on disk says otherwise, which took days to notice.
+  force_handlers: true
   roles:
     - alloy
   become: true

--- a/roles/alloy/tasks/node-exporter.yml
+++ b/roles/alloy/tasks/node-exporter.yml
@@ -38,7 +38,10 @@
       ansible.builtin.dnf:
         name: epel-release
         state: present
-      when: ansible_os_family == "RedHat"
+      # Fedora carries node_exporter in its own repos and has no epel-release.
+      when:
+        - ansible_os_family == "RedHat"
+        - ansible_distribution != "Fedora"
 
     - name: node_exporter - Install {{ alloy_node_exporter_package }}
       ansible.builtin.package:


### PR DESCRIPTION
Three fixes on top of the merged alloy work (#862, #876), all found while pushing the rollout to the last stragglers in the fleet.

## What changed

- **`node-exporter.yml`: skip `epel-release` on Fedora.** Fedora ships `node_exporter` (as `node-exporter`) in its own repos and has no `epel-release` package, so the EPEL task failed the play on the Fedora dev boxes (sockeni07, vossi05). Guarded the EPEL install with `ansible_distribution != "Fedora"`.

- **`alloy.yml`: `force_handlers: true`.** A task failing mid-run (e.g. soko02's permanently wedged MAAS `dpkg`) silently dropped the queued `Restart alloy` handler, so the host kept running a month-old config while the on-disk config had already changed. Forcing handlers means a partial failure still restarts alloy onto the current config.

- **`alloy.yml`: exclude DNS-alias inventory names.** `teuthology.front` is a CNAME for `soko04.front`, and `o01/o02.front` are CNAMEs for their `.vlan107` names. With both names of one machine in the play, the last run wins the `instance`/`host` labels and the box flaps identity between runs (this is what made "teuthology" spend a stretch reporting as soko04 and vice-versa). Added `!teuthology:!o01.front.sepia.ceph.com:!o02.front.sepia.ceph.com` so each machine is configured under one name only.

## Reviewer notes

- Branched off current `main`; contains only these three commits. (The session's original working branch was cut from a stale base and predates ~90 files of unrelated merged work, so it wasn't suitable to PR directly.)
- The inventory_hostname label flip and the grafana-agent not-found-stub fix from earlier in this effort are already in `main` via #876.
- All three changes are already deployed across the live fleet; this PR makes git match what's running.