### PR TITLE
prep-fog-capture: mask remaining apt-touching boot units

### DIFF
--- a/tools/roles/prep-fog-capture/tasks/main.yml
+++ b/tools/roles/prep-fog-capture/tasks/main.yml
@@ -133,6 +133,14 @@
     - apt-daily-upgrade.service
     - apt-daily.timer
     - apt-daily-upgrade.timer
+    - apt-news.service
+    - esm-cache.service
+    - motd-news.service
+    - motd-news.timer
+    - update-notifier-download.service
+    - update-notifier-download.timer
+    - update-notifier-motd.service
+    - update-notifier-motd.timer
   failed_when: false
 
 - name: Disable cloud init networking config


### PR DESCRIPTION
Follow-up to the existing `Disable cloud init and disruptive apt services` task, related to https://tracker.ceph.com/issues/58223.

### Why

The existing mask list is working — on a node booted from a prep-fog-capture image, `apt-daily.timer`, `apt-daily-upgrade.timer` and `unattended-upgrades.service` never start. Confirmed from the boot console log of `nithyab-2026-09-10_09:42:24-rgw-wip-nbalacha-test-sep8-distro-default-smithi/547754` (smithi114, Ubuntu 24.04).

But these *do* still start on that same boot, and none are masked:

- `motd-news.timer`
- `update-notifier-motd.timer`
- `update-notifier-download.timer`

Sixteen seconds after `multi-user.target` was reached, teuthology's `sudo apt-get clean` failed:

```
E: Could not get lock /var/lib/apt/lists/lock. It is held by process 2531 (apt-get)
E: Unable to lock directory /var/lib/apt/lists/
```

Every instance I found has the same shape — the lock holder's PID is in the 2100-2700 range, i.e. a unit started in the first seconds of boot. Recent ones:

| Date | Job | Lock | Holder PID |
|---|---|---|---|
| 2026-07-04 | `yuriw-2026-07-04_14:56:59-...-trial/339156` | `/var/lib/apt/lists/lock` | 2429 |
| 2026-07-15 | `jenkins-build-2026-07-15_06:03:37-orch-tentacle.../365257` | `/var/lib/apt/lists/lock` | 2386 |
| 2026-08-04 | `jenkins-build-2026-08-04_06:05:18-rados-umbrella.../427500` | `/var/lib/apt/lists/lock` | 2418 |
| 2026-08-07 | `pdonnell-2026-08-07_16:07:21-...-smithi/443582` | `/var/lib/apt/lists/lock` | 2188 |
| 2026-09-01 | `trociny-2026-09-01_16:55:47-...-smithi/528609` | `/var/cache/apt/archives/lock` | 2631 |
| 2026-09-01 | `trociny-2026-09-01_16:55:47-...-smithi/528610` | `/var/lib/apt/lists/lock` | 2629 |
| 2026-09-10 | `nithyab-2026-09-10_09:42:24-...-smithi/547754` | `/var/lib/apt/lists/lock` | 2531 |

Note the contended lock is now `/var/lib/apt/lists/lock`, not `lock-frontend` — consistent with a list-refresh rather than an unattended upgrade. The original `fuser -v /var/lib/dpkg/lock-frontend` signature from the tracker stopped appearing after 2025-12-16.

### What this does

Adds the update-notifier and ubuntu-pro cache units to the existing loop. `failed_when: false` is already set, so releases that don't ship a given unit are unaffected.

### Caveat

I could not pin down which unit owns the offending `apt-get` — test nodes weren't reachable to inspect live, so the unit list above comes from the failing job's boot console log. This broadens the mask to the apt-touching units that are still enabled rather than pinpointing one. Worth watching whether the failures stop after the next image capture.

### Possibly worth a separate change

This block only runs in `tools/prep-fog-capture.yml`, so it only reaches nodes that boot an image baked after it landed (2026-02-18). Moving it into `roles/testnode` would apply it per job regardless of how the node was imaged — happy to do that separately if you'd prefer.