### PR TITLE
teuthology: add optional old-LRC fallback to nginx vhost

### DIFF
--- a/roles/teuthology/README.rst
+++ b/roles/teuthology/README.rst
@@ -37,3 +37,22 @@ Variables
   ``SystemMaxUse`` (e.g. ``1G``, ``2G``).
 
   Default: ``2G``
+
+``teuthology_old_lrc_fallback``
+  When true, the nginx vhost gets a ``try_files`` fallback so requests for
+  logs not found under ``archive_base`` are served from a read-only mount of
+  the old (pre-migration) LRC cephfs at ``teuthology_old_lrc_root``.  Set to
+  true in host_vars (in the secrets repo) for ``soko04.front.sepia.ceph.com``,
+  which serves the pre-migration teuthology log archive.
+
+  The mount itself is not managed by this role.  On soko04 it is a manually
+  maintained fstab entry using ``ceph-fuse`` (``fuse.ceph``, ``ro,allow_other``)
+  because the old LRC cluster issues aes256k service tickets that the host's
+  kernel client does not support.
+
+  Default: ``false``
+
+``teuthology_old_lrc_root``
+  Filesystem path of the old LRC cephfs mount used by the fallback above.
+
+  Default: ``/www-data/old-lrc``

--- a/roles/teuthology/defaults/main.yml
+++ b/roles/teuthology/defaults/main.yml
@@ -17,5 +17,11 @@ archive_base: "/home/{{ teuthology_execution_user }}/archive"
 
 remote_crontab_url: "https://raw.githubusercontent.com/ceph/ceph/main/qa/crontab/teuthology-cronjobs"
 
+# Serve pre-migration teuthology logs from a read-only mount of the old
+# LRC cephfs if they're not found under archive_base.
+# Set to true in host_vars (e.g., soko04) in the secrets repo.
+teuthology_old_lrc_fallback: false
+teuthology_old_lrc_root: /www-data/old-lrc
+
 journald_max_retention: 7day
 journald_max_use: 2G

--- a/roles/teuthology/templates/nginx.conf
+++ b/roles/teuthology/templates/nginx.conf
@@ -1,5 +1,7 @@
 # {{ ansible_managed }}
 server {
+        listen 80;
+        listen [::]:80;
         gzip on;
         gzip_types *;
         gzip_comp_level 9;
@@ -11,10 +13,20 @@ server {
         server_name {{ inventory_hostname }};
         location /teuthology {
           alias {{ archive_base }};
+{% if teuthology_old_lrc_fallback %}
+          # Fall back to pre-migration logs on the old LRC cephfs mount
+          try_files $uri $uri/ @old_lrc;
+{% endif %}
           # Prevents Chromium from thinking certain text files are binary,
           # e.g. console logs while reimaging is underway
           add_header X-Content-Type-Options nosniff;
         }
+{% if teuthology_old_lrc_fallback %}
+        location @old_lrc {
+          rewrite ^/teuthology(/.+)$ $1 break;
+          root {{ teuthology_old_lrc_root }};
+        }
+{% endif %}
         types {
             text/plain log;
             text/plain yaml yml;


### PR DESCRIPTION
soko04's live `/etc/nginx/sites-available/test_logs.conf` was hand-edited on 2026-08-10 to serve pre-migration teuthology logs from the old LRC cephfs mounted read-only at `/www-data/old-lrc`. Requests under `/teuthology` that miss the local archive fall back (`try_files ... @old_lrc`) to a named location rooted at the old mount. If anyone ran the teuthology role against soko04, the template would clobber that fallback and all pre-migration log URLs would 404.

This brings the template in line with the live config:

- New `teuthology_old_lrc_fallback` variable (default `false`) gates the `try_files` fallback and the `@old_lrc` named location, so other teuthology-role hosts render the same vhost as before. soko04's host_vars in the secrets repo should set it to `true` (companion change there).
- The mount path is configurable via `teuthology_old_lrc_root` (default `/www-data/old-lrc`).
- Added explicit `listen 80; listen [::]:80;` — the vhost previously had no listen directive, so it was IPv4-only and IPv6 requests fell through to the default server. Cosmetic on soko04 (traffic arrives over IPv4 from soko01), but correct everywhere.

The cephfs mount itself is intentionally not managed by this role: on soko04 it's a manual fstab entry using ceph-fuse (`fuse.ceph`, `ro,allow_other`) because the old LRC cluster issues aes256k service tickets unsupported by the host's 6.8 kernel client, and it needs a keyring from the old cluster. That's documented in the role README instead.

Verified by rendering the template with the flag on (matches soko04's live config, plus listen directives) and off (identical to the previous template output, plus listen directives).